### PR TITLE
Only Cast float8 and int4 to float32 when converting to Python list

### DIFF
--- a/tripy/tests/frontend/test_tensor.py
+++ b/tripy/tests/frontend/test_tensor.py
@@ -88,7 +88,10 @@ class TestTensor:
             )
         tensor = tp.Tensor(input_data, dtype=dtype)
         assert tensor.trace_tensor.producer.dtype == dtype
-        print(tensor)
+        if dtype == tp.float8:
+            assert tensor.data().dtype == tp.float32
+        else:
+            assert tensor.data().dtype == dtype
         assert tensor.trace_tensor.producer.data.dtype.name == dtype.name
         assert tensor.trace_tensor.producer.data.dtype.itemsize == dtype.itemsize
 

--- a/tripy/tripy/frontend/tensor.py
+++ b/tripy/tripy/frontend/tensor.py
@@ -216,7 +216,7 @@ class Tensor(metaclass=TensorMeta):
         from tripy.frontend.trace.ops.cast import cast
 
         arr = self.eval()
-        if self.dtype not in get_supported_array_type():
+        if self.dtype in [tripy.common.datatype.float8, tripy.common.datatype.int4]:
             arr = cast(Tensor(arr), tripy.common.datatype.float32).eval()
         return arr
 


### PR DESCRIPTION
All other types except for float8 and int4 can be converted to a Python list without requiring an explicit cast. Update test to ensure round-tripping a python sequence from Tripy does not change data type except for `float8` where an explicit cast is required.