### PR TITLE
Fix code formatting pre-commit hook

### DIFF
--- a/tripy/.pre-commit-config.yaml
+++ b/tripy/.pre-commit-config.yaml
@@ -1,21 +1,19 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: end-of-file-fixer
-    # only include python files
-    files: \.py$
-  - id: trailing-whitespace
-    # only include python files
-    files: \.py$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: end-of-file-fixer
+      # only include python files
+      files: \.py$
+    - id: trailing-whitespace
+      # only include python files
+      files: \.py$
 
-repos:
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 24.1.0
     hooks:
-    - id: black
+      - id: black
 
-repos:
   - repo: local
     hooks:
       - id: add-license


### PR DESCRIPTION
We need to list all `repo` under a single `repos` for pre-commit hooks to work. Until now only the last hook i.e. `add-license` was working.