### PR TITLE
Fix llvm-project .gitignore

### DIFF
--- a/mlir-tensorrt/.gitignore
+++ b/mlir-tensorrt/.gitignore
@@ -2,6 +2,7 @@
 **/build/**
 *.log
 **/llvm-project/**
+**/llvm-project/
 
 # Docs build artifacts
 /public/


### PR DESCRIPTION
For some reason downloaded llvm-project in not getting ignored by .gitignore with `**/llvm-project/**` pattern, add `**/llvm-project/` pattern which works.