### PR TITLE
Array does not allocate buffer for list data

### DIFF
--- a/tripy/tripy/backend/mlir/executor.py
+++ b/tripy/tripy/backend/mlir/executor.py
@@ -36,55 +36,52 @@ class Executor:
         self.device = self.runtime_client.get_devices()[0]  # Assume a single device is available.
         self.signature = executable.get_signature("main")
 
-    def _get_inputs_shape_memref(self, inputs):
-        inputs_shape_memref = []
-        for input in inputs:
-            input_shape = Array(
-                input.trace_tensor.producer.data.shape,
-                shape=make_tuple(input.trace_tensor.rank),
-                dtype=datatype.int64,
-                device=device("cpu"),
-            )
-            inputs_shape_memref.append(input_shape.memref_value)
-        return inputs_shape_memref
+    def _create_shape_memref(self, shape):
+        from tripy.common.utils import convert_list_to_array
 
-    def _get_outputs_shape_memref(self):
+        shape = make_tuple(shape)
+        return self.runtime_client.create_memref(
+            convert_list_to_array(shape, datatype.int64),
+            shape=(len(shape),),
+            dtype=runtime.ScalarTypeCode.i64,
+        )
+
+    def _get_inputs_shape(self, inputs):
+        inputs_shape = []
+        for input in inputs:
+            inputs_shape.append(input.trace_tensor.producer.data.shape)
+        return inputs_shape
+
+    def _get_outputs_shape(self):
         offset = self.signature.get_num_input_args()
-        outputs_shape_memref = []
+        outputs_shape = []
+        all_outputs_known = True
         for output_index in range(self.signature.get_num_output_args()):
             arg_index = output_index + offset
             arg = self.signature.get_arg(arg_index)
             assert compiler.MemRefType.isinstance(arg)
             memref = runtime.MemRefType(arg)
             rank = len(memref.shape)
-            if len(memref.shape) > 0:
-                output_shape = Array(memref.shape, shape=make_tuple(rank), dtype=datatype.int64, device=device("cpu"))
-                outputs_shape_memref.append(output_shape.memref_value)
+            if rank > 0:
+                outputs_shape.append(memref.shape)
+                all_outputs_known &= all(dim >= 0 for dim in memref.shape)
             else:
-                outputs_shape_memref.append(None)
-        return outputs_shape_memref
+                outputs_shape.append(None)
+        return outputs_shape, all_outputs_known
 
-    def _execute_shape_inference(self, inputs_shape_memref, outputs_shape_memref):
+    def _execute_shape_inference(self, inputs_shape, outputs_shape):
         # Only execute shape inference if shape function name is valid.
-        if not self.signature.get_shape_func_name():
-            for memref in outputs_shape_memref:
-                if memref is not None:
-                    assert (
-                        all(dim >= 0 for dim in memref.shape)
-                        and f"Output shape {memref.shape} must be statically known if shape inference function is missing. "
-                    )
-            return None
+        assert (
+            self.signature.get_shape_func_name()
+        ), f"Shape inference function is missing while output shapes are not known."
 
+        inputs_shape_memref = [self._create_shape_memref(inp_shape) for inp_shape in inputs_shape]
+        outputs_shape_memref = [self._create_shape_memref(out_shape) for out_shape in outputs_shape]
         self.session.execute_function(
             name=self.signature.get_shape_func_name(), in_args=inputs_shape_memref, out_args=outputs_shape_memref
         )
 
-        outputs_shapes_host = [
-            Array(memoryview(s).tolist(), shape=s.shape, dtype=datatype.int64, device=device("cpu"))
-            for s in outputs_shape_memref
-        ]
-
-        outputs_runtime_shape = [s.data() for s in outputs_shapes_host]
+        outputs_runtime_shape = [memoryview(s).tolist() for s in outputs_shape_memref]
         return outputs_runtime_shape
 
     def _get_output_tensor_info(self, outputs_runtime_shape, output_devices):
@@ -126,12 +123,13 @@ class Executor:
         return outputs_tensor_info
 
     def get_output_tensor_runtime_info(self, inputs, output_devices=List[device]):
-        inputs_shape_memref = self._get_inputs_shape_memref(
-            inputs
-        )  # Can we use executable signature inputs to retrieve this information?
-        outputs_shape_memref = self._get_outputs_shape_memref()
-        outputs_runtime_shape = self._execute_shape_inference(inputs_shape_memref, outputs_shape_memref)
-        output_tensor_info = self._get_output_tensor_info(outputs_runtime_shape, output_devices)
+        outputs_shape, all_outputs_known = self._get_outputs_shape()
+        if not all_outputs_known:
+            inputs_shape = self._get_inputs_shape(
+                inputs
+            )  # Can we use executable signature inputs to retrieve this information?
+            outputs_shape = self._execute_shape_inference(inputs_shape, outputs_shape)
+        output_tensor_info = self._get_output_tensor_info(outputs_shape, output_devices)
         return output_tensor_info
 
     @log_time

--- a/tripy/tripy/backend/mlir/utils.py
+++ b/tripy/tripy/backend/mlir/utils.py
@@ -79,6 +79,11 @@ def get_mlir_dtype(dtype: "tripy.dtype"):
     }[dtype.name]
 
 
+def get_mlir_scalar_attr(dtype: "tripy.dtype", value):
+    attr_func = ir.FloatAttr.get if "float" in dtype.name else ir.IntegerAttr.get
+    return attr_func(get_mlir_dtype(dtype), value)
+
+
 def get_mlir_quant_dtype(
     origin_dtype: "tripy.dtype",
     quant_dtype: "tripy.dtype",

--- a/tripy/tripy/flat_ir/ops/constant.py
+++ b/tripy/tripy/flat_ir/ops/constant.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import numbers
 from dataclasses import dataclass
 from typing import Sequence, Set
 
@@ -24,8 +25,6 @@ from mlir_tensorrt.compiler.dialects import stablehlo
 from tripy import utils
 from tripy.common.array import Array
 from tripy.flat_ir.ops.base import BaseFlatIROp
-
-import mlir_tensorrt.runtime.api as runtime
 
 
 @dataclass(repr=False)
@@ -44,34 +43,46 @@ class ConstantOp(BaseFlatIROp):
         from tripy.backend.mlir import utils as mlir_utils
 
         # TODO(#189): Remove explicit copy to host for constants
-        assert isinstance(self.data, Array)
-        memref_value = self.data.memref_value
-        if self.data.device.kind == "gpu":
-            memref_value = mlir_utils.MLIRRuntimeClient().copy_to_host(
-                device_memref=memref_value,
-                stream=None,
-            )
-
-        # Workaround (#208): bools are represented as i1 in MLIR-TRT but they cannot be used for DenseElementsAttr
-        # so we have to represent them as ints and then cast the result
-        if self.outputs[0].dtype == datatype.bool:
-            # need to use memoryview.cast to ensure that the view will be flattened
-            int_memref = self.data.runtime_client.create_memref(
-                array.array("i", memoryview(memref_value).cast("b").tolist()),
-                shape=self.data.shape,
-                dtype=mlir_utils.convert_tripy_dtype_to_runtime_dtype(datatype.int32),
-                device=None,
-            )
-            attr = ir.DenseElementsAttr.get(
-                array=int_memref, type=mlir_utils.get_mlir_dtype(datatype.int32), shape=self.data.shape
-            )
-            cast_output = mlir_utils.make_mlir_tensor(datatype.bool, self.data.shape)
-            constant_op = stablehlo.ConstantOp(attr)
-            return [stablehlo.ConvertOp(result=cast_output, operand=constant_op)]
-
         assert self.data.dtype == self.outputs[0].dtype
-        attr = ir.DenseElementsAttr.get(
-            array=memref_value, type=mlir_utils.get_mlir_dtype(self.outputs[0].dtype), shape=self.data.shape
-        )
+        if self.data.has_memref:
+            memref_value = self.data.memref_value
+            if self.data.device.kind == "gpu":
+                memref_value = mlir_utils.MLIRRuntimeClient().copy_to_host(
+                    device_memref=memref_value,
+                    stream=None,
+                )
+
+            # Workaround (#208): bools are represented as i1 in MLIR-TRT but they cannot be used for DenseElementsAttr
+            # so we have to represent them as ints and then cast the result
+            if self.outputs[0].dtype == datatype.bool:
+                # need to use memoryview.cast to ensure that the view will be flattened
+                int_memref = self.data.runtime_client.create_memref(
+                    array.array("i", memoryview(memref_value).cast("b").tolist()),
+                    shape=self.data.shape,
+                    dtype=mlir_utils.convert_tripy_dtype_to_runtime_dtype(datatype.int32),
+                    device=None,
+                )
+                attr = ir.DenseElementsAttr.get(
+                    array=int_memref, type=mlir_utils.get_mlir_dtype(datatype.int32), shape=self.data.shape
+                )
+                cast_output = mlir_utils.make_mlir_tensor(datatype.bool, self.data.shape)
+                constant_op = stablehlo.ConstantOp(attr)
+                return [stablehlo.ConvertOp(result=cast_output, operand=constant_op)]
+
+            attr = ir.DenseElementsAttr.get(
+                array=memref_value, type=mlir_utils.get_mlir_dtype(self.outputs[0].dtype), shape=self.data.shape
+            )
+        else:
+            out_dtype = self.outputs[0].dtype
+
+            def to_attrs(data):
+                if isinstance(data, numbers.Number):
+                    return [mlir_utils.get_mlir_scalar_attr(out_dtype, data)]
+                attrs = []
+                for element in data:
+                    attrs.extend(to_attrs(element))
+                return attrs
+
+            attr = ir.DenseElementsAttr.get(attrs=to_attrs(self.data.data()), type=self.outputs[0].to_mlir())
 
         return [stablehlo.ConstantOp(attr)]

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -67,7 +67,7 @@ class Cast(BaseTraceOp):
                 device=convert_input.device,
                 reason_details=["Zero scalar for casting to bool"],
             )
-            ConstantOp.build([], [single_zero], data=Array(0, shape=(), dtype=zero_dtype, device=convert_input.device))
+            ConstantOp.build([], [single_zero], data=0)
             zeros_shape = op_utils.get_shape_of_tensor(convert_input)
             zeros = FlatIRTensor.build(
                 shape=convert_input.shape,

--- a/tripy/tripy/frontend/trace/ops/copy.py
+++ b/tripy/tripy/frontend/trace/ops/copy.py
@@ -57,9 +57,5 @@ def copy(input: "tripy.Tensor", device: "tripy.device") -> "tripy.Tensor":
         assert np.array_equal(np.from_dlpack(output), np.array([1, 2], dtype=np.float32))
         assert output.trace_tensor.producer.device.kind == "cpu"
     """
-    from tripy.frontend.trace.ops import Storage
-
-    if isinstance(input.trace_tensor.producer, Storage) and input.trace_tensor.producer.device == device:
-        return input
 
     return Copy.build([input], device)

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -65,14 +65,14 @@ class Fill(BaseTraceOp):
         from tripy.flat_ir.tensor import FlatIRTensor
 
         const_val_tensor = FlatIRTensor.build(
+            shape=(),
             rank=0,
             dtype=outputs[0].dtype,
             device=outputs[0].device,
             reason_details=[f"create the constant value tensor (containing {self.value}) for a fill operation"],
         )
 
-        data = Array(self.value, shape=(), dtype=self.dtype, device=device("cpu"))
-        ConstantOp.build([], [const_val_tensor], data=data)
+        ConstantOp.build([], [const_val_tensor], data=self.value)
 
         DynamicBroadcastOp.build(
             [const_val_tensor, inputs[0]],

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -63,8 +63,6 @@ class Fill(BaseTraceOp):
         from tripy.common.device import device
         from tripy.flat_ir.ops import ConstantOp, DynamicBroadcastOp
         from tripy.flat_ir.tensor import FlatIRTensor
-        from tripy.frontend.tensor import Tensor
-        from tripy.frontend.trace.ops.cast import cast
 
         const_val_tensor = FlatIRTensor.build(
             rank=0,
@@ -90,11 +88,6 @@ def full_impl(
     dtype: "tripy.dtype",
     output_rank: int,
 ) -> "tripy.Tensor":
-    from tripy.common.utils import get_element_type
-    from tripy.frontend.trace.ops.cast import cast
-
-    if get_element_type(value) != dtype:
-        return cast(Fill.build([shape], value, output_rank, get_element_type(value)), dtype)
     return Fill.build([shape], value, output_rank, dtype)
 
 

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -63,6 +63,7 @@ class Reduce(BaseTraceOp):
         from tripy.common.utils import get_element_type
         init_value = self.kind.init_value
         init_const = FlatIRTensor.build(
+            shape=(),
             rank=0,
             dtype=outputs[0].dtype,
             device=outputs[0].device,
@@ -70,22 +71,7 @@ class Reduce(BaseTraceOp):
                 f"create the constant value tensor (containing {init_value}) for the initial value of a '{self.kind.op}' operation"
             ],
         )
-        if get_element_type(init_value) != outputs[0].dtype:
-            init_const_from_kind = FlatIRTensor.build(
-                rank=0,
-                dtype=get_element_type(init_value),
-                device=outputs[0].device,
-                reason_details=[
-                    f"create the constant value tensor (containing {init_value}) for the initial value of a '{self.kind.op}' operation with type {get_element_type(init_value)}"
-                ],
-            )
-            data = Array(init_value, shape=(), dtype=get_element_type(init_value), device=device("cpu"))
-            ConstantOp.build([], [init_const_from_kind], data=data)
-            ConvertOp.build([init_const_from_kind], [init_const])
-        else:
-            data = Array(init_value, shape=(), dtype=outputs[0].dtype, device=device("cpu"))
-            ConstantOp.build([], [init_const], data=data)
-
+        ConstantOp.build([], [init_const], data=init_value)
         ReduceOp.build([inputs[0], init_const], outputs, reduce_mode=self.kind.op, reduce_dims=self.dim)
 
 
@@ -128,12 +114,12 @@ class ArgMinMax(Reduce):
         ConstantOp.build(
             [],
             [init_val_const],
-            data=Array(0, shape=(), dtype=inputs[0].dtype, device=device("cpu")),
+            data=0,
         )
         ConstantOp.build(
             [],
             [init_idx_const],
-            data=Array(0, shape=(), dtype=outputs[0].dtype, device=device("cpu")),
+            data=0,
         )
 
         ArgMinMaxOp.build(

--- a/tripy/tripy/frontend/trace/ops/storage.py
+++ b/tripy/tripy/frontend/trace/ops/storage.py
@@ -57,6 +57,7 @@ class Storage(BaseTraceOp):
 
     def infer_rank(self):
         self.outputs[0].rank = len(self.shape)
+        self.outputs[0].shape = self.shape
 
     def infer_devices(self):
         # This is different from self.device

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -187,7 +187,7 @@ def add_constant_tensor_from_list(data: list, device: "tripy.device"):
     ConstantOp.build(
         [],
         [const_output_tensor],
-        data=Array(data, shape=[len(data)], dtype=int32, device=device("cpu")),
+        data=Array(data if len(data) else None, shape=[len(data)], dtype=int32, device=device("cpu")),
     )
     return const_output_tensor
 

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -184,10 +184,12 @@ def add_constant_tensor_from_list(data: list, device: "tripy.device"):
         device=device,
         reason_details=[f"create constant rank 1 int32 tensor filled with {data}."],
     )
+    if not data:
+        data = Array(None, shape=[len(data)], dtype=int32, device=device("cpu"))
     ConstantOp.build(
         [],
         [const_output_tensor],
-        data=Array(data if len(data) else None, shape=[len(data)], dtype=int32, device=device("cpu")),
+        data=data,
     )
     return const_output_tensor
 
@@ -469,44 +471,16 @@ def get_clamp_min_max(element_dtype, quant_dtype):
         device=device("gpu"),
         reason_details=["Construct max value for clamp."],
     )
-    if element_dtype in (tp_dtype.float16, tp_dtype.bfloat16):
-        clamp_min_fp32 = FlatIRTensor.build(
-            shape=(),
-            rank=0,
-            dtype=tp_dtype.float32,
-            device=device("gpu"),
-            reason_details=["Construct min value in float32."],
-        )
-        clamp_max_fp32 = FlatIRTensor.build(
-            shape=(),
-            rank=0,
-            dtype=tp_dtype.float32,
-            device=device("gpu"),
-            reason_details=["Construct max value in float32."],
-        )
-        ConstantOp.build(
-            [],
-            [clamp_min_fp32],
-            data=Array(min_val, shape=(), dtype=tp_dtype.float32, device=device("cpu")),
-        )
-        ConstantOp.build(
-            [],
-            [clamp_max_fp32],
-            data=Array(max_val, shape=(), dtype=tp_dtype.float32, device=device("cpu")),
-        )
-        ConvertOp.build([clamp_min_fp32], [clamp_min])
-        ConvertOp.build([clamp_max_fp32], [clamp_max])
-    else:
-        ConstantOp.build(
-            [],
-            [clamp_min],
-            data=Array(min_val, shape=(), dtype=element_dtype, device=device("cpu")),
-        )
-        ConstantOp.build(
-            [],
-            [clamp_max],
-            data=Array(max_val, shape=(), dtype=element_dtype, device=device("cpu")),
-        )
+    ConstantOp.build(
+        [],
+        [clamp_min],
+        data=min_val,
+    )
+    ConstantOp.build(
+        [],
+        [clamp_max],
+        data=max_val,
+    )
     return clamp_min, clamp_max
 
 


### PR DESCRIPTION
When we use list to initialize a Tensor, `Array` will not allocate memref. The list will be stored and directly translated to MLIR during evaluation.

+: No more casting when dtype is not supported by memref.
-: Add a separate condition `Array.has_memref`

On 2nd commit:
Array only accepts an object with memory allocated (such as external lib's array). When using a list to initialize a Tensor, the list will be directly passed to `Storage` op, and then lowered into MLIR via `ConstantOp`.