### PR TITLE
Ease translation of known static shape args to mlir

### DIFF
--- a/tripy/tests/backend/test_compiler_api.py
+++ b/tripy/tests/backend/test_compiler_api.py
@@ -101,7 +101,8 @@ def single_return_executable():
 @pytest.fixture(scope="session")
 def multiple_return_executable():
     compiler = tp.Compiler(returns_multiple_tensors)
-    return compiler.compile(tp.InputInfo((2, 2), dtype=tp.float32), tp.InputInfo((2, 2), dtype=tp.float32))
+    # TODO: revert back to InputInfo (2,2) when https://github.com/NVIDIA/TensorRT-Incubator/issues/44 is fixed.
+    return compiler.compile(tp.InputInfo((2, [1,2,3]), dtype=tp.float32), tp.InputInfo((2, [1,2,3]), dtype=tp.float32))
 
 
 class TestExecutable:
@@ -153,12 +154,12 @@ class TestExecutable:
         input_info = multiple_return_executable.get_input_info()
         assert len(input_info) == 2
         for i in range(2):
-            assert input_info[i].shape_bounds == ((2, 2), (2, 2))
+            assert input_info[i].shape_bounds == ((2, 2), (1, 3))
             assert input_info[i].dtype == tp.float32
         output_info = multiple_return_executable.get_output_info()
         assert len(output_info) == 2
         for i in range(2):
-            assert output_info[i].shape_bounds == ((2, 2), (2, 2))
+            assert output_info[i].shape_bounds == ((2, 2), (1, 3))
             assert output_info[i].dtype == tp.float32
 
     def test_file_io(self, single_return_executable):

--- a/tripy/tripy/common/shape_bounds.py
+++ b/tripy/tripy/common/shape_bounds.py
@@ -24,3 +24,6 @@ class ShapeBounds:
     min: Sequence[int]
     opt: Sequence[int]
     max: Sequence[int]
+    
+    def is_static(self):
+        return self.min == self.opt == self.max

--- a/tripy/tripy/flat_ir/flat_ir.py
+++ b/tripy/tripy/flat_ir/flat_ir.py
@@ -113,16 +113,18 @@ class FlatIR:
                         arg_attrs: List[Dict[str, ir.Attribute]] = []
                         for bound in self.shapes:
                             # TODO (#244): Support multiple profiles
-
-                            arg_attrs.append(
-                                {
-                                    "tensorrt.shape_profile": ir.Attribute.parse(
-                                        f"#tensorrt.shape_profile<min={list(bound.min)}, opt={list(bound.opt)}, max={list(bound.max)}>"
+                            if bound.is_static():
+                                arg_attrs.append(ir.DictAttr.get({}))
+                            else:
+                                arg_attrs.append(
+                                    ir.DictAttr.get({
+                                        "tensorrt.shape_profile": ir.Attribute.parse(
+                                            f"#tensorrt.shape_profile<min={list(bound.min)}, opt={list(bound.opt)}, max={list(bound.max)}>"
+                                            )
+                                        }
                                     )
-                                }
-                            )
-
-                        func_op.arg_attrs = ir.ArrayAttr.get([ir.DictAttr.get(attrs) for attrs in arg_attrs])
+                                )
+                        func_op.arg_attrs = ir.ArrayAttr.get(arg_attrs)
 
                     # Append device location if outputs are on host as MLIR-TensorRT does not adhere to this constraint.
                     # TODO(#155): Fix TensorKindAnalysis to ensure result tensors with attribute `tensorrt.host_tensor` are allocated on host.

--- a/tripy/tripy/frontend/trace/trace.py
+++ b/tripy/tripy/frontend/trace/trace.py
@@ -123,7 +123,7 @@ class Trace:
         # Assign shapes to static shape arguments to ease translation and optimizations during the lowering to MLIR.
         if self.shapes:
             for input, shape_bounds in zip(self.inputs, self.shapes):
-                if shape_bounds.is_static():
+                if shape_bounds.is_static() and input.shape is None:
                     assert all(s >= 0 for s in shape_bounds.min), f"shape bounds expected to be >= 0, got {shape_bounds.min}"
                     input.shape = shape_bounds.min
 

--- a/tripy/tripy/frontend/trace/trace.py
+++ b/tripy/tripy/frontend/trace/trace.py
@@ -124,6 +124,7 @@ class Trace:
         if self.shapes:
             for input, shape_bounds in zip(self.inputs, self.shapes):
                 if shape_bounds.is_static():
+                    assert all(s >= 0 for s in shape_bounds.min), f"shape bounds expected to be >= 0, got {shape_bounds.min}"
                     input.shape = shape_bounds.min
 
         flat_ir.inputs = [flat_ir.register_tensor(inp.to_flat_ir()) for inp in self.inputs]

--- a/tripy/tripy/frontend/trace/trace.py
+++ b/tripy/tripy/frontend/trace/trace.py
@@ -120,6 +120,11 @@ class Trace:
         from tripy.flat_ir.flat_ir import FlatIR
 
         flat_ir = FlatIR(shapes=self.shapes)
+        # Assign shapes to static shape arguments to ease translation and optimizations during the lowering to MLIR.
+        if self.shapes:
+            for input, shape_bounds in zip(self.inputs, self.shapes):
+                if shape_bounds.is_static():
+                    input.shape = shape_bounds.min
 
         flat_ir.inputs = [flat_ir.register_tensor(inp.to_flat_ir()) for inp in self.inputs]
         flat_ir.outputs = [flat_ir.register_tensor(out.to_flat_ir()) for out in self.outputs]


### PR DESCRIPTION
This PR eases the translation to MLIR program via ensuring static shape arguments are not expressed as dynamic shape args with shape profile of `min==max==opt`.

New function signature after this change:
```py
module @ins_a_b_outs_t8_1 {
  func.func @main(%arg0: tensor<?xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [1], opt = [2], max = [5]>}, %arg1: tensor<1xf32>) -> tensor<?xf32> {

  }
}
```
Old function signature:
```py
  func.func @main(%arg0: tensor<?xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [1], opt = [2], max = [5]>}, %arg1: tensor<?xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [1], opt = [1], max = [1]>}) -> tensor<?xf32> {
```

