### PR TITLE
Add external reference counting to AllocTracker

### DIFF
--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -177,6 +177,12 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtMemRefValueGetDLPackManagedTensor(
 MLIR_CAPI_EXPORTED MTRT_Status mtrtMemRefValueGetDLPackDevice(
     MTRT_MemRefValue memrefValue, int32_t *device_type, int32_t *device_id);
 
+MLIR_CAPI_EXPORTED MTRT_Status mtrtMemRefReferenceCount(
+    MTRT_RuntimeClient client, uintptr_t ptr, int32_t *externalRefCount);
+
+MLIR_CAPI_EXPORTED MTRT_Status mtrtMemRefIsReleasedInternally(
+    MTRT_RuntimeClient client, uintptr_t ptr, bool *isReleasedInternally);
+
 //===----------------------------------------------------------------------===//
 // MTRT_RuntimeClient
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -783,7 +783,22 @@ PYBIND11_MODULE(_api, m) {
             THROW_IF_MTRT_ERROR(s);
           },
           py::arg("device_memref"), py::arg("existing_host_memref"),
-          py::arg("stream") = py::none());
+          py::arg("stream") = py::none())
+      .def("external_reference_count",
+           [](PyRuntimeClient &self, uintptr_t ptr) {
+             int32_t externalRefCount;
+             MTRT_Status s =
+                 mtrtMemRefReferenceCount(self, ptr, &externalRefCount);
+             THROW_IF_MTRT_ERROR(s);
+             return externalRefCount;
+           })
+      .def("is_released_internally", [](PyRuntimeClient &self, uintptr_t ptr) {
+        bool isReleasedInternally;
+        MTRT_Status s =
+            mtrtMemRefIsReleasedInternally(self, ptr, &isReleasedInternally);
+        THROW_IF_MTRT_ERROR(s);
+        return isReleasedInternally;
+      });
 
   py::class_<PyRuntimeValue>(m, "RuntimeValue", py::module_local())
       .def_property_readonly(MTRT_PYTHON_CAPI_PTR_ATTR,

--- a/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
@@ -1,6 +1,8 @@
 # RUN: %PYTHON %s 2>&1 | FileCheck %s
 # REQUIRES: host-has-at-least-1-gpus
 
+import gc
+
 import array
 import cupy as cp
 import numpy as np
@@ -292,3 +294,157 @@ def test_memref_allocations():
 
 
 test_memref_allocations()
+
+
+def create_host_memref_external_owner_with_external_reference(arr):
+    # memref ptr is owned externally, should not get deleted until np holds memref ptr
+    memref = client.create_host_memref_view(
+        int(arr.ctypes.data), shape=[3], dtype=runtime.ScalarTypeCode.f64
+    )
+    return np.from_dlpack(memref)
+
+
+def create_device_memref_external_owner_with_external_reference(arr):
+    # memref ptr is owned externally, should not get deleted until np holds memref ptr
+    memref = client.create_device_memref_view(
+        int(arr.data.ptr),
+        shape=[3],
+        dtype=runtime.ScalarTypeCode.f64,
+        device=devices[0],
+    )
+    return cp.from_dlpack(memref)
+
+
+def create_host_memref_internal_owner_with_external_reference():
+    # memref is owned internally, should not get deleted until np holds memref ptr
+    arr = array.array("f", [5.0, 4.0, 2.0])
+    memref = client.create_memref(arr)
+    return np.from_dlpack(memref)
+
+
+def create_device_memref_internal_owner_with_external_reference():
+    # memref is owned internally, should not get deleted until np holds memref ptr
+    arr = array.array("f", [5.0, 4.0, 2.0])
+    memref = client.create_memref(arr, device=devices[0])
+    return cp.from_dlpack(memref)
+
+
+def test_memref_external_reference():
+    np_arr = np.array([5.0, 4.0, 2.0])
+    cp_arr = cp.array([5.0, 4.0, 2.0])
+    print(
+        f"Test externally owned Array -> client.host_memref_view -> externally referenced numpy.from_dlpack"
+    )
+    print(
+        f"Numpy Array: ",
+        create_host_memref_external_owner_with_external_reference(np_arr),
+    )
+    print(
+        f"Test externally owned Array -> client.device_memref_view -> externally referenced cupy.from_dlpack"
+    )
+    print(
+        f"Cupy Array: ",
+        create_device_memref_external_owner_with_external_reference(cp_arr),
+    )
+    print(
+        f"Test internally owned Array -> client.host_memref -> externally referenced numpy.from_dlpack"
+    )
+    print(f"Numpy Array: ", create_host_memref_internal_owner_with_external_reference())
+    print(
+        f"Test internally owned Array -> client.device_memref-> externally referenced cupy.from_dlpack"
+    )
+    print(
+        f"Cupy Array: ", create_device_memref_internal_owner_with_external_reference()
+    )
+
+
+print("Test memref external reference counting")
+test_memref_external_reference()
+
+# CHECK-LABEL: Test memref external reference counting
+# CHECK-NEXT: Test externally owned Array -> client.host_memref_view -> externally referenced numpy.from_dlpack
+# CHECK-NEXT: Numpy Array:  [5. 4. 2.]
+# CHECK-NEXT: Test externally owned Array -> client.device_memref_view -> externally referenced cupy.from_dlpack
+# CHECK-NEXT: Cupy Array:  [5. 4. 2.]
+# CHECK-NEXT: Test internally owned Array -> client.host_memref -> externally referenced numpy.from_dlpack
+# CHECK-NEXT: Numpy Array:  [5. 4. 2.]
+# CHECK-NEXT: Test internally owned Array -> client.device_memref-> externally referenced cupy.from_dlpack
+# CHECK-NEXT: Cupy Array:  [5. 4. 2.]
+
+
+def test_num_external_references():
+    arr = np.array([5.0, 4.0, 2.0])
+    memref = client.create_host_memref_view(
+        int(arr.ctypes.data), shape=[3], dtype=runtime.ScalarTypeCode.f64
+    )
+    num_ref_count = 10
+    arrays = []
+    for i in range(num_ref_count):
+        arrays.append(np.from_dlpack(memref))
+    print(
+        "Number of External reference count: ",
+        client.external_reference_count(arr.ctypes.data),
+    )
+
+
+print("Test memref number of external reference counts")
+test_num_external_references()
+
+# CHECK-LABEL: Test memref number of external reference counts
+# CHECK-NEXT: Number of External reference count:  10
+
+
+def test_released_internally():
+    arr = np.array([5.0, 4.0, 2.0])
+
+    def memref_alloc():
+        memref = client.create_host_memref_view(
+            int(arr.ctypes.data), shape=[3], dtype=runtime.ScalarTypeCode.f64
+        )
+        return np.from_dlpack(
+            memref
+        )  # Ensure we have an externally reference to the pointer.
+
+    _ = memref_alloc()
+    print(
+        "Memref released internally: ", client.is_released_internally(arr.ctypes.data)
+    )
+
+
+print("Test memref is released internally with an external reference")
+test_released_internally()
+
+# CHECK-LABEL: Test memref is released internally with an external reference
+# CHECK-NEXT: Memref released internally:  True
+
+
+def test_memref_lifetime():
+    def memref_alloc():
+        # allocate internally owned array
+        arr_in = array.array("f", [5.0, 4.0, 2.0])
+        memref = client.create_memref(arr_in)
+        # create an external reference
+        arr_out = np.from_dlpack(memref)
+        # memref goes out of scope
+        return arr_out
+
+    arr_out = memref_alloc()
+    gc.collect()  # Ensure memref is GC'ed.
+    print(
+        "Memref released internally: ",
+        client.is_released_internally(arr_out.ctypes.data),
+    )
+    print(
+        "Number of External reference count: ",
+        client.external_reference_count(arr_out.ctypes.data),
+    )
+    print("Numpy Array: ", arr_out)
+
+
+print("Test memref lifetime")
+test_memref_lifetime()
+
+# CHECK-LABEL: Test memref lifetime
+# CHECK-NEXT: Memref released internally:  True
+# CHECK-NEXT: Number of External reference count:  1
+# CHECK-NEXT: Numpy Array:  [5. 4. 2.]


### PR DESCRIPTION
RuntimeClient uses the AllocTracker class to manage the lifetime of pointers.
A pointer could be owned internally or externally and referenced internally or externally. The current implementation only accounts for infernal references. This PR extends AllocTracker to account for external reference and fixes a bug where we would deallocate a memref even if it is being referenced externally (eg. by a DL managed tensor owned by numpy/cupy etc.)

Before this change:
```
Test internally owned Array -> client.host_memref -> externally referenced numpy.from_dlpack
Numpy Array:  [5.4155870e-39 3.2533946e-41 2.1489487e-11]
```

After this change:
```
Test internally owned Array -> client.host_memref -> externally referenced numpy.from_dlpack
Numpy Array:  [5. 4. 2.]
```

Signed-off-by: Jhalak Patel <jhalakp@nvidia.com>