### PR TITLE
Remove remove_constants utils

### DIFF
--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -33,7 +33,7 @@ import torch
 
 import tripy as tp
 from tripy import utils
-from tripy.backend.mlir.utils import remove_constants, remove_sym_attr
+from tripy.backend.mlir.utils import remove_sym_attr
 from tripy.common.exception import _make_stack_info_message
 from tripy.frontend import Tensor
 from tripy.frontend.trace import Trace
@@ -76,7 +76,7 @@ def check_mlir(mlir, expected):
     # Checks a given MLIR module against a string of the expected program.
     # MLIR indents with 2 spaces; we'll replace it with 4 spaces so that it's
     # easier to write the expected string.
-    mlir_str = remove_constants(str(mlir)).replace(" " * 2, " " * 4).strip()
+    mlir_str = mlir.operation.get_asm(large_elements_limit=32).replace(" " * 2, " " * 4).strip()
     mlir_str = remove_sym_attr(mlir_str)
     assert mlir_str == dedent(expected).strip()
 

--- a/tripy/tests/tools/test_stablehlo_runner.py
+++ b/tripy/tests/tools/test_stablehlo_runner.py
@@ -23,7 +23,6 @@ import pytest
 
 import tripy as tp
 from tools.stablehlo_runner import compile_code, preprocess_program, read_program_from_file
-from tripy.backend.mlir.utils import remove_constants
 from tripy.frontend.trace import Trace
 
 
@@ -39,7 +38,7 @@ def init_mlir_textual():
 
     out = a + b
     trace = Trace([out])
-    mlir_textual = remove_constants(str(trace.to_flat_ir().to_mlir()))
+    mlir_textual = trace.to_flat_ir().to_mlir().operation.get_asm(large_elements_limit=32)
     return mlir_textual
 
 

--- a/tripy/tripy/backend/mlir/compiler.py
+++ b/tripy/tripy/backend/mlir/compiler.py
@@ -26,7 +26,6 @@ from tripy.backend.mlir.utils import (
     make_ir_context,
     map_error_to_user_code_and_raise,
     redirect_stderr,
-    remove_constants,
 )
 from tripy.logging import logger
 
@@ -93,7 +92,7 @@ class Compiler:
     # The optional flat_ir parameter is used to generate nicer error messages.
     @utils.log_time
     def compile(self, mlir_module: ir.Module, flat_ir: Optional["FlatIR"] = None) -> compiler.Executable:
-        logger.mlir(lambda: f"{remove_constants(str(mlir_module))}\n")
+        logger.mlir(lambda: f"{mlir_module.operation.get_asm(large_elements_limit=32)}\n")
         opts = self._make_mlir_opts(self.trt_builder_opt_level)
 
         try:

--- a/tripy/tripy/backend/mlir/utils.py
+++ b/tripy/tripy/backend/mlir/utils.py
@@ -133,26 +133,6 @@ def remove_sym_attr(mlir_text: str) -> str:
     return re.sub(r"module @\S+ {", "module {", mlir_text)
 
 
-def remove_constants(mlir_text) -> str:
-    lines = mlir_text.split("\n")
-
-    def replace_dense_data(text):
-        const_start_index = text.find("<") + 1
-        const_end_index = text.find(">") - 1
-        start_index = text.find(": tensor<") + 9
-
-        substr = text[start_index:]
-        dims = substr.split("x")
-        dims = [int(dim) for dim in dims if dim.isdigit()]
-
-        if utils.should_omit_constant_in_str(dims):
-            return text[:const_start_index] + "..." + text[const_end_index + 1 :]
-        return text
-
-    replaced = [replace_dense_data(line) if "stablehlo.constant dense" in line else line for line in lines]
-    return "\n".join(replaced)
-
-
 UNKNOWN_LOC = "unknown"
 OUTPUT_SEPARATOR = ";;<out>;;"
 TRACE_INPUTS_SEPARATOR = ";;<trace_in>;;"


### PR DESCRIPTION
Utilize `get_asm(large_elements_limit=32)` for printing mlir textual program.
Thanks @christopherbate for pointing this out.