### PR TITLE
Use the new APIs for mlir compiler

### DIFF
--- a/tripy/tests/integration/test_iota.py
+++ b/tripy/tests/integration/test_iota.py
@@ -85,7 +85,7 @@ class TestIota:
 
         exception_str = "error: 'tensorrt.linspace' op result #0 must be 0D/1D/2D/3D/4D/5D/6D/7D/8D tensor of 32-bit float or 32-bit signless integer values"
         if dtype == tp.bool:
-            exception_str = "InternalError: failed to run compilation pipeline"
+            exception_str = "InternalError: failed to run compilation"
         with helper.raises(
             tp.TripyException,
             match=exception_str,

--- a/tripy/tripy/backend/mlir/compiler.py
+++ b/tripy/tripy/backend/mlir/compiler.py
@@ -46,7 +46,7 @@ def _get_compiler_objects() -> Tuple[ir.Context, compiler.CompilerClient]:
 
     if G_MLIR_CONTEXT is None or G_COMPILER_CLIENT is None:
         G_MLIR_CONTEXT = make_ir_context()
-        G_COMPILER_CLIENT = compiler.CompilerClient(G_MLIR_CONTEXT, compiler.CompilerClientOptions(G_TIMING_CACHE_FILE))
+        G_COMPILER_CLIENT = compiler.CompilerClient(G_MLIR_CONTEXT)
     return G_MLIR_CONTEXT, G_COMPILER_CLIENT
 
 
@@ -56,9 +56,10 @@ class Compiler:
         self.trt_builder_opt_level = trt_builder_opt_level
 
     def _make_mlir_opts(self, trt_builder_opt_level):
-        opts = compiler.StableHLOToExecutableOptions(
-            tensorrt_builder_opt_level=trt_builder_opt_level, tensorrt_strongly_typed=True
-        )
+        opts = compiler.StableHLOToExecutableOptions(self.compiler_client,
+                                                     [f"--tensorrt-timing-cache-path={G_TIMING_CACHE_FILE}",
+                                                      f"--tensorrt-builder-opt-level={trt_builder_opt_level}",
+                                                      "--tensorrt-strongly-typed=True"])
         if config.enable_mlir_debug or config.enable_tensorrt_debug:
             opts.set_debug_options(
                 config.enable_mlir_debug,


### PR DESCRIPTION
Update to the new API for `CompilerClient` and `StableHLOToExecutableOptions`.