### PR TITLE
Revert "Fix MLIR_DIR path in README.md (#11)"

### DIFF
--- a/mlir-tensorrt/README.md
+++ b/mlir-tensorrt/README.md
@@ -61,7 +61,7 @@ cmake -B ./build/mlir-tensorrt -S . -G Ninja \
     -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
     -DMLIR_TRT_USE_LINKER=lld \
     -DMLIR_TRT_PACKAGE_CACHE_DIR=${PWD}/.cache.cpm \
-    -DMLIR_DIR=build/llvm/lib/cmake/mlir \
+    -DMLIR_DIR=build/llvm-project/lib/cmake/mlir \
     -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON
 ninja -C build/mlir-tensorrt all
 ninja -C build/mlir-tensorrt check-mlir-executor


### PR DESCRIPTION
This reverts commit 7bb356261494ba1bec6e9a6aebfc62f69f3f59a1.