### PR TITLE
Added compile fixture

### DIFF
--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 import tripy as tp
 
-@pytest.fixture(params=['compile', 'lazy'])
+@pytest.fixture(params=['compile', 'eager'])
 def mode(request):
     return request.param
 
@@ -36,6 +36,6 @@ def compile_fixture(mode):
             compile_kwargs = dict((k, get_shape(v) if isinstance(v, tp.Tensor) else v) for k, v in kwargs.items())
             compiled_func = compiler.compile(*compile_args, **compile_kwargs)
             return compiled_func(*args, **kwargs)
-        elif mode == "lazy":
+        elif mode == "eager":
             return func(*args, **kwargs)
     return wrapper

--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -1,0 +1,41 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+import tripy as tp
+
+@pytest.fixture(params=['compile', 'lazy'])
+def mode(request):
+    return request.param
+
+@pytest.fixture
+def compile_fixture(mode):
+    def get_shape(x: tp.Tensor):
+        x.eval()
+        return tp.InputInfo(x.trace_tensor.shape, dtype=x.dtype)
+
+    def wrapper(func, *args, **kwargs):
+        if mode == 'compile':
+            compiler = tp.Compiler(func)
+            compile_args = tuple(map(lambda x: get_shape(x) if isinstance(x, tp.Tensor) else x, list(args)))
+            compile_kwargs = dict((k, get_shape(v) if isinstance(v, tp.Tensor) else v) for k, v in kwargs.items())
+            compiled_func = compiler.compile(*compile_args, **compile_kwargs)
+            return compiled_func(*args, **kwargs)
+        elif mode == "lazy":
+            return func(*args, **kwargs)
+    return wrapper

--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -21,22 +21,13 @@ import tripy as tp
 
 
 @pytest.fixture(params=["compile", "eager"])
-def mode(request):
-    # TODO: Fix dynamically adding markers for compile / eager testing
-    # if request.param == "compile":
-    #     request.node.add_marker("compile")
-    # elif request.param == "eager":
-    #     request.node.add_marker("eager")
-    return request.param
-
-
-@pytest.fixture
-def compile_fixture(mode):
+def compile_fixture(request):
     def wrapper(func, *args, **kwargs):
         def get_shape(x: tp.Tensor):
             x.eval()
             return tp.InputInfo(x.trace_tensor.shape, dtype=x.dtype)
 
+        mode = request.param
         if mode == "compile":
             compiler = tp.Compiler(func)
             # Cast appropriate args / kwargs to use `tp.InputInfo`

--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -19,9 +19,11 @@ import pytest
 
 import tripy as tp
 
-@pytest.fixture(params=['compile', 'eager'])
+
+@pytest.fixture(params=["compile", "eager"])
 def mode(request):
     return request.param
+
 
 @pytest.fixture
 def compile_fixture(mode):
@@ -29,8 +31,8 @@ def compile_fixture(mode):
         def get_shape(x: tp.Tensor):
             x.eval()
             return tp.InputInfo(x.trace_tensor.shape, dtype=x.dtype)
-        
-        if mode == 'compile':
+
+        if mode == "compile":
             compiler = tp.Compiler(func)
             # Cast appropriate args / kwargs to use `tp.InputInfo`
             compile_args = tuple(map(lambda x: get_shape(x) if isinstance(x, tp.Tensor) else x, list(args)))
@@ -38,8 +40,9 @@ def compile_fixture(mode):
             compiled_func = compiler.compile(*compile_args, **compile_kwargs)
             # Remove baked in args, aka, only keep tp.Tensor's
             args = tuple(filter(lambda x: isinstance(x, tp.Tensor), args))
-            kwargs = dict(filter(lambda _, v: isinstance(v, tp.Tensor), kwargs.items()))
+            kwargs = dict(filter(lambda kv: isinstance(kv[1], tp.Tensor), kwargs.items()))
             return compiled_func(*args, **kwargs)
         elif mode == "eager":
             return func(*args, **kwargs)
+
     return wrapper

--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -22,6 +22,11 @@ import tripy as tp
 
 @pytest.fixture(params=["compile", "eager"])
 def mode(request):
+    # TODO: Fix dynamically adding markers for compile / eager testing
+    # if request.param == "compile":
+    #     request.node.add_marker("compile")
+    # elif request.param == "eager":
+    #     request.node.add_marker("eager")
     return request.param
 
 

--- a/tripy/tests/integration/test_allclose.py
+++ b/tripy/tests/integration/test_allclose.py
@@ -36,6 +36,8 @@ class TestAllClose:
     )
     def test_all_close_float32(self, tensor_a, tensor_b, rtol, atol):
         np_result = torch.allclose(torch.FloatTensor(tensor_a), torch.FloatTensor(tensor_b), rtol=rtol, atol=atol)
+        # Cannot use `compile_fixture` here since `tp.Compiler` only works if the output of the function is a Tensor
+        # and the output of `tp.allclose` is a bool.
         tp_result = tp.allclose(
             tp.Tensor(tensor_a, dtype=tp.float32), tp.Tensor(tensor_b, dtype=tp.float32), rtol=rtol, atol=atol
         )

--- a/tripy/tests/integration/test_cast.py
+++ b/tripy/tests/integration/test_cast.py
@@ -56,7 +56,8 @@ class TestCast:
         # TODO(#222): Integer casts with negative numbers fail in many cases
         input_tensor = tp.Tensor([0, 1, 2], dtype=tp_input_dtype)
         np_input = cp.from_dlpack(input_tensor).get()
-        output = tp.cast(input_tensor, tp_target_dtype)
+
+        output = compile_fixture(tp.cast, input_tensor, tp_target_dtype)
 
         assert np.array_equal(cp.from_dlpack(output).get(), np_input.astype(target_dtype))
 

--- a/tripy/tests/integration/test_cast.py
+++ b/tripy/tests/integration/test_cast.py
@@ -49,7 +49,7 @@ class TestCast:
             # (np.int8, bool),
         ],
     )
-    def test_cast(self, input_dtype, target_dtype):
+    def test_cast(self, input_dtype, target_dtype, compile_fixture):
         tp_input_dtype = np_to_tripy_dtype(input_dtype)
         tp_target_dtype = np_to_tripy_dtype(target_dtype)
 

--- a/tripy/tests/integration/test_cast.py
+++ b/tripy/tests/integration/test_cast.py
@@ -63,22 +63,28 @@ class TestCast:
 
     # these dtypes don't have analogues in numpy
     @pytest.mark.parametrize("source_dtype", [pytest.param(tp.float8, marks=skip_if_older_than_sm89), tp.int4])
-    def test_cast_quantized_dtypes_into_bool(self, source_dtype):
+    def test_cast_quantized_dtypes_into_bool(self, source_dtype, compile_fixture):
         # TODO(#223): Using an odd size leads to a strange crash, so can't just use [-1.0, 0.0, 1.0]
         input_tensor = tp.Tensor([-1.0, 0.0, 0.0, 1.0], dtype=tp.float32)
-        q = tp.quantize(input_tensor, scale=1.0, dtype=source_dtype)
-        output = tp.cast(q, tp.bool)
+
+        def func(input):
+            q = tp.quantize(input, scale=1.0, dtype=source_dtype)
+            output = tp.cast(q, tp.bool)
+            return output
+
+        output = compile_fixture(func, input_tensor)
+
         assert cp.from_dlpack(output).get().tolist() == [True, False, False, True]
 
     @pytest.mark.parametrize("target_dtype", [np.float32, np.int32, np.int64, np.int8])
-    def test_cast_from_bool(self, target_dtype):
+    def test_cast_from_bool(self, target_dtype, compile_fixture):
         tp_target_dtype = np_to_tripy_dtype(target_dtype)
 
         # in principle, it is not important what *specific* values we convert to,
         # so long as false is mapped to 0 and true to nonzero
         input_tensor = tp.Tensor([False, True], dtype=tp.bool)
         np_input = cp.from_dlpack(input_tensor).get()
-        output = tp.cast(input_tensor, tp_target_dtype)
+        output = compile_fixture(tp.cast, input_tensor, tp_target_dtype)
 
         tp_compare_to_zero = cp.from_dlpack(output).get() == 0
         np_compare_to_zero = np_input.astype(target_dtype) == 0

--- a/tripy/tests/integration/test_concatenate.py
+++ b/tripy/tests/integration/test_concatenate.py
@@ -33,7 +33,7 @@ class TestConcatenate:
             ([(2, 3, 4)], 0),
         ],
     )
-    def test_concat(self, tensor_shapes, dim):
+    def test_concat(self, tensor_shapes, dim, compile_fixture):
         tensors = [tp.ones(shape) for shape in tensor_shapes]
         out = tp.concatenate(tensors, dim=dim)
         assert np.array_equal(

--- a/tripy/tests/integration/test_concatenate.py
+++ b/tripy/tests/integration/test_concatenate.py
@@ -35,7 +35,7 @@ class TestConcatenate:
     )
     def test_concat(self, tensor_shapes, dim, compile_fixture):
         tensors = [tp.ones(shape) for shape in tensor_shapes]
-        out = tp.concatenate(tensors, dim=dim)
+        out = compile_fixture(tp.concatenate, tensors, dim=dim)
         assert np.array_equal(
             cp.from_dlpack(out).get(), np.concatenate([np.ones(shape) for shape in tensor_shapes], axis=dim)
         )
@@ -44,8 +44,8 @@ class TestConcatenate:
         "tensor_shapes, dim",
         [([(2, 3, 4), (2, 4, 4)], 0), ([(4, 5, 6), (4, 1, 6)], -1)],
     )
-    def test_negative_concat(self, tensor_shapes, dim):
+    def test_negative_concat(self, tensor_shapes, dim, compile_fixture):
         tensors = [tp.ones(shape) for shape in tensor_shapes]
         with helper.raises(tp.TripyException, match=f"not compatible at non-concat index"):
-            out = tp.concatenate(tensors, dim=dim)
+            out = compile_fixture(tp.concatenate, tensors, dim=dim)
             print(out)

--- a/tripy/tests/integration/test_conv_transpose.py
+++ b/tripy/tests/integration/test_conv_transpose.py
@@ -81,7 +81,7 @@ test_cases_transpose_downscale = [
 @pytest.mark.parametrize("torch_dtype,tp_dtype", DTYPES)
 class TestConvolution:
     @pytest.mark.parametrize("test_case", test_cases_transpose_1d)
-    def test_transposed_convolution_1d(self, torch_dtype, tp_dtype, test_case):
+    def test_transposed_convolution_1d(self, torch_dtype, tp_dtype, test_case, compile_fixture):
         if not test_case.torch_pad:
             test_case.torch_pad = 0
         if not test_case.stride:
@@ -129,14 +129,14 @@ class TestConvolution:
             conv_layer.bias = tp.cast(tp.Tensor(conv_layer_torch.bias.data), tp_dtype)
 
         expected = conv_layer_torch(input_torch).to(torch_dtype)
-        output = conv_layer(input)
+        output = compile_fixture(conv_layer, input)
 
         rtol_ = 1e-3
         assert tp.allclose(output, tp.Tensor(expected), rtol=rtol_)
         assert output.shape == expected.shape
 
     @pytest.mark.parametrize("test_case", test_cases_transpose_2d)
-    def test_transposed_convolution_2d(self, torch_dtype, tp_dtype, test_case):
+    def test_transposed_convolution_2d(self, torch_dtype, tp_dtype, test_case, compile_fixture):
         if not test_case.torch_pad:
             test_case.torch_pad = 0
         if not test_case.stride:
@@ -184,14 +184,14 @@ class TestConvolution:
             conv_layer.bias = tp.cast(tp.Tensor(conv_layer_torch.bias.data), tp_dtype)
 
         expected = conv_layer_torch(input_torch).to(torch_dtype)
-        output = conv_layer(input)
+        output = compile_fixture(conv_layer, input)
 
         rtol_ = 1e-3
         assert tp.allclose(output, tp.Tensor(expected), rtol=rtol_)
         assert output.shape == expected.shape
 
     @pytest.mark.parametrize("test_case", test_cases_transpose_3d)
-    def test_transposed_convolution_3d(self, torch_dtype, tp_dtype, test_case):
+    def test_transposed_convolution_3d(self, torch_dtype, tp_dtype, test_case, compile_fixture):
         if not test_case.torch_pad:
             test_case.torch_pad = 0
         if not test_case.stride:
@@ -239,12 +239,12 @@ class TestConvolution:
             conv_layer.bias = tp.cast(tp.Tensor(conv_layer_torch.bias.data), tp_dtype)
 
         expected = conv_layer_torch(input_torch).to(torch_dtype)
-        output = conv_layer(input)
+        output = compile_fixture(conv_layer, input)
         rtol_ = 1.3e-6 if tp_dtype == tp.float32 else 1.6e-3
         assert tp.allclose(output, tp.Tensor(expected), rtol=rtol_)
         assert output.shape == expected.shape
 
-    def test_transposed_equivalency(self, torch_dtype, tp_dtype):
+    def test_transposed_equivalency(self, torch_dtype, tp_dtype, compile_fixture):
         input_torch = torch.arange(9, dtype=torch.float32, device=torch.device("cuda")).reshape(*(1, 1, 3, 3))
         input = tp.cast(tp.Tensor(input_torch), tp_dtype)
 
@@ -277,8 +277,8 @@ class TestConvolution:
 
         expected = conv_layer_torch(input_torch).to(torch_dtype)
         expected_transpose = conv_transpose_layer_torch(input_torch).to(torch_dtype)
-        output = conv_layer(input)
-        output_transpose = conv_transpose_layer(input)
+        output = compile_fixture(conv_layer, input)
+        output_transpose = compile_fixture(conv_transpose_layer, input)
 
         rtol_ = 2e-7 if tp_dtype == tp.float32 else 9e-4
         assert tp.allclose(output, tp.Tensor(expected), rtol=rtol_)
@@ -291,7 +291,7 @@ class TestConvolution:
         assert expected.shape == expected_transpose.shape
 
     @pytest.mark.parametrize("test_case", test_cases_transpose_downscale)
-    def test_transposed_downscale(self, torch_dtype, tp_dtype, test_case):
+    def test_transposed_downscale(self, torch_dtype, tp_dtype, test_case, compile_fixture):
         input_torch = torch.arange(9, dtype=torch.float32, device=torch.device("cuda")).reshape(*(1, 1, 3, 3))
         input = tp.cast(tp.Tensor(input_torch), tp_dtype)
 
@@ -320,7 +320,7 @@ class TestConvolution:
         conv_layer.weight = tp.cast(tp.Tensor(conv_layer_torch.weight.data), tp_dtype)
 
         expected = conv_layer_torch(input_torch).to(torch_dtype)
-        output = conv_layer(input)
+        output = compile_fixture(conv_layer, input)
 
         rtol_ = 1e-15 if tp_dtype == tp.float32 else 1e-10
         assert tp.allclose(output, tp.Tensor(expected), rtol=rtol_)

--- a/tripy/tests/integration/test_convolution.py
+++ b/tripy/tests/integration/test_convolution.py
@@ -84,7 +84,7 @@ class TestConvolution:
             test_case.dilation = (1,)
 
         input_torch = torch.arange(40, dtype=torch.float32, device=torch.device("cuda")).reshape(*(2, 4, 5))
-        input = tp.cast(tp.Tensor(input_torch), tp_dtype)
+        input = tp.cast(tp.Tensor(input_torch, device=tp.device("gpu")), tp_dtype)
 
         conv_layer_torch = torch.nn.Conv1d(
             4,

--- a/tripy/tests/integration/test_dequantize.py
+++ b/tripy/tests/integration/test_dequantize.py
@@ -29,12 +29,12 @@ class TestDequantize:
     @pytest.mark.parametrize(
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
-    def test_dequantize_int8_per_tensor(self, dtype):
+    def test_dequantize_int8_per_tensor(self, dtype, compile_fixture):
         data = [4, 8]
         input_tp = tp.Tensor(data, dtype=tp.int8)
         scale = torch.tensor(0.5, dtype=TORCH_DTYPES[dtype])
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        dequantized = tp.dequantize(input_tp, scale_tp, dtype)
+        dequantized = compile_fixture(tp.dequantize, input_tp, scale_tp, dtype)
         expected = torch.tensor(data) * scale
         output = torch.from_dlpack(dequantized)
         assert torch.allclose(expected, output.to("cpu"))
@@ -42,7 +42,7 @@ class TestDequantize:
     @pytest.mark.parametrize(
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
-    def test_dequantize_int8_per_channel(self, dtype):
+    def test_dequantize_int8_per_channel(self, dtype, compile_fixture):
         # TODO: Fix in #153
         if dtype == tp.float16:
             pytest.skip("TRT does not support fp16->int8 per-channel dequant.")
@@ -50,7 +50,7 @@ class TestDequantize:
         input_tp = tp.Tensor(data, dtype=tp.int8)
         scale = torch.tensor([0.8, 0.9], dtype=TORCH_DTYPES[dtype])
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        dequantized = tp.dequantize(input_tp, scale_tp, dtype, dim=0)
+        dequantized = compile_fixture(tp.dequantize, input_tp, scale_tp, dtype, dim=0)
         expected = torch.tensor(data) * scale.reshape((2, 1))
         output = torch.from_dlpack(dequantized)
         assert torch.allclose(expected, output.to("cpu"))
@@ -60,14 +60,13 @@ class TestDequantize:
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
     @skip_if_older_than_sm89
-    def test_dequantize_fp8_per_tensor(self, dtype):
+    def test_dequantize_fp8_per_tensor(self, dtype, compile_fixture):
         data_value = [1.0, 1.0]
         input_tp = tp.Tensor(data_value, dtype=tp.float8)
         scale = torch.tensor(0.5, dtype=TORCH_DTYPES[dtype])
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        dequantized = tp.dequantize(input_tp, scale_tp, dtype)
+        dequantized = compile_fixture(tp.dequantize, input_tp, scale_tp, dtype)
         assert dequantized.dtype == dtype
-        print(dequantized)
         expected = torch.Tensor(data_value) * scale
         output = torch.from_dlpack(dequantized).to(dtype=torch.float32)
         assert torch.allclose(expected, output.to("cpu"))
@@ -76,23 +75,23 @@ class TestDequantize:
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
     @skip_if_older_than_sm89
-    def test_dequantize_fp8_per_channel(self, dtype):
+    def test_dequantize_fp8_per_channel(self, dtype, compile_fixture):
         data_value = [[1.0, 1.0], [1.0, 1.0]]
         input_tp = tp.Tensor(data_value, dtype=tp.float8)
         scale = torch.tensor([0.8, 0.9], dtype=TORCH_DTYPES[dtype])
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        dequantized = tp.dequantize(input_tp, scale_tp, dtype, dim=0)
+        dequantized = compile_fixture(tp.dequantize, input_tp, scale_tp, dtype, dim=0)
         assert dequantized.dtype == dtype
         print(dequantized)
         expected = torch.Tensor(data_value) * scale.reshape((2, 1))
         output = torch.from_dlpack(dequantized).to(dtype=torch.float32)
         assert torch.allclose(expected, output.to("cpu"))
 
-    def test_negative_non_constant_scale(self):
+    def test_negative_non_constant_scale(self, compile_fixture):
         data = [[4, 8], [4, 8]]
         input = tp.Tensor(data, dtype=tp.int8)
         scale = tp.ones((2,))
-        dequantized = tp.dequantize(input, scale, tp.float32, dim=0)
+        dequantized = compile_fixture(tp.dequantize, input, scale, tp.float32, dim=0)
         with raises(
             tp.TripyException,
             match="Scale must be a constant tensor in dequantize op",

--- a/tripy/tests/integration/test_expand.py
+++ b/tripy/tests/integration/test_expand.py
@@ -22,24 +22,24 @@ import tripy as tp
 
 
 class TestExpand:
-    def test_int_sizes(self):
+    def test_int_sizes(self, compile_fixture):
         input = tp.ones((2, 1))
-        out = tp.expand(input, (-1, 2))
+        out = compile_fixture(tp.expand, input, (-1, 2))
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 2), dtype=np.float32))
 
-    def test_shape_sizes(self):
+    def test_shape_sizes(self, compile_fixture):
         input = tp.ones((2, 1))
         a = tp.ones((2, 4))
-        out = tp.expand(input, a.shape)
+        out = compile_fixture(tp.expand, input, a.shape)
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 4), dtype=np.float32))
 
-    def test_extra_dims(self):
+    def test_extra_dims(self, compile_fixture):
         input = tp.ones((2, 1))
-        out = tp.expand(input, (1, -1, 2))
+        out = compile_fixture(tp.expand, input, (1, -1, 2))
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((1, 2, 2), dtype=np.float32))
 
-    def test_mixed_sizes(self):
+    def test_mixed_sizes(self, compile_fixture):
         input = tp.ones((2, 1, 1))
         a = tp.ones((4, 4))
-        out = tp.expand(input, (-1, a.shape[0], a.shape[1]))
+        out = compile_fixture(tp.expand, input, (-1, a.shape[0], a.shape[1]))
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 4, 4), dtype=np.float32))

--- a/tripy/tests/integration/test_flip.py
+++ b/tripy/tests/integration/test_flip.py
@@ -26,14 +26,14 @@ class TestFlip:
         "dims",
         [0, 1, None, [0, 1], [1, 0], -1, -2, [0, -1], [-2, 1]],
     )
-    def test_flip(self, dims):
+    def test_flip(self, dims, compile_fixture):
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
-        f = tp.flip(a, dims=dims)
+        f = compile_fixture(tp.flip, a, dims=dims)
         assert np.array_equal(cp.from_dlpack(f).get(), np.flip(cp_a.get(), axis=dims))
 
         # also ensure that flipping a second time restores the original value
-        f2 = tp.flip(f, dims=dims)
+        f2 = compile_fixture(tp.flip, f, dims=dims)
         assert cp.array_equal(cp.from_dlpack(f2), cp_a)
 
     def test_no_op(self):

--- a/tripy/tests/integration/test_flip.py
+++ b/tripy/tests/integration/test_flip.py
@@ -36,24 +36,25 @@ class TestFlip:
         f2 = compile_fixture(tp.flip, f, dims=dims)
         assert cp.array_equal(cp.from_dlpack(f2), cp_a)
 
-    def test_no_op(self):
+    def test_no_op(self, compile_fixture):
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
-        f = tp.flip(a, dims=[])
+        f = compile_fixture(tp.flip, a, dims=[])
         assert cp.array_equal(cp.from_dlpack(a), cp.from_dlpack(f))
 
-    def test_zero_rank(self):
+    def test_zero_rank(self, compile_fixture):
         t = tp.Tensor(1)
-        f = tp.flip(t)
+        f = compile_fixture(tp.flip, t)
         assert cp.array_equal(cp.from_dlpack(t), cp.from_dlpack(f))
 
     @pytest.mark.parametrize(
         "dims1, dims2",
         [(0, -2), (1, -1), ([0, 1], None), ([0, 1], [1, 0]), ([0, 1], [-2, -1])],
     )
-    def test_equivalences(self, dims1, dims2):
+    def test_equivalences(self, dims1, dims2, compile_fixture):
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
-        f1 = tp.flip(a, dims=dims1)
-        f2 = tp.flip(a, dims=dims2)
+
+        f1 = compile_fixture(tp.flip, a, dims=dims1)
+        f2 = compile_fixture(tp.flip, a, dims=dims2)
         assert cp.array_equal(cp.from_dlpack(f1), cp.from_dlpack(f2))

--- a/tripy/tests/integration/test_full.py
+++ b/tripy/tests/integration/test_full.py
@@ -20,18 +20,20 @@ import numpy as np
 
 import tripy as tp
 
+tp.logger.verbosity = "ir"
+
 
 class TestFull:
-    def test_normal_shape(self):
-        out = tp.full((2, 2), 5.0, tp.float32)
+    def test_normal_shape(self, compile_fixture):
+        out = compile_fixture(tp.full, (2, 2), 5.0, tp.float32)
         assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 2), 5.0, np.float32))
 
-    def test_shape_tensor(self):
+    def test_shape_tensor(self, compile_fixture):
         a = tp.ones((2, 3))
-        out = tp.full(a.shape, 5.0, tp.float32)
+        out = compile_fixture(tp.full, a.shape, 5.0, tp.float32)
         assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 3), 5.0, np.float32))
 
-    def test_mixed_shape(self):
+    def test_mixed_shape(self, compile_fixture):
         a = tp.ones((2, 3))
-        out = tp.full((a.shape[0], 4), 5.0, tp.float32)
+        out = compile_fixture(tp.full, (a.shape[0], 4), 5.0, tp.float32)
         assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 4), 5.0, np.float32))

--- a/tripy/tests/integration/test_full.py
+++ b/tripy/tests/integration/test_full.py
@@ -20,8 +20,6 @@ import numpy as np
 
 import tripy as tp
 
-tp.logger.verbosity = "ir"
-
 
 class TestFull:
     def test_normal_shape(self, compile_fixture):

--- a/tripy/tests/integration/test_iota.py
+++ b/tripy/tests/integration/test_iota.py
@@ -100,12 +100,12 @@ class TestIota:
         ):
             print(out)
 
-    def test_iota_from_shape_tensor(self):
+    def test_iota_from_shape_tensor(self, compile_fixture):
         a = tp.ones((2, 2))
-        output = tp.iota(a.shape)
+        output = compile_fixture(tp.iota, a.shape)
         assert np.array_equal(cp.from_dlpack(output).get(), self._compute_ref_iota("float32", (2, 2), 0))
 
-    def test_iota_from_mixed_seqence(self):
+    def test_iota_from_mixed_seqence(self, compile_fixture):
         a = tp.ones((2, 2))
-        output = tp.iota((3, a.shape[0]))
+        output = compile_fixture(tp.iota, (3, a.shape[0]))
         assert np.array_equal(cp.from_dlpack(output).get(), self._compute_ref_iota("float32", (3, 2), 0))

--- a/tripy/tests/integration/test_matrix_multiplication.py
+++ b/tripy/tests/integration/test_matrix_multiplication.py
@@ -23,23 +23,29 @@ import tripy as tp
 import tripy.common.datatype
 
 
+# Provided since we cannot perform something like `compile_fixture(@, a, b)` or `compile_fixture(__matmul__, a, b)`
+def matmul(a, b):
+    return a @ b
+
+
 class TestMatrixMultiplication:
-    def test_2d_tensors(self):
+
+    def test_2d_tensors(self, compile_fixture):
         a_np = np.arange(6).reshape((2, 3)).astype(np.float32)
         b_np = np.arange(6).reshape((3, 2)).astype(np.float32)
         a = tp.Tensor(a_np)
         b = tp.Tensor(b_np)
 
-        out = a @ b
+        out = compile_fixture(matmul, a, b)
         assert tp.allclose(out, tp.Tensor(a_np @ b_np))
 
-    def test_1d_tensors(self):
+    def test_1d_tensors(self, compile_fixture):
         a_np = np.arange(64).astype(np.float32)  # 1D Tensor
         b_np = np.arange(64).astype(np.float32)  # 1D Tensor
         a = tripy.Tensor(cp.asanyarray(a_np))
         b = tripy.Tensor(cp.asanyarray(b_np))
 
-        out = a @ b
+        out = compile_fixture(matmul, a, b)
         assert tp.allclose(out, tp.Tensor(cp.array(a_np @ b_np)), atol=1e-2)
 
     @pytest.mark.parametrize(
@@ -53,11 +59,11 @@ class TestMatrixMultiplication:
             ((1, 2, 3), (0, 0, 3, 2)),  # Broadcasting batch dims with 0
         ],
     )
-    def test_broadcast_gemm(self, shape_a, shape_b):
+    def test_broadcast_gemm(self, shape_a, shape_b, compile_fixture):
         a_np = np.arange(np.prod(shape_a)).reshape(shape_a).astype(np.float32)
         b_np = np.arange(np.prod(shape_b)).reshape(shape_b).astype(np.float32)
         a = tp.Tensor(a_np)
         b = tp.Tensor(b_np)
 
-        out = a @ b
+        out = compile_fixture(matmul, a, b)
         assert tp.allclose(out, tp.Tensor(a_np @ b_np))

--- a/tripy/tests/integration/test_plugin.py
+++ b/tripy/tests/integration/test_plugin.py
@@ -15,36 +15,16 @@
 # limitations under the License.
 #
 
-import cupy as cp
+import pytest
 
 import tripy as tp
 
 
 class TestPlugin:
-    def test_gelu(self):
-        # TODO: We add `+ 1` as a hack to work around MLIR-TRT Issue #915. We should be able to remove it once fixed
-        inp = tp.iota((2, 2)) + 1
-        out = tp.plugin(
-            "CustomGeluPluginDynamic",
-            [inp],
-            output_info=[(inp.rank, inp.dtype)],
-            # Plugin Parameters:
-            type_id=0,
-        )
-
-        ref_out = tp.gelu(inp)
-
-        assert cp.allclose(cp.from_dlpack(out), cp.from_dlpack(ref_out))
-
-    def test_dynamic_shape_gelu(self):
+    @pytest.mark.parametrize("inp", [tp.iota((2, 1, 4)), tp.ones((2, 2, 4), dtype=tp.float32)])
+    def test_gelu_plugin(self, inp, compile_fixture):
         def gelu(X):
             return tp.plugin("CustomGeluPluginDynamic", [X], output_info=[(X.rank, X.dtype)], type_id=0)
 
-        compiler = tp.Compiler(gelu)
-        compiled_gelu = compiler.compile(tp.InputInfo((2, (1, 2, 3), 4), dtype=tp.float32))
-
-        inp = tp.iota((2, 1, 4))
-        assert tp.allclose(compiled_gelu(inp), tp.gelu(inp))
-
-        new_inp = tp.ones((2, 2, 4), dtype=tp.float32)
-        assert tp.allclose(compiled_gelu(new_inp), tp.gelu(new_inp))
+        out = compile_fixture(gelu, inp)
+        assert tp.allclose(out, tp.gelu(inp))

--- a/tripy/tests/integration/test_quantize.py
+++ b/tripy/tests/integration/test_quantize.py
@@ -29,24 +29,24 @@ class TestQuantize:
     @pytest.mark.parametrize(
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
-    def test_quantize_int8_per_tensor(self, dtype):
+    def test_quantize_int8_per_tensor(self, dtype, compile_fixture):
         input = torch.tensor([1.0, 2.0], dtype=TORCH_DTYPES[dtype])
         scale = torch.tensor(0.5, dtype=TORCH_DTYPES[dtype])
         input_tp = tp.Tensor(input, dtype=dtype)
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        quantized = tp.quantize(input_tp, scale_tp, tp.int8)
+        quantized = compile_fixture(tp.quantize, input_tp, scale_tp, tp.int8)
         expected = (input / scale).to(dtype=torch.int8)
         assert torch.equal(expected, torch.from_dlpack(quantized).to("cpu"))
 
     @pytest.mark.parametrize(
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
-    def test_quantize_int8_per_channel(self, dtype):
+    def test_quantize_int8_per_channel(self, dtype, compile_fixture):
         input = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=TORCH_DTYPES[dtype])
         scale = torch.tensor([0.2, 0.1], dtype=TORCH_DTYPES[dtype])
         input_tp = tp.Tensor(input, dtype=dtype)
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        quantized = tp.quantize(input_tp, scale_tp, tp.int8, dim=0)
+        quantized = compile_fixture(tp.quantize, input_tp, scale_tp, tp.int8, dim=0)
         expected = (input / scale.reshape(2, 1)).to(dtype=torch.int8)
         assert torch.equal(expected, torch.from_dlpack(quantized).to("cpu"))
 
@@ -54,12 +54,12 @@ class TestQuantize:
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
     @skip_if_older_than_sm89
-    def test_quantize_fp8_per_tensor(self, dtype):
+    def test_quantize_fp8_per_tensor(self, dtype, compile_fixture):
         input = torch.tensor([1.0, 2.0], dtype=TORCH_DTYPES[dtype])
         scale = torch.tensor(0.5, dtype=TORCH_DTYPES[dtype])
         input_tp = tp.Tensor(input, dtype=dtype)
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        quantized = tp.quantize(input_tp, scale_tp, tp.float8)
+        quantized = compile_fixture(tp.quantize, input_tp, scale_tp, tp.float8)
         assert quantized.dtype == tp.float8
         expected = (input / scale).to(dtype=torch.float32)
         with raises(
@@ -73,12 +73,12 @@ class TestQuantize:
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
     @skip_if_older_than_sm89
-    def test_quantize_fp8_per_channel(self, dtype):
+    def test_quantize_fp8_per_channel(self, dtype, compile_fixture):
         input = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=TORCH_DTYPES[dtype])
         scale = torch.tensor([0.2, 0.1], dtype=TORCH_DTYPES[dtype])
         input_tp = tp.Tensor(input, dtype=dtype)
         scale_tp = tp.Tensor(scale, dtype=dtype)
-        quantized = tp.quantize(input_tp, scale_tp, tp.float8, dim=0)
+        quantized = compile_fixture(tp.quantize, input_tp, scale_tp, tp.float8, dim=0)
         assert quantized.dtype == tp.float8
         expected = (input / scale.reshape(2, 1)).to(dtype=torch.float32)
         with raises(
@@ -92,7 +92,7 @@ class TestQuantize:
         "dtype", [tp.float32, tp.float16, pytest.param(tp.bfloat16, marks=skip_if_older_than_sm80)]
     )
     @pytest.mark.parametrize("quant_mode", ["block-wise", "per-tensor", "per-channel-0", "per-channel-1"])
-    def test_qdq_int4(self, dtype, quant_mode):
+    def test_qdq_int4(self, dtype, quant_mode, compile_fixture):
         if quant_mode == "block-wise":
             dim = None
             scale = torch.ones((2, 4), dtype=TORCH_DTYPES[dtype])
@@ -109,14 +109,18 @@ class TestQuantize:
         input = torch.ones((4, 4), dtype=TORCH_DTYPES[dtype])
         input_tp = tp.Tensor(input, dtype=dtype)
         scale_tp = tp.Tensor(scale)
-        quantized = tp.quantize(input_tp, scale_tp, tp.int4, dim)
-        dequantized = tp.dequantize(quantized, scale_tp, dtype, dim)
+
+        def func(input):
+            quantized = tp.quantize(input, scale_tp, tp.int4, dim)
+            return tp.dequantize(quantized, scale_tp, dtype, dim)
+
+        dequantized = compile_fixture(func, input_tp)
         assert torch.equal(input, torch.from_dlpack(dequantized).to("cpu"))
 
-    def test_negative_non_constant_scale(self):
+    def test_negative_non_constant_scale(self, compile_fixture):
         input = tp.ones((4, 4))
         scale = tp.ones((4,))
-        quantized = tp.quantize(input, scale, tp.int8, dim=0)
+        quantized = compile_fixture(tp.quantize, input, scale, tp.int8, dim=0)
         with raises(
             tp.TripyException,
             match="Scale must be a constant tensor in quantize op",

--- a/tripy/tests/integration/test_reduce.py
+++ b/tripy/tests/integration/test_reduce.py
@@ -36,12 +36,12 @@ class TestReduceOp:
             ((2, 3, 4, 5), (-2, -1), True),
         ],
     )
-    def test_all(self, x_shape, axis, keepdim):
+    def test_all(self, x_shape, axis, keepdim, compile_fixture):
         x = np.array([i % 2 == 0 for i in np.arange(np.prod(x_shape))]).reshape(x_shape)
         a = tp.Tensor(x)
-        out = tp.all(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.all, a, dim=axis, keepdim=keepdim)
         expected = tp.Tensor(np.array(x.all(axis=axis, keepdims=keepdim)))
-        #np.array is necessary to deal with case where x.all returns a numpy scalar (5th case)
+        # np.array is necessary to deal with case where x.all returns a numpy scalar (5th case)
         assert out.shape == expected.shape
         assert tp.allclose(out, expected)
 
@@ -57,18 +57,22 @@ class TestReduceOp:
             ((2, 3, 4, 5), (-2, -1), True),
         ],
     )
-
-    def test_any(self, x_shape, axis, keepdim):
+    def test_any(self, x_shape, axis, keepdim, compile_fixture):
         x = np.array([i % 2 == 0 for i in np.arange(np.prod(x_shape))]).reshape(x_shape)
         a = tp.Tensor(x)
-        out = tp.any(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.any, a, dim=axis, keepdim=keepdim)
         assert tp.allclose(out, tp.Tensor(np.array(x.any(axis=axis, keepdims=keepdim))))
 
     @pytest.mark.parametrize(
         "x_shape, axis, keepdim",
         [
             ((2, 3), 1, True),
-            pytest.param((2, 3, 4), (1, 2), True, marks=pytest.mark.skip(reason="For this test case without out.eval() tp.allclose fails. (Issue #)")),
+            pytest.param(
+                (2, 3, 4),
+                (1, 2),
+                True,
+                marks=pytest.mark.skip(reason="For this test case without out.eval() tp.allclose fails. (Issue #)"),
+            ),
             ((2, 3), 1, False),
             ((2, 3, 4), (1, 2), False),
             ((2, 3, 4), None, False),
@@ -77,11 +81,11 @@ class TestReduceOp:
         ],
     )
     @pytest.mark.parametrize("dtype", [tp.float32, tp.float16])
-    def test_mean(self, x_shape, axis, keepdim: bool, dtype):
+    def test_mean(self, x_shape, axis, keepdim: bool, dtype, compile_fixture):
         np_dtype = np.float32 if dtype == tp.float32 else np.float16
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np_dtype)
         a = tp.Tensor(x, dtype=dtype)
-        out = tp.mean(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.mean, a, dim=axis, keepdim=keepdim)
         expected = tp.Tensor(cp.array(x.mean(axis=axis, keepdims=keepdim)))
         assert out.shape == expected.shape
         assert tp.allclose(out, expected, rtol=1e-3, atol=1e-3)
@@ -98,10 +102,10 @@ class TestReduceOp:
             ((2, 3, 4, 5), (-2, -1), True),
         ],
     )
-    def test_var(self, x_shape, axis, keepdim: bool):
+    def test_var(self, x_shape, axis, keepdim: bool, compile_fixture):
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np.float32)
         a = tp.Tensor(x)
-        out = tp.var(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.var, a, dim=axis, keepdim=keepdim)
         torch_tensor = torch.Tensor(x)
         expected = tp.Tensor(torch_tensor.var(dim=axis, keepdim=keepdim))
         assert out.shape == expected.shape
@@ -118,10 +122,10 @@ class TestReduceOp:
             ((2, 3, 4), None, True),
         ],
     )
-    def test_argmax(self, x_shape, axis, keepdim: bool):
+    def test_argmax(self, x_shape, axis, keepdim: bool, compile_fixture):
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np.float32)
         a = tp.Tensor(x)
-        out = tp.argmax(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.argmax, a, dim=axis, keepdim=keepdim)
         assert np.array_equal(cp.from_dlpack(out).get(), np.array(x.argmax(axis=axis, keepdims=keepdim)))
 
     @pytest.mark.parametrize(
@@ -135,8 +139,8 @@ class TestReduceOp:
             ((2, 3, 4), None, True),
         ],
     )
-    def test_argmin(self, x_shape, axis, keepdim: bool):
+    def test_argmin(self, x_shape, axis, keepdim: bool, compile_fixture):
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np.float32)
         a = tp.Tensor(x)
-        out = tp.argmin(a, dim=axis, keepdim=keepdim)
+        out = compile_fixture(tp.argmin, a, dim=axis, keepdim=keepdim)
         assert np.array_equal(cp.from_dlpack(out).get(), np.array(x.argmin(axis=axis, keepdims=keepdim)))

--- a/tripy/tests/integration/test_reshape.py
+++ b/tripy/tests/integration/test_reshape.py
@@ -54,9 +54,9 @@ class TestReshape:
         out = compile_fixture(tp.reshape, a, (a.shape[0], a.shape[1], b.shape[2], b.shape[3]))
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 3, 2, 2), dtype=np.float32))
 
-    def test_reshape_shape_with_unknown(self):
+    def test_reshape_shape_with_unknown(self, compile_fixture):
         a = tp.ones((2, 3, 4))
-        out = tp.reshape(a, (2, a.shape[1], a.shape[2] / 2, -1))
+        out = compile_fixture(tp.reshape, a, (2, a.shape[1], a.shape[2] / 2, -1))
         assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 3, 2, 2), dtype=np.float32))
 
 

--- a/tripy/tests/integration/test_slice.py
+++ b/tripy/tests/integration/test_slice.py
@@ -70,14 +70,14 @@ class TestSliceOp:
             ((5,), lambda t: t[-12:-5:-1]),
         ],
     )
-    def test_static_slice_op(self, dims_a, slice_func):
+    def test_static_slice_op(self, dims_a, slice_func, compile_fixture):
         a_cp = cp.arange(np.prod(dims_a)).reshape(dims_a).astype(np.float32)
         a = tp.Tensor(a_cp, device=tp.device("gpu"))
 
         def func(a):
             return slice_func(a)
 
-        out = func(a)
+        out = compile_fixture(func, a)
         assert np.array_equal(cp.from_dlpack(out).get(), slice_func(a_cp).get())
 
     def test_slice_as_gather(self):

--- a/tripy/tests/integration/test_slice.py
+++ b/tripy/tests/integration/test_slice.py
@@ -80,7 +80,10 @@ class TestSliceOp:
         out = compile_fixture(func, a)
         assert np.array_equal(cp.from_dlpack(out).get(), slice_func(a_cp).get())
 
-    def test_slice_as_gather(self):
+    def test_slice_as_gather(self, compile_fixture):
+        def func(x, y):
+            return y[x]
+
         x_data = [0, 1, 2]
         y_data = [3, 4, 5]
         x = tp.Tensor(x_data)
@@ -88,7 +91,8 @@ class TestSliceOp:
         x_cp = cp.array(x_data)
         y_cp = cp.array(y_data)
 
-        assert np.array_equal(cp.from_dlpack(y[x]).get(), y_cp[x_cp].get())
+        out = compile_fixture(func, x, y)
+        assert np.array_equal(cp.from_dlpack(out).get(), y_cp[x_cp].get())
 
         x_shape = (2, 2)
         y_shape = (4, 3, 2)
@@ -99,4 +103,5 @@ class TestSliceOp:
         x_cp = cp.arange(x_vol, dtype=cp.int32).reshape(x_shape)
         y_cp = cp.arange(y_vol).reshape(y_shape)
 
-        assert np.array_equal(cp.from_dlpack(y[x]).get(), y_cp[x_cp].get())
+        out = compile_fixture(func, x, y)
+        assert np.array_equal(cp.from_dlpack(out).get(), y_cp[x_cp].get())

--- a/tripy/tests/integration/test_split.py
+++ b/tripy/tests/integration/test_split.py
@@ -46,13 +46,13 @@ class TestSplitOp:
             ((3, 0), (5, 1), lambda t: (t[:, :0], t[:, 0:0], t[:, 0:0], t[:, 0:0], t[:, 0:0])),
         ],
     )
-    def test_split_static(self, dims_a, split_params, reference_slices):
+    def test_split_static(self, dims_a, split_params, reference_slices, compile_fixture):
         a_cp = cp.arange(np.prod(dims_a)).reshape(dims_a).astype(cp.float32)
         a = tp.Tensor(a_cp, device=tp.device("gpu"))
 
         def func(t):
             return tp.split(t, split_params[0], split_params[1])
 
-        out = func(a)
+        out = compile_fixture(func, a)
         reference_out = reference_slices(a_cp)
         compare_split_results(out, reference_out)

--- a/tripy/tests/integration/test_strongly_typed.py
+++ b/tripy/tests/integration/test_strongly_typed.py
@@ -29,11 +29,11 @@ class TestStronglyTyped:
     def test_fp16_no_overflow(self, compile_fixture):
         a = tp.Tensor([10000, 60000], dtype=tp.float32)
 
-        def compute(a):
+        def func(a):
             a = tp.sum(a)  # 7e+4 is out of fp16 upperbound
             a = a / 5.0
             return tp.cast(a, tp.float16)
         
-        a = compile_fixture(compute, a)
+        a = compile_fixture(func, a)
 
         assert cp.from_dlpack(a).get() == np.array([14000], dtype=np.float16)

--- a/tripy/tests/integration/test_strongly_typed.py
+++ b/tripy/tests/integration/test_strongly_typed.py
@@ -26,10 +26,14 @@ class TestStronglyTyped:
     Sanity test that strongly typed mode is enabled.
     """
 
-    def test_fp16_no_overflow(self):
+    def test_fp16_no_overflow(self, compile_fixture):
         a = tp.Tensor([10000, 60000], dtype=tp.float32)
-        a = tp.sum(a)  # 7e+4 is out of fp16 upperbound
-        a = a / 5.0
-        a = tp.cast(a, tp.float16)
+
+        def compute(a):
+            a = tp.sum(a)  # 7e+4 is out of fp16 upperbound
+            a = a / 5.0
+            return tp.cast(a, tp.float16)
+        
+        a = compile_fixture(compute, a)
 
         assert cp.from_dlpack(a).get() == np.array([14000], dtype=np.float16)

--- a/tripy/tests/integration/test_unary_elementwise.py
+++ b/tripy/tests/integration/test_unary_elementwise.py
@@ -35,7 +35,7 @@ _UNARY_OPS = {
 
 class TestUnaryElementwise:
     @pytest.mark.parametrize("tp_func, np_func", [(tp_func, np_func) for tp_func, np_func in _UNARY_OPS.items()])
-    def test_op_funcs(self, tp_func, np_func):
+    def test_op_funcs(self, tp_func, np_func, compile_fixture):
         input = tp.arange(1, 4, dtype=tp.float32)
-        output = tp_func(input)
+        output = compile_fixture(tp_func, input)
         assert tp.allclose(output, tp.Tensor(np_func(cp.from_dlpack(input).get())))

--- a/tripy/tests/integration/test_unsqueeze.py
+++ b/tripy/tests/integration/test_unsqueeze.py
@@ -24,7 +24,7 @@ import tripy as tp
 
 class TestUnsqueezeOp:
     @pytest.mark.parametrize("axis", [0, 2, 3])
-    def test_unsqueeze_dynamic_op(self, axis):
+    def test_unsqueeze_dynamic_op(self, axis, compile_fixture):
         def func(a):
             return tp.unsqueeze(a, dim=axis)
 
@@ -34,5 +34,5 @@ class TestUnsqueezeOp:
 
         inp = np.ones((4, 2, 2, 3), dtype=np.float32)
 
-        out = func(tp.Tensor(inp))
+        out = compile_fixture(func, tp.Tensor(inp))
         assert tp.allclose(out, tp.Tensor(np.expand_dims(inp, axis=axis)))

--- a/tripy/tests/integration/test_unsqueeze.py
+++ b/tripy/tests/integration/test_unsqueeze.py
@@ -35,4 +35,6 @@ class TestUnsqueezeOp:
         inp = np.ones((4, 2, 2, 3), dtype=np.float32)
 
         out = compile_fixture(func, tp.Tensor(inp))
-        assert tp.allclose(out, tp.Tensor(np.expand_dims(inp, axis=axis)))
+        correct = tp.Tensor(np.expand_dims(inp, axis=axis))
+        assert out.shape == correct.shape
+        assert tp.allclose(out, correct)

--- a/tripy/tests/integration/test_where_op.py
+++ b/tripy/tests/integration/test_where_op.py
@@ -35,19 +35,19 @@ class TestWhereOp:
             ((0,), (1,), (1,)),  # 0 dim in the condition
         ],
     )
-    def test_where_broadcast_shapes(self, cond, x, y):
+    def test_where_broadcast_shapes(self, cond, x, y, compile_fixture):
         x = np.arange(np.prod(x)).reshape(x).astype(np.float32)
         y = np.arange(np.prod(y)).reshape(y).astype(np.float32)
         t_cond = np.arange(np.prod(cond)).reshape(cond).astype(np.float32)
         a = Tensor(x)
         b = Tensor(y)
         condition = Tensor(t_cond % 2 == 0)
-        out = tp.where(condition, a, b)
+        out = compile_fixture(tp.where, condition, a, b)
         assert np.array_equal(cp.from_dlpack(out).get(), np.array(np.where((t_cond % 2 == 0), x, y)))
 
-    def test_explicit_condition(self):
+    def test_explicit_condition(self, compile_fixture):
         select_indices = tp.Tensor([True, False, True, False], dtype=tp.bool)
         ones = tp.ones((4,), dtype=tp.int32)
         zeros = tp.zeros((4,), dtype=tp.int32)
-        w = tp.where(select_indices, ones, zeros)
+        w = compile_fixture(tp.where, select_indices, ones, zeros)
         assert cp.from_dlpack(w).get().tolist() == [1, 0, 1, 0]


### PR DESCRIPTION
This MR adds a compile fixture to our integration test suite so that we can test ops both lazily and using the compiler API. Addresses #256.