### PR TITLE
Use packages.html file for identifying packages required for tripy

### DIFF
--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 
     <!-- TODO (#release) -->
     ```bash
-    docker build -t tripy --build-arg GITHUB_TOKEN=$GITHUB_TOKEN .
+    docker build -t tripy .
     ```
 
 3. Launch the container; from the [`tripy` root directory](.), run:

--- a/tripy/Dockerfile
+++ b/tripy/Dockerfile
@@ -31,11 +31,10 @@ RUN cd /usr/lib/ && \
 ENV LD_LIBRARY_PATH=/usr/lib/TensorRT-10.1.0.27/lib/:$LD_LIBRARY_PATH
 
 COPY pyproject.toml /tripy/pyproject.toml
-RUN pip install https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.29/mlir_tensorrt_compiler-0.1.29+cuda12.trt102-cp310-cp310-linux_x86_64.whl
-RUN pip install https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.29/mlir_tensorrt_runtime-0.1.29+cuda12.trt102-cp310-cp310-linux_x86_64.whl
 
 RUN pip install .[docs,dev,test] \
     -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
+    -f https://nvidia.github.io/TensorRT-Incubator/packages.html \
     --extra-index-url https://download.pytorch.org/whl
 
 

--- a/tripy/README.md
+++ b/tripy/README.md
@@ -17,9 +17,7 @@ user experience without compromising performance. Some of the features of Tripy 
 ## Installation
 
 ```bash
-pip3 install https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.29/mlir_tensorrt_compiler-0.1.29+cuda12.trt102-cp310-cp310-linux_x86_64.whl
-pip3 install https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.29/mlir_tensorrt_runtime-0.1.29+cuda12.trt102-cp310-cp310-linux_x86_64.whl
-pip3 install https://github.com/NVIDIA/TensorRT-Incubator/releases/download/tripy-v0.0.1/tripy-0.0.1-py3-none-any.whl
+pip3 install --no-index -f https://nvidia.github.io/TensorRT-Incubator/packages.html tripy
 ```
 
 If you want to build from source, please follow the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
https://nvidia.github.io/TensorRT-Incubator/packages.html (generated by https://github.com/NVIDIA/TensorRT-Incubator/pull/39)