### PR TITLE
Updates MLIR-TRT packages to depend on TensorRT 10

### DIFF
--- a/mlir-tensorrt/executor/lib/Utils/TensorRTDynamicLoader/TensorRTDynamicLoader.cpp
+++ b/mlir-tensorrt/executor/lib/Utils/TensorRTDynamicLoader/TensorRTDynamicLoader.cpp
@@ -30,10 +30,14 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif // defined(__clang__)
+#include "NvInferVersion.h"
 #include <NvInfer.h>
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif // defined(__clang__)
+
+#define STR_IMPL(x) #x
+#define STR(x) STR_IMPL(x)
 
 extern "C" {
 
@@ -48,7 +52,8 @@ extern "C" {
   } while (false)
 
 #define LOAD_NVINFER_LIB_OR_RETURN(varName, errorReturnValue)                  \
-  LOAD_LIB_OR_RETURN(varName, errorReturnValue, "libnvinfer.so")
+  LOAD_LIB_OR_RETURN(varName, errorReturnValue,                                \
+                     "libnvinfer.so." STR(NV_TENSORRT_MAJOR))
 #define LOAD_NVINFER_LIB_OR_RETURN_NULLPTR(varName)                            \
   LOAD_NVINFER_LIB_OR_RETURN(varName, nullptr)
 

--- a/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/api.py
+++ b/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/api.py
@@ -1,1 +1,4 @@
+# Import tensorrt so that the libraries are loaded
+import tensorrt
+
 from ._mlir_libs._api import *

--- a/mlir-tensorrt/python/mlir_tensorrt_compiler/pyproject.toml
+++ b/mlir-tensorrt/python/mlir_tensorrt_compiler/pyproject.toml
@@ -26,5 +26,6 @@ dependencies = [
     "pybind11>=2.8.0, <=2.10.3",
     "PyYAML>= 5.3.1, <=6.0.1",
     "dataclasses>=0.6, <=0.8",
+    "tensorrt~=10.0",
 ]
 dynamic = ["version"]

--- a/mlir-tensorrt/python/mlir_tensorrt_runtime/mlir_tensorrt/runtime/api.py
+++ b/mlir-tensorrt/python/mlir_tensorrt_runtime/mlir_tensorrt/runtime/api.py
@@ -1,1 +1,4 @@
+# Import tensorrt so that the libraries are loaded
+import tensorrt
+
 from ._mlir_libs._api import *

--- a/mlir-tensorrt/python/mlir_tensorrt_runtime/pyproject.toml
+++ b/mlir-tensorrt/python/mlir_tensorrt_runtime/pyproject.toml
@@ -21,4 +21,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Private :: Do Not Upload"
 ]
+dependencies = [
+    "tensorrt~=10.0",
+]
 dynamic = ["version"]


### PR DESCRIPTION
- Updates MLIR-TRT and Tripy packages to depend on TRT 10.X

- Updates MLIR-TRT to include major version when loading TRT. The libraries that ship with the wheels always include the major version and do not provide a `libvninfer.so` symlink

- Updates MLIR-TRT to load the TRT Python package when the Python bindings are imported. This ensures that the correct version of the libraries will be picked up by the loader later on.