### PR TITLE
Use `create_memref_view_from_dlpack` within Tripy

### DIFF
--- a/tripy/tests/integration/test_functional.py
+++ b/tripy/tests/integration/test_functional.py
@@ -166,11 +166,11 @@ class TestFunctional:
 
             tripy_linear = tp.Linear(2, 3)
             if kind == "gpu":
-                tripy_linear.weight = tp.Parameter(tp.Tensor(torch_linear.weight.to("cuda"), device=tp.device(kind)))
-                tripy_linear.bias = tp.Parameter(tp.Tensor(torch_linear.bias.to("cuda"), device=tp.device(kind)))
+                tripy_linear.weight = tp.Parameter(tp.Tensor(torch_linear.weight.detach().to("cuda"), device=tp.device(kind)))
+                tripy_linear.bias = tp.Parameter(tp.Tensor(torch_linear.bias.detach().to("cuda"), device=tp.device(kind)))
             else:
-                tripy_linear.weight = tp.Parameter(tp.Tensor(torch_linear.weight, device=tp.device(kind)))
-                tripy_linear.bias = tp.Parameter(tp.Tensor(torch_linear.bias, device=tp.device(kind)))
+                tripy_linear.weight = tp.Parameter(tp.Tensor(torch_linear.weight.detach(), device=tp.device(kind)))
+                tripy_linear.bias = tp.Parameter(tp.Tensor(torch_linear.bias.detach(), device=tp.device(kind)))
 
             tripy_out = tripy_linear(tp.Tensor(inp, device=tp.device(kind)))
             assert tp.allclose(tripy_out, tp.Tensor(torch_out))

--- a/tripy/tripy/common/array.py
+++ b/tripy/tripy/common/array.py
@@ -273,70 +273,7 @@ class Array:
                     device=mlirtrt_device,
                 )
             else:
-                # TODO(#182): Use DLPack/buffer protocol to convert FW types to MemRefValue.
-                # Assume data is allocated using external framework. Create a view over it.
-                from tripy.backend.mlir.utils import convert_tripy_dtype_to_runtime_dtype
-
-                def can_access_attr(attr_name):
-                    try:
-                        getattr(data, attr_name)
-                    except:
-                        return False
-                    return True
-
-                ptr = None
-                if hasattr(data, "__array_interface__"):
-                    ptr = int(data.ctypes.data)
-                    device = tp_device("cpu")
-                elif hasattr(data, "data_ptr"):
-                    ptr = int(data.data_ptr())
-                    device = tp_device(
-                        ("cpu" if data.device.type == "cpu" else "gpu")
-                        + (":" + str(data.device.index) if data.device.index is not None else "")
-                    )
-                elif can_access_attr("__cuda_array_interface__"):
-                    ptr = int(data.__cuda_array_interface__["data"][0])
-                    device = tp_device("gpu")
-                elif hasattr(data, "__array__"):
-                    ptr = data.__array__().ctypes.data
-                    device = tp_device("cpu")
-                else:
-                    raise_error(f"Unsupported type: {data}")
-
-                self.device = utils.default(self.device, device)
-                if self.device != device:
-                    raise_error(
-                        f"Cannot allocate tensor that is currently on: {device} on requested device: {self.device}"
-                    )
-
-                # a pointer value of 0 is used only for empty tensors
-                if ptr == 0:
-                    assert 0 in list(
-                        self.shape
-                    ), f"Recieved null pointer for buffer but tensor is not empty (shape {list(self.shape)})"
-                    self.device = utils.default(self.device, tp_device("gpu"))
-                    mlirtrt_device = self.runtime_client.get_devices()[0] if self.device == tp_device("gpu") else None
-
-                    return self.runtime_client.create_memref(
-                        array.array("i", []),  # typecode is not important because it's empty
-                        shape=list(self.shape),
-                        dtype=convert_tripy_dtype_to_runtime_dtype(self.dtype),
-                        device=mlirtrt_device,
-                    )
-
-                if self.device.kind == "cpu":
-                    return self.runtime_client.create_host_memref_view(
-                        ptr,
-                        shape=list(self.shape),
-                        dtype=convert_tripy_dtype_to_runtime_dtype(self.dtype),
-                    )
-                else:
-                    return self.runtime_client.create_device_memref_view(
-                        ptr,
-                        shape=list(self.shape),
-                        dtype=convert_tripy_dtype_to_runtime_dtype(self.dtype),
-                        device=self.runtime_client.get_devices()[self.device.index],
-                    )
+                return self.runtime_client.create_memref_view_from_dlpack(data.__dlpack__())
 
     def __dlpack__(self, stream=None):
         return self.memref_value.__dlpack__()

--- a/tripy/tripy/common/array.py
+++ b/tripy/tripy/common/array.py
@@ -191,7 +191,6 @@ class Array:
 
         # Store the memref_value
         self.runtime_client = MLIRRuntimeClient()
-        self.data_ref = data  # Ensure that data does not go out of scope when we create a view over it.
         self.memref_value = self._memref(data)
         self.device = (
             tp_device("gpu") if self.memref_value.address_space == runtime.PointerType.device else tp_device("cpu")


### PR DESCRIPTION
Relies on #71. Simplifies our Array class by using `create_memref_view_from_dlpack`.