### PR TITLE
Added function `create_memref_view_from_dlpack`

### DIFF
--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -389,11 +389,11 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtRuntimeSessionExecuteFunction(
 
 /// Converts a DLDeviceType to MTRT_PointerType. This function will throw a runtime
 /// error if the device type is invalid.
-static MTRT_PointerType getPointerTypeFromDLDeviceType(DLDeviceType device);
+MLIR_CAPI_EXPORTED MTRT_Status getPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_PointerType* result);
 
 /// Converts a DLDataType to MTRT_ScalarTypeCode. This function will throw a runtime
 /// error if the data type is invalid.
-static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataType(DLDataType dtype);
+MLIR_CAPI_EXPORTED MTRT_Status getScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTypeCode* result);
 
 #ifdef __cplusplus
 }

--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -389,11 +389,11 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtRuntimeSessionExecuteFunction(
 
 /// Converts a DLDeviceType to MTRT_PointerType. This function will throw a runtime
 /// error if the device type is invalid.
-MLIR_CAPI_EXPORTED MTRT_Status getPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_PointerType* result);
+MLIR_CAPI_EXPORTED MTRT_Status mtrtGetPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_PointerType* result);
 
 /// Converts a DLDataType to MTRT_ScalarTypeCode. This function will throw a runtime
 /// error if the data type is invalid.
-MLIR_CAPI_EXPORTED MTRT_Status getScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTypeCode* result);
+MLIR_CAPI_EXPORTED MTRT_Status mtrtGetScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTypeCode* result);
 
 #ifdef __cplusplus
 }

--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -25,6 +25,7 @@
 #ifndef MLIR_EXECUTOR_C_RUNTIME_RUNTIME
 #define MLIR_EXECUTOR_C_RUNTIME_RUNTIME
 
+#include "dlpack/dlpack.h"
 #include "mlir-c/Support.h"
 #include "mlir-executor-c/Common/Common.h"
 #include "mlir-executor-c/Support/Status.h"
@@ -381,6 +382,18 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtRuntimeSessionExecuteFunction(
     MTRT_RuntimeSession session, MTRT_StringView name,
     const MTRT_RuntimeValue *inArgs, size_t numInArgs,
     const MTRT_RuntimeValue *outArgs, size_t numOutArgs, MTRT_Stream stream);
+
+//===----------------------------------------------------------------------===//
+// DLPack
+//===----------------------------------------------------------------------===//
+
+/// Converts a DLDeviceType to MTRT_PointerType. This function will throw a runtime
+/// error if the device type is invalid.
+static MTRT_PointerType getPointerTypeFromDLDeviceType(DLDeviceType device);
+
+/// Converts a DLDataType to MTRT_ScalarTypeCode. This function will throw a runtime
+/// error if the data type is invalid.
+static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataType(DLDataType dtype);
 
 #ifdef __cplusplus
 }

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -363,9 +363,7 @@ static StatusOr<DLDataTypeCode> toDLPackDataTypeCode(ScalarTypeCode type) {
     return DLDataTypeCode::kDLBfloat;
   default:
     return getStatusWithMsg(
-        StatusCode::InvalidArgument, "Scalar type code [",
-        EnumNameScalarTypeCode(type),
-        "] conversion to DLPackDataTypeCode is not supported.");
+        StatusCode::InvalidArgument, "Scalar type code conversion to DLPackDataTypeCode is not supported.");
   }
   return DLDataTypeCode::kDLFloat;
 }
@@ -397,10 +395,7 @@ MTRT_Status mtrtGetScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTyp
     case kDLOpaqueHandle:
     default:
       return wrap(getStatusWithMsg(
-        StatusCode::InvalidArgument, "DLDataType [",
-        // "code: ", dtype.code,
-        // "bits: ", dtype.bits,
-        "] conversion to MTRT_ScalarTypeCode is not supported."));
+        StatusCode::InvalidArgument, "DLDataType conversion to MTRT_ScalarTypeCode is not supported."));
   }
   #undef RETURN_OK
 }

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -337,7 +337,7 @@ MTRT_Status mtrtGetPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_Pointer
       return wrap(getStatusWithMsg(
         StatusCode::InvalidArgument, "DLDeviceType [",
         // device,
-        "] conversion to MTRT_PointerType is not supported.").getStatus());
+        "] conversion to MTRT_PointerType is not supported."));
   }
   #undef RETURN_OK
 }
@@ -400,7 +400,7 @@ MTRT_Status mtrtGetScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTyp
         StatusCode::InvalidArgument, "DLDataType [",
         // "code: ", dtype.code,
         // "bits: ", dtype.bits,
-        "] conversion to MTRT_ScalarTypeCode is not supported.").getStatus());
+        "] conversion to MTRT_ScalarTypeCode is not supported."));
   }
   #undef RETURN_OK
 }

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -326,6 +326,21 @@ static StatusOr<DLDeviceType> toDLPackDeviceType(PointerType address) {
   return DLDeviceType::kDLCPU;
 }
 
+static MTRT_PointerType getPointerTypeFromDLDeviceType(DLDeviceType device) {
+  switch (device) {
+    case DLDeviceType::kDLCUDA:
+      return MTRT_PointerType_device;
+    case DLDeviceType::kDLCPU:
+      return MTRT_PointerType_host;
+    case DLDeviceType::kDLCUDAHost:
+      return MTRT_PointerType_pinned_host;
+    case DLDeviceType::kDLCUDAManaged:
+      return MTRT_PointerType_unified;
+    default:
+      throw std::runtime_error("Unsupported DLPack device type.");
+  }
+}
+
 static StatusOr<DLDataTypeCode> toDLPackDataTypeCode(ScalarTypeCode type) {
   switch (type) {
   case ScalarTypeCode::i1:
@@ -352,6 +367,37 @@ static StatusOr<DLDataTypeCode> toDLPackDataTypeCode(ScalarTypeCode type) {
         "] conversion to DLPackDataTypeCode is not supported.");
   }
   return DLDataTypeCode::kDLFloat;
+}
+
+static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataType(DLDataType dtype) {
+  switch (dtype.code) {
+    case kDLBool:
+      return MTRT_ScalarTypeCode_i1;
+    case kDLInt:
+      switch (dtype.bits) {
+        case 8: return MTRT_ScalarTypeCode_i8;
+        case 16: return MTRT_ScalarTypeCode_i16;
+        case 32: return MTRT_ScalarTypeCode_i32;
+        case 64: return MTRT_ScalarTypeCode_i64;
+      }
+    case kDLUInt:
+      switch (dtype.bits) {
+        case 8: return MTRT_ScalarTypeCode_ui8;
+      }
+    case kDLFloat:
+      switch (dtype.bits) {
+        case 8: return MTRT_ScalarTypeCode_f8e4m3fn;
+        case 16: return MTRT_ScalarTypeCode_f16;
+        case 32: return MTRT_ScalarTypeCode_f32;
+        case 64: return MTRT_ScalarTypeCode_f64;
+      }
+    case kDLBfloat:
+      return MTRT_ScalarTypeCode_bf16;
+    case kDLComplex:
+    case kDLOpaqueHandle:
+    default:
+      throw std::runtime_error("Unsupported DLPack data type.");
+  }
 }
 
 static void dlpackManagedTensorDeleter(DLManagedTensor *tensor) {

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -326,7 +326,7 @@ static StatusOr<DLDeviceType> toDLPackDeviceType(PointerType address) {
   return DLDeviceType::kDLCPU;
 }
 
-MTRT_Status getPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_PointerType* result) {
+MTRT_Status mtrtGetPointerTypeFromDLDeviceType(DLDeviceType device, MTRT_PointerType* result) {
   #define RETURN_OK(v) *result = v; return mtrtStatusGetOk();
   switch (device) {
     case DLDeviceType::kDLCUDA: RETURN_OK(MTRT_PointerType_device)
@@ -370,7 +370,7 @@ static StatusOr<DLDataTypeCode> toDLPackDataTypeCode(ScalarTypeCode type) {
   return DLDataTypeCode::kDLFloat;
 }
 
-MTRT_Status getScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTypeCode* result) {
+MTRT_Status mtrtGetScalarTypeCodeFromDLDataType(DLDataType dtype, MTRT_ScalarTypeCode* result) {
   #define RETURN_OK(v) *result = v; return mtrtStatusGetOk();
   switch (dtype.code) {
     case kDLBool: RETURN_OK(MTRT_ScalarTypeCode_i1)

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -312,7 +312,7 @@ static std::unique_ptr<PyMemRefValue> createMemRef(
   return std::make_unique<PyMemRefValue>(result);
 }
 
-static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataTypeCode(uint8_t code) {
+static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataType(DLDataType dtype) {
   switch (dtype.code) {
     case kDLBool:
       return MTRT_ScalarTypeCode_i1;

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -355,13 +355,13 @@ createMemRefViewFromDLPack(PyRuntimeClient &client,
 
   MTRT_ScalarTypeCode elementType;
   MTRT_Status s;
-  s = getScalarTypeCodeFromDLDataType(dtype, &elementType);
+  s = mtrtGetScalarTypeCodeFromDLDataType(dtype, &elementType);
   THROW_IF_MTRT_ERROR(s);
 
   int64_t bytesPerElement = llvm::divideCeil(dtype.bits, 8);
 
   MTRT_PointerType addressSpace;
-  s = getPointerTypeFromDLDeviceType(device_type, &addressSpace);
+  s = mtrtGetPointerTypeFromDLDeviceType(device_type, &addressSpace);
   THROW_IF_MTRT_ERROR(s);
 
   MTRT_Device device{nullptr};

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -326,7 +326,6 @@ createMemRefViewFromDLPack(PyRuntimeClient &client,
   }
 
   MTRT_MemRefValue result{nullptr};
-  assert(managedTensor != nullptr && "DLManagedTensor should not be null");
 
   // Extract the necessary information from the DLManagedTensor
   void *data = managedTensor->dl_tensor.data;

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -318,8 +318,7 @@ static std::unique_ptr<PyMemRefValue>
 createMemRefViewFromDLPack(PyRuntimeClient &client,
                        py::capsule capsule) {
   DLManagedTensor *managedTensor =
-      (DLManagedTensor *)PyCapsule_GetPointer(capsule.ptr(),
-      "dltensor");
+      static_cast<DLManagedTensor*>(PyCapsule_GetPointer(capsule.ptr(), "dltensor"));
 
   if (managedTensor == nullptr) {
       Py_DECREF(capsule);

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -312,52 +312,6 @@ static std::unique_ptr<PyMemRefValue> createMemRef(
   return std::make_unique<PyMemRefValue>(result);
 }
 
-static MTRT_ScalarTypeCode getScalarTypeCodeFromDLDataType(DLDataType dtype) {
-  switch (dtype.code) {
-    case kDLBool:
-      return MTRT_ScalarTypeCode_i1;
-    case kDLInt:
-      switch (dtype.bits) {
-        case 8: return MTRT_ScalarTypeCode_i8;
-        case 16: return MTRT_ScalarTypeCode_i16;
-        case 32: return MTRT_ScalarTypeCode_i32;
-        case 64: return MTRT_ScalarTypeCode_i64;
-      }
-    case kDLUInt:
-      switch (dtype.bits) {
-        case 8: return MTRT_ScalarTypeCode_ui8;
-      }
-    case kDLFloat:
-      switch (dtype.bits) {
-        case 8: return MTRT_ScalarTypeCode_f8e4m3fn;
-        case 16: return MTRT_ScalarTypeCode_f16;
-        case 32: return MTRT_ScalarTypeCode_f32;
-        case 64: return MTRT_ScalarTypeCode_f64;
-      }
-    case kDLBfloat:
-      return MTRT_ScalarTypeCode_bf16;
-    case kDLComplex:
-    case kDLOpaqueHandle:
-    default:
-      throw std::runtime_error("Unsupported DLPack data type.");
-  }
-}
-
-
-static MTRT_PointerType getPointerTypeFromDLDeviceType(DLDeviceType device) {
-  switch (device) {
-    case DLDeviceType::kDLCUDA:
-      return MTRT_PointerType_device;
-    case DLDeviceType::kDLCPU:
-      return MTRT_PointerType_host;
-    case DLDeviceType::kDLCUDAHost:
-      return MTRT_PointerType_pinned_host;
-    case DLDeviceType::kDLCUDAManaged:
-      return MTRT_PointerType_unified;
-    default:
-      throw std::runtime_error("Unsupported DLPack device type.");
-  }
-}
 
 
 static std::unique_ptr<PyMemRefValue>

--- a/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
@@ -455,7 +455,7 @@ def create_memref_from_dlpack(arr, module):
     memref = client.create_memref_view_from_dlpack(arr.__dlpack__())
     print(f"-- Memref shape: {memref.shape}")
     print(f"-- Memref dtype: {memref.dtype}")
-    print(f"-- {module}.from_dlpack(): {module.from_dlpack(memref)}")
+    print(f"-- {module.__name__}.from_dlpack(): {module.from_dlpack(memref)}")
 
 print(f"Test np.array -> client.create_memref_from_dlpack")
 create_memref_from_dlpack(np.array([1, 2, 3, 4], dtype=np.int32), np)
@@ -471,28 +471,28 @@ create_memref_from_dlpack(cp.ones(0, dtype=cp.int8), cp)
 # CHECK-NEXT: Array: [1 2 3 4]
 # CHECK-NEXT: -- Memref shape: [4]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- np.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: -- numpy.from_dlpack(): [1 2 3 4]
 # CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: -- Memref shape: [1, 2, 3]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- np.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- numpy.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: Array: []
 # CHECK-NEXT: -- Memref shape: [0]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- np.from_dlpack(): []
+# CHECK-NEXT: -- numpy.from_dlpack(): []
 # CHECK-LABEL: Test cp.array -> client.create_memref_from_dlpack
 # CHECK-NEXT: Array: [1 2 3 4]
 # CHECK-NEXT: -- Memref shape: [4]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- cp.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: -- cupy.from_dlpack(): [1 2 3 4]
 # CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: -- Memref shape: [1, 2, 3]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- cp.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- cupy.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: Array: []
 # CHECK-NEXT: -- Memref shape: [0]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- cp.from_dlpack(): []
+# CHECK-NEXT: -- cupy.from_dlpack(): []
 
 
 def create_dangling_memref():

--- a/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
@@ -448,69 +448,6 @@ test_memref_lifetime()
 # CHECK-NEXT: Memref released internally:  True
 # CHECK-NEXT: Number of External reference count:  1
 # CHECK-NEXT: Numpy Array:  [5. 4. 2.]
-def create_memref_from_dlpack(arr, module):
-    print(f"Array: {arr}")
-    memref = client.create_memref_view_from_dlpack(arr.__dlpack__())
-    print(f"-- Memref shape: {memref.shape}")
-    print(f"-- Memref dtype: {memref.dtype}")
-    print(f"-- {module}.from_dlpack(): {module.from_dlpack(memref)}")
-
-print(f"Test np.array -> client.create_memref_from_dlpack")
-create_memref_from_dlpack(np.array([1, 2, 3, 4], dtype=np.int32), np)
-create_memref_from_dlpack(np.ones((1, 2, 3), dtype=np.float32), np)
-create_memref_from_dlpack(np.ones(0, dtype=np.int8), np)
-print(f"Test cp.array -> client.create_memref_from_dlpack")
-create_memref_from_dlpack(cp.array([1, 2, 3, 4], dtype=cp.int32), cp)
-create_memref_from_dlpack(cp.ones((1, 2, 3), dtype=cp.float32), cp)
-create_memref_from_dlpack(cp.ones(0, dtype=cp.int8), cp)
-
-
-# CHECK-LABEL: Test np.array -> client.create_memref_from_dlpack
-# CHECK-NEXT: Array: [1 2 3 4]
-# CHECK-NEXT: -- Memref shape: [4]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
-# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
-# CHECK-NEXT: -- Memref shape: [1, 2, 3]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
-# CHECK-NEXT: Array: []
-# CHECK-NEXT: -- Memref shape: [0]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- module.from_dlpack(): []
-# CHECK-LABEL: Test cp.array -> client.create_memref_from_dlpack
-# CHECK-NEXT: Array: [1 2 3 4]
-# CHECK-NEXT: -- Memref shape: [4]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
-# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
-# CHECK-NEXT: -- Memref shape: [1, 2, 3]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
-# CHECK-NEXT: Array: []
-# CHECK-NEXT: -- Memref shape: [0]
-# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- module.from_dlpack(): []
-
-
-def create_dangling_memref():
-    array = np.array([1, 2])
-    dlpack_capsule = array.__dlpack__()
-    memref = client.create_memref_view_from_dlpack(dlpack_capsule)
-    print("-- Inner scope: np.from_dlpack(): ", np.from_dlpack(memref))
-    return memref
-
-
-print("Test memref maintains data's lifetime")
-memref = create_dangling_memref()
-# Declare a new array to overwrite the old memory
-b = np.array([10, 10])
-print("-- Outer scope: np.from_dlpack(): ", np.from_dlpack(memref))
-
-
-# CHECK-LABEL: Test memref maintains data's lifetime
-# CHECK-NEXT: -- Inner scope: np.from_dlpack(): [1 2]
-# CHECK-NEXT: -- Outer scope: np.from_dlpack(): [1 2]
 
 
 def create_memref_from_dlpack(arr, module):
@@ -534,28 +471,28 @@ create_memref_from_dlpack(cp.ones(0, dtype=cp.int8), cp)
 # CHECK-NEXT: Array: [1 2 3 4]
 # CHECK-NEXT: -- Memref shape: [4]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: -- np.from_dlpack(): [1 2 3 4]
 # CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: -- Memref shape: [1, 2, 3]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- np.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: Array: []
 # CHECK-NEXT: -- Memref shape: [0]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- module.from_dlpack(): []
+# CHECK-NEXT: -- np.from_dlpack(): []
 # CHECK-LABEL: Test cp.array -> client.create_memref_from_dlpack
 # CHECK-NEXT: Array: [1 2 3 4]
 # CHECK-NEXT: -- Memref shape: [4]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
-# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: -- cp.from_dlpack(): [1 2 3 4]
 # CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: -- Memref shape: [1, 2, 3]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
-# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- cp.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
 # CHECK-NEXT: Array: []
 # CHECK-NEXT: -- Memref shape: [0]
 # CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
-# CHECK-NEXT: -- module.from_dlpack(): []
+# CHECK-NEXT: -- cp.from_dlpack(): []
 
 
 def create_dangling_memref():

--- a/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_create_memref.py
@@ -448,3 +448,131 @@ test_memref_lifetime()
 # CHECK-NEXT: Memref released internally:  True
 # CHECK-NEXT: Number of External reference count:  1
 # CHECK-NEXT: Numpy Array:  [5. 4. 2.]
+def create_memref_from_dlpack(arr, module):
+    print(f"Array: {arr}")
+    memref = client.create_memref_view_from_dlpack(arr.__dlpack__())
+    print(f"-- Memref shape: {memref.shape}")
+    print(f"-- Memref dtype: {memref.dtype}")
+    print(f"-- {module}.from_dlpack(): {module.from_dlpack(memref)}")
+
+print(f"Test np.array -> client.create_memref_from_dlpack")
+create_memref_from_dlpack(np.array([1, 2, 3, 4], dtype=np.int32), np)
+create_memref_from_dlpack(np.ones((1, 2, 3), dtype=np.float32), np)
+create_memref_from_dlpack(np.ones(0, dtype=np.int8), np)
+print(f"Test cp.array -> client.create_memref_from_dlpack")
+create_memref_from_dlpack(cp.array([1, 2, 3, 4], dtype=cp.int32), cp)
+create_memref_from_dlpack(cp.ones((1, 2, 3), dtype=cp.float32), cp)
+create_memref_from_dlpack(cp.ones(0, dtype=cp.int8), cp)
+
+
+# CHECK-LABEL: Test np.array -> client.create_memref_from_dlpack
+# CHECK-NEXT: Array: [1 2 3 4]
+# CHECK-NEXT: -- Memref shape: [4]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
+# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- Memref shape: [1, 2, 3]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
+# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: Array: []
+# CHECK-NEXT: -- Memref shape: [0]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
+# CHECK-NEXT: -- module.from_dlpack(): []
+# CHECK-LABEL: Test cp.array -> client.create_memref_from_dlpack
+# CHECK-NEXT: Array: [1 2 3 4]
+# CHECK-NEXT: -- Memref shape: [4]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
+# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- Memref shape: [1, 2, 3]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
+# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: Array: []
+# CHECK-NEXT: -- Memref shape: [0]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
+# CHECK-NEXT: -- module.from_dlpack(): []
+
+
+def create_dangling_memref():
+    array = np.array([1, 2])
+    dlpack_capsule = array.__dlpack__()
+    memref = client.create_memref_view_from_dlpack(dlpack_capsule)
+    print("-- Inner scope: np.from_dlpack(): ", np.from_dlpack(memref))
+    return memref
+
+
+print("Test memref maintains data's lifetime")
+memref = create_dangling_memref()
+# Declare a new array to overwrite the old memory
+b = np.array([10, 10])
+print("-- Outer scope: np.from_dlpack(): ", np.from_dlpack(memref))
+
+
+# CHECK-LABEL: Test memref maintains data's lifetime
+# CHECK-NEXT: -- Inner scope: np.from_dlpack(): [1 2]
+# CHECK-NEXT: -- Outer scope: np.from_dlpack(): [1 2]
+
+
+def create_memref_from_dlpack(arr, module):
+    print(f"Array: {arr}")
+    memref = client.create_memref_view_from_dlpack(arr.__dlpack__())
+    print(f"-- Memref shape: {memref.shape}")
+    print(f"-- Memref dtype: {memref.dtype}")
+    print(f"-- {module}.from_dlpack(): {module.from_dlpack(memref)}")
+
+print(f"Test np.array -> client.create_memref_from_dlpack")
+create_memref_from_dlpack(np.array([1, 2, 3, 4], dtype=np.int32), np)
+create_memref_from_dlpack(np.ones((1, 2, 3), dtype=np.float32), np)
+create_memref_from_dlpack(np.ones(0, dtype=np.int8), np)
+print(f"Test cp.array -> client.create_memref_from_dlpack")
+create_memref_from_dlpack(cp.array([1, 2, 3, 4], dtype=cp.int32), cp)
+create_memref_from_dlpack(cp.ones((1, 2, 3), dtype=cp.float32), cp)
+create_memref_from_dlpack(cp.ones(0, dtype=cp.int8), cp)
+
+
+# CHECK-LABEL: Test np.array -> client.create_memref_from_dlpack
+# CHECK-NEXT: Array: [1 2 3 4]
+# CHECK-NEXT: -- Memref shape: [4]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
+# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- Memref shape: [1, 2, 3]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
+# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: Array: []
+# CHECK-NEXT: -- Memref shape: [0]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
+# CHECK-NEXT: -- module.from_dlpack(): []
+# CHECK-LABEL: Test cp.array -> client.create_memref_from_dlpack
+# CHECK-NEXT: Array: [1 2 3 4]
+# CHECK-NEXT: -- Memref shape: [4]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i32
+# CHECK-NEXT: -- module.from_dlpack(): [1 2 3 4]
+# CHECK-NEXT: Array: {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: -- Memref shape: [1, 2, 3]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.f32
+# CHECK-NEXT: -- module.from_dlpack(): {{\[\[\[1. 1. 1.\][[:space:]]*\[1. 1. 1.\]\]\]}}
+# CHECK-NEXT: Array: []
+# CHECK-NEXT: -- Memref shape: [0]
+# CHECK-NEXT: -- Memref dtype: ScalarTypeCode.i8
+# CHECK-NEXT: -- module.from_dlpack(): []
+
+
+def create_dangling_memref():
+    array = np.array([1, 2])
+    dlpack_capsule = array.__dlpack__()
+    memref = client.create_memref_view_from_dlpack(dlpack_capsule)
+    print("-- Inner scope: np.from_dlpack(): ", np.from_dlpack(memref))
+    return memref
+
+
+print("Test memref maintains data's lifetime")
+memref = create_dangling_memref()
+# Declare a new array to overwrite the old memory
+b = np.array([10, 10])
+print("-- Outer scope: np.from_dlpack(): ", np.from_dlpack(memref))
+
+
+# CHECK-LABEL: Test memref maintains data's lifetime
+# CHECK-NEXT: -- Inner scope: np.from_dlpack(): [1 2]
+# CHECK-NEXT: -- Outer scope: np.from_dlpack(): [1 2]


### PR DESCRIPTION
This function greatly simplifies Tripy's Array implementation. We want to be able to handle memref creation from all types that implement the `__dlpack__()` interface rather than the limited set we currently support. This function should allow us to achieve this. The corresponding Tripy changes are #72.


 