### PR TITLE
Added array_equal function and tests

### DIFF
--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -410,7 +410,10 @@ import tripy as tp
 
 def test_multi_dimensional():
     output = tp.theta([2, 3], dim=1)
-    expected = tp.Tensor(np.broadcast_to(np.arange(0, 3, dtype=np.float32), (2, 3)))
+    expected = tp.Tensor([
+        [0., 1., 2.],
+        [0., 1., 2.]
+    ], dtype=tp.float32)
 
     assert tp.array_equal(output, expected)
 

--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -232,7 +232,7 @@ def theta(shape: Tuple[int], dim: int = 0, dtype: datatype.dtype = datatype.floa
 
         output = tp.theta([3])
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.arange(0, 3, dtype=np.float32)))
     """
 
     # Next we build the trace operator. The `build()` function is also responsible for constructing
@@ -410,9 +410,9 @@ import tripy as tp
 
 def test_multi_dimensional():
     output = tp.theta([2, 3], dim=1)
-    expected = np.broadcast_to(np.arange(0, 3, dtype=np.float32), (2, 3))
+    expected = tp.Tensor(np.broadcast_to(np.arange(0, 3, dtype=np.float32), (2, 3)))
 
-    assert np.array_equal(cp.from_dlpack(output).get(), expected)
+    assert tp.array_equal(output, expected)
 
 ```
 

--- a/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
+++ b/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
@@ -14,7 +14,7 @@ But enough talk; let's see some code:
 a = tp.arange(5)
 c = a + 1.5
 print(c)
-assert np.array_equal(cp.from_dlpack(c).get(), np.arange(5, dtype=np.float32) + 1.5) # doc: omit
+assert tp.array_equal(c, tp.Tensor(np.arange(5, dtype=np.float32) + 1.5)) # doc: omit
 ```
 
 This should look familiar if you've used linear algebra or deep learning libraries like

--- a/tripy/tests/backend/test_compiler_api.py
+++ b/tripy/tests/backend/test_compiler_api.py
@@ -173,7 +173,7 @@ class TestExecutable:
             inp = tp.iota((2, 2), dtype=tp.float32)
             out1 = single_return_executable(inp, inp)
             out2 = loaded_executable(inp, inp)
-            assert cp.array_equal(cp.from_dlpack(out1), cp.from_dlpack(out2))
+            assert tp.array_equal(out1, out2)
 
 
 class TestCompile:
@@ -185,8 +185,7 @@ class TestCompile:
         inp = tp.ones((2, 2), dtype=tp.float32)
         out = compiled_gelu(inp)
 
-        # TODO (#225): Replace with tp.all
-        assert cp.array_equal(cp.from_dlpack(out), cp.from_dlpack(tp.relu(inp)))
+        assert tp.array_equal(out, tp.relu(inp))
 
     def test_module(self):
         layernorm = tp.LayerNorm(2)
@@ -195,7 +194,7 @@ class TestCompile:
         inp = tp.ones((2, 2), dtype=tp.float32)
         out = compiled_layernorm(inp)
 
-        assert cp.array_equal(cp.from_dlpack(out), cp.from_dlpack(layernorm(inp)))
+        assert tp.array_equal(out, layernorm(inp))
 
     def test_compile_arg_order_irrelevant(self):
         compiler = tp.Compiler(sub)
@@ -212,7 +211,7 @@ class TestCompile:
 
         # Compiled function should still take arguments in (a, b) order.
         out = compiled_sub(a, b)
-        assert cp.array_equal(cp.from_dlpack(out), cp.ones((2, 2), dtype=cp.float32))
+        assert tp.array_equal(out, tp.ones((2, 2), dtype=tp.float32))
 
     @pytest.mark.parametrize("b", [2, tp.ones((2, 2), dtype=tp.float32) * 2])
     def test_constants_baked(self, b):
@@ -225,7 +224,7 @@ class TestCompile:
 
         out = compiled_add(a)
 
-        assert cp.array_equal(cp.from_dlpack(out), cp.ones((2, 2), dtype=cp.float32) * 2)
+        assert tp.array_equal(out, tp.ones((2, 2), dtype=tp.float32) * 2)
 
     @pytest.mark.parametrize("func", [variadic_positional, variadic_keyword])
     def test_variadic_arguments_rejected(self, func):
@@ -247,8 +246,8 @@ class TestCompile:
 
         plus, minus = compiled_func(a, b)
 
-        assert cp.array_equal(cp.from_dlpack(plus), cp.ones((2, 2), dtype=cp.float32) * 3)
-        assert cp.array_equal(cp.from_dlpack(minus), cp.ones((2, 2), dtype=cp.float32))
+        assert tp.array_equal(plus, tp.ones((2, 2), dtype=tp.float32) * 3)
+        assert tp.array_equal(minus, tp.ones((2, 2), dtype=tp.float32))
 
     def test_incorrect_dtype_rejected(self):
         compiler = tp.Compiler(add)
@@ -288,10 +287,10 @@ class TestCompile:
         )
 
         out = compiled_add(tp.ones((2, 1), dtype=tp.float32), tp.ones((2, 1), dtype=tp.float32))
-        assert cp.array_equal(cp.from_dlpack(out), cp.ones((2, 1), dtype=cp.float32) * 2)
+        assert tp.array_equal(out, tp.ones((2, 1), dtype=tp.float32) * 2)
 
         out = compiled_add(tp.ones((3, 1), dtype=tp.float32), tp.ones((3, 1), dtype=tp.float32))
-        assert cp.array_equal(cp.from_dlpack(out), cp.ones((3, 1), dtype=cp.float32) * 2)
+        assert tp.array_equal(out, tp.ones((3, 1), dtype=tp.float32) * 2)
 
 
 # TODO (#256): Remove these tests and replace with exhaustive integration testing
@@ -303,7 +302,7 @@ class TestCompiledOps:
         a = tp.ones((2, 2), dtype=tp.float32)
         out = compiled_cast(a)
 
-        assert cp.array_equal(cp.from_dlpack(out), cp.ones((2, 2), dtype=cp.int32))
+        assert tp.array_equal(out, tp.ones((2, 2), dtype=tp.int32))
 
     def test_linear(self):
         linear = tp.Linear(2, 3)
@@ -315,4 +314,4 @@ class TestCompiledOps:
 
         out = compiled_linear(a)
 
-        assert cp.array_equal(cp.from_dlpack(out), cp.from_dlpack(linear(a)))
+        assert tp.array_equal(out, linear(a))

--- a/tripy/tests/frontend/module/test_module.py
+++ b/tripy/tests/frontend/module/test_module.py
@@ -29,8 +29,8 @@ class TestModule:
         assert len(dict(test_net.named_parameters())) == 1
         assert len(dict(test_net.named_children())) == 2
 
-        result = np.array([1.0, 2.0]) + np.full(2, sum(call_args), dtype=np.float32)
-        assert np.array_equal(cp.from_dlpack(test_net(*inputs)).get(), result)
+        result = tp.Tensor(np.array([1.0, 2.0], dtype=np.float32) + np.full(2, sum(call_args), dtype=np.float32))
+        assert tp.array_equal(test_net(*inputs), result)
 
     def test_get_set_attr(self, network):
         network.new_attr = True

--- a/tripy/tests/frontend/module/test_parameter.py
+++ b/tripy/tests/frontend/module/test_parameter.py
@@ -36,11 +36,11 @@ class TestParameter:
         tensor = tp.Tensor([1, 2, 3])
         param = tp.Parameter(tensor)
 
-        assert np.array_equal(cp.from_dlpack(param).get(), cp.from_dlpack(tensor).get())
+        assert tp.array_equal(param, tensor)
 
     def test_can_construct_from_non_tensor(self):
         param = tp.Parameter([1, 2, 3])
-        assert np.array_equal(cp.from_dlpack(param).get(), np.array([1, 2, 3], dtype=np.int32))
+        assert tp.array_equal(param, tp.Tensor(np.array([1, 2, 3], dtype=np.int32)))
 
     @pytest.mark.parametrize(
         "other,is_compatible",
@@ -83,4 +83,4 @@ class TestDefaultParameter:
 
     def test_data_can_be_materialized(self):
         param = DefaultParameter((1, 2), dtype=tp.float32)
-        assert np.array_equal(cp.from_dlpack(param).get(), np.array([[0, 1]], dtype=np.float32))
+        assert tp.array_equal(param, tp.Tensor(np.array([[0, 1]], dtype=np.float32)))

--- a/tripy/tests/integration/test_array_equal.py
+++ b/tripy/tests/integration/test_array_equal.py
@@ -1,0 +1,37 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import numpy as np
+import torch
+
+import tripy as tp
+
+
+class TestArrayEqual:
+    @pytest.mark.parametrize(
+        "a, b",
+        [
+            (tp.Tensor([1, 2], dtype=tp.float32), tp.Tensor([1, 2], dtype=tp.float32)),
+            (tp.ones((2, 2), dtype=tp.int32), tp.Tensor([[1, 1], [1, 1]], dtype=tp.int32)),
+            (tp.ones((1, 4)), tp.ones((4, 1))),
+        ],
+    )
+    def test_array_equal(self, a, b):
+        torch_result = torch.equal(torch.from_dlpack(a), torch.from_dlpack(b))
+        tp_result = tp.array_equal(a, b)
+        assert torch_result == tp_result

--- a/tripy/tests/integration/test_concatenate.py
+++ b/tripy/tests/integration/test_concatenate.py
@@ -36,9 +36,7 @@ class TestConcatenate:
     def test_concat(self, tensor_shapes, dim):
         tensors = [tp.ones(shape) for shape in tensor_shapes]
         out = tp.concatenate(tensors, dim=dim)
-        assert np.array_equal(
-            cp.from_dlpack(out).get(), np.concatenate([np.ones(shape) for shape in tensor_shapes], axis=dim)
-        )
+        assert tp.array_equal(out, tp.Tensor(np.concatenate([np.ones(shape, dtype=np.float32) for shape in tensor_shapes], axis=dim)))
 
     @pytest.mark.parametrize(
         "tensor_shapes, dim",

--- a/tripy/tests/integration/test_expand.py
+++ b/tripy/tests/integration/test_expand.py
@@ -25,21 +25,21 @@ class TestExpand:
     def test_int_sizes(self):
         input = tp.ones((2, 1))
         out = tp.expand(input, (-1, 2))
-        assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 2), dtype=np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.ones((2, 2), dtype=np.float32)))
 
     def test_shape_sizes(self):
         input = tp.ones((2, 1))
         a = tp.ones((2, 4))
         out = tp.expand(input, a.shape)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 4), dtype=np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.ones((2, 4), dtype=np.float32)))
 
     def test_extra_dims(self):
         input = tp.ones((2, 1))
         out = tp.expand(input, (1, -1, 2))
-        assert np.array_equal(cp.from_dlpack(out).get(), np.ones((1, 2, 2), dtype=np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.ones((1, 2, 2), dtype=np.float32)))
 
     def test_mixed_sizes(self):
         input = tp.ones((2, 1, 1))
         a = tp.ones((4, 4))
         out = tp.expand(input, (-1, a.shape[0], a.shape[1]))
-        assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 4, 4), dtype=np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.ones((2, 4, 4), dtype=np.float32)))

--- a/tripy/tests/integration/test_flip.py
+++ b/tripy/tests/integration/test_flip.py
@@ -30,22 +30,23 @@ class TestFlip:
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
         f = tp.flip(a, dims=dims)
-        assert np.array_equal(cp.from_dlpack(f).get(), np.flip(cp_a.get(), axis=dims))
+        cp_a_f = np.flip(cp_a.get(), axis=dims)
+        assert tp.array_equal(f, tp.Tensor(cp_a_f))
 
         # also ensure that flipping a second time restores the original value
         f2 = tp.flip(f, dims=dims)
-        assert cp.array_equal(cp.from_dlpack(f2), cp_a)
+        assert tp.array_equal(f2, tp.Tensor(cp_a))
 
     def test_no_op(self):
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
         f = tp.flip(a, dims=[])
-        assert cp.array_equal(cp.from_dlpack(a), cp.from_dlpack(f))
+        assert tp.array_equal(a, f)
 
     def test_zero_rank(self):
         t = tp.Tensor(1)
         f = tp.flip(t)
-        assert cp.array_equal(cp.from_dlpack(t), cp.from_dlpack(f))
+        assert tp.array_equal(t, f)
 
     @pytest.mark.parametrize(
         "dims1, dims2",
@@ -56,4 +57,4 @@ class TestFlip:
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
         f1 = tp.flip(a, dims=dims1)
         f2 = tp.flip(a, dims=dims2)
-        assert cp.array_equal(cp.from_dlpack(f1), cp.from_dlpack(f2))
+        assert tp.array_equal(f1, f2)

--- a/tripy/tests/integration/test_flip.py
+++ b/tripy/tests/integration/test_flip.py
@@ -30,12 +30,12 @@ class TestFlip:
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)
         a = tp.Tensor(cp_a, device=tp.device("gpu"))
         f = tp.flip(a, dims=dims)
-        cp_a_f = np.flip(cp_a.get(), axis=dims)
-        assert tp.array_equal(f, tp.Tensor(cp_a_f))
+        #TODO(129): The tensor we get from np.flip will have negative strides. We cannot currently construct a tensor with negatives strides
+        assert np.array_equal(cp.from_dlpack(f).get(), np.flip(cp_a.get(), axis=dims))
 
         # also ensure that flipping a second time restores the original value
         f2 = tp.flip(f, dims=dims)
-        assert tp.array_equal(f2, tp.Tensor(cp_a))
+        assert np.array_equal(cp.from_dlpack(f2).get(), cp_a.get())
 
     def test_no_op(self):
         cp_a = cp.arange(16).reshape((4, 4)).astype(cp.float32)

--- a/tripy/tests/integration/test_full.py
+++ b/tripy/tests/integration/test_full.py
@@ -24,14 +24,14 @@ import tripy as tp
 class TestFull:
     def test_normal_shape(self):
         out = tp.full((2, 2), 5.0, tp.float32)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 2), 5.0, np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.full((2, 2), 5.0, np.float32)))
 
     def test_shape_tensor(self):
         a = tp.ones((2, 3))
         out = tp.full(a.shape, 5.0, tp.float32)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 3), 5.0, np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.full((2, 3), 5.0, np.float32)))
 
     def test_mixed_shape(self):
         a = tp.ones((2, 3))
         out = tp.full((a.shape[0], 4), 5.0, tp.float32)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.full((2, 4), 5.0, np.float32))
+        assert tp.array_equal(out, tp.Tensor(np.full((2, 4), 5.0, np.float32)))

--- a/tripy/tests/integration/test_iota.py
+++ b/tripy/tests/integration/test_iota.py
@@ -103,9 +103,9 @@ class TestIota:
     def test_iota_from_shape_tensor(self):
         a = tp.ones((2, 2))
         output = tp.iota(a.shape)
-        assert np.array_equal(cp.from_dlpack(output).get(), self._compute_ref_iota("float32", (2, 2), 0))
+        assert tp.array_equal(output, tp.Tensor(self._compute_ref_iota("float32", (2, 2), 0)))
 
-    def test_iota_from_mixed_seqence(self):
+    def test_iota_from_mixed_sequence(self):
         a = tp.ones((2, 2))
         output = tp.iota((3, a.shape[0]))
-        assert np.array_equal(cp.from_dlpack(output).get(), self._compute_ref_iota("float32", (3, 2), 0))
+        assert tp.array_equal(output, tp.Tensor(self._compute_ref_iota("float32", (3, 2), 0)))

--- a/tripy/tests/integration/test_iota.py
+++ b/tripy/tests/integration/test_iota.py
@@ -32,17 +32,27 @@ class TestIota:
         (("int32", tp.common.datatype.int32)),
     ]
 
-    def _compute_ref_iota(self, dtype, shape, dim):
+    def _compute_ref_iota(self, dtype, shape, dim): 
         if dim is None:
             dim = 0
         elif dim < 0:
             dim += len(shape)
+    
         expected = np.arange(0, shape[dim], dtype=dtype)
+    
         if dim < len(shape) - 1:
             expand_dims = [1 + i for i in range(len(shape) - 1 - dim)]
             expected = np.expand_dims(expected, expand_dims)
-        expected = np.broadcast_to(expected, shape)
+    
+        repeats = [1] * len(shape)
+        for i in range(len(shape)):
+            if i != dim:
+                repeats[i] = shape[i]
+    
+        expected = np.tile(expected, repeats)
+    
         return expected
+
 
     @pytest.mark.parametrize("dtype", DTYPE_PARAMS)
     @pytest.mark.parametrize(

--- a/tripy/tests/integration/test_linear.py
+++ b/tripy/tests/integration/test_linear.py
@@ -132,4 +132,4 @@ class TestQuantLinear:
 
         np_out = cp_input.get() @ (np_weight.transpose()) + np_bias
 
-        assert np.array_equal(cp.from_dlpack(out).get(), np_out)
+        assert tp.array_equal(out, tp.Tensor(np_out))

--- a/tripy/tests/integration/test_reduce.py
+++ b/tripy/tests/integration/test_reduce.py
@@ -42,8 +42,7 @@ class TestReduceOp:
         out = tp.all(a, dim=axis, keepdim=keepdim)
         expected = tp.Tensor(np.array(x.all(axis=axis, keepdims=keepdim)))
         #np.array is necessary to deal with case where x.all returns a numpy scalar (5th case)
-        assert out.shape == expected.shape
-        assert tp.allclose(out, expected)
+        assert tp.array_equal(out, expected)
 
     @pytest.mark.parametrize(
         "x_shape, axis, keepdim",
@@ -57,7 +56,6 @@ class TestReduceOp:
             ((2, 3, 4, 5), (-2, -1), True),
         ],
     )
-
     def test_any(self, x_shape, axis, keepdim):
         x = np.array([i % 2 == 0 for i in np.arange(np.prod(x_shape))]).reshape(x_shape)
         a = tp.Tensor(x)
@@ -68,7 +66,12 @@ class TestReduceOp:
         "x_shape, axis, keepdim",
         [
             ((2, 3), 1, True),
-            pytest.param((2, 3, 4), (1, 2), True, marks=pytest.mark.skip(reason="For this test case without out.eval() tp.allclose fails. (Issue #)")),
+            pytest.param(
+                (2, 3, 4),
+                (1, 2),
+                True,
+                marks=pytest.mark.skip(reason="For this test case without out.eval() tp.allclose fails. (Issue #)"),
+            ),
             ((2, 3), 1, False),
             ((2, 3, 4), (1, 2), False),
             ((2, 3, 4), None, False),
@@ -122,7 +125,7 @@ class TestReduceOp:
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np.float32)
         a = tp.Tensor(x)
         out = tp.argmax(a, dim=axis, keepdim=keepdim)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.array(x.argmax(axis=axis, keepdims=keepdim)))
+        assert tp.array_equal(out, tp.Tensor(np.array(x.argmax(axis=axis, keepdims=keepdim))))
 
     @pytest.mark.parametrize(
         "x_shape, axis, keepdim",
@@ -139,4 +142,4 @@ class TestReduceOp:
         x = np.arange(np.prod(x_shape)).reshape(x_shape).astype(np.float32)
         a = tp.Tensor(x)
         out = tp.argmin(a, dim=axis, keepdim=keepdim)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.array(x.argmin(axis=axis, keepdims=keepdim)))
+        assert tp.array_equal(out, tp.Tensor(np.array(x.argmin(axis=axis, keepdims=keepdim))))

--- a/tripy/tests/integration/test_reshape.py
+++ b/tripy/tests/integration/test_reshape.py
@@ -39,7 +39,7 @@ class TestReshape:
         b = tp.reshape(a, new_shape)
         if -1 in new_shape:
             new_shape = tuple(np.prod(shape) // -np.prod(new_shape) if d == -1 else d for d in new_shape)
-        assert np.array_equal(cp.from_dlpack(b).get(), cp_a.reshape(new_shape).get())
+        assert tp.array_equal(b, tp.Tensor(cp_a.reshape(new_shape).get()))
 
     def test_invalid_neg_dim_reshape(self):
         shape = (1, 30)
@@ -52,7 +52,7 @@ class TestReshape:
         a = tp.ones((2, 3, 4))
         b = tp.ones((2, 3, 2, 2))
         out = tp.reshape(a, (a.shape[0], a.shape[1], b.shape[2], b.shape[3]))
-        assert np.array_equal(cp.from_dlpack(out).get(), np.ones((2, 3, 2, 2), dtype=np.float32))
+        assert tp.array_equal(out, tp.ones((2, 3, 2, 2), dtype=tp.float32))
 
     def test_reshape_shape_with_unknown(self):
         a = tp.ones((2, 3, 4))

--- a/tripy/tests/integration/test_slice.py
+++ b/tripy/tests/integration/test_slice.py
@@ -78,7 +78,7 @@ class TestSliceOp:
             return slice_func(a)
 
         out = func(a)
-        assert np.array_equal(cp.from_dlpack(out).get(), slice_func(a_cp).get())
+        assert tp.array_equal(out, tp.Tensor(slice_func(a_cp).get()))
 
     def test_slice_as_gather(self):
         x_data = [0, 1, 2]
@@ -88,7 +88,7 @@ class TestSliceOp:
         x_cp = cp.array(x_data)
         y_cp = cp.array(y_data)
 
-        assert np.array_equal(cp.from_dlpack(y[x]).get(), y_cp[x_cp].get())
+        assert tp.array_equal(y[x], tp.Tensor(y_cp[x_cp].get()))
 
         x_shape = (2, 2)
         y_shape = (4, 3, 2)
@@ -99,4 +99,4 @@ class TestSliceOp:
         x_cp = cp.arange(x_vol, dtype=cp.int32).reshape(x_shape)
         y_cp = cp.arange(y_vol).reshape(y_shape)
 
-        assert np.array_equal(cp.from_dlpack(y[x]).get(), y_cp[x_cp].get())
+        assert tp.array_equal(y[x], tp.Tensor(y_cp[x_cp].get()))

--- a/tripy/tests/integration/test_where_op.py
+++ b/tripy/tests/integration/test_where_op.py
@@ -43,11 +43,11 @@ class TestWhereOp:
         b = Tensor(y)
         condition = Tensor(t_cond % 2 == 0)
         out = tp.where(condition, a, b)
-        assert np.array_equal(cp.from_dlpack(out).get(), np.array(np.where((t_cond % 2 == 0), x, y)))
+        assert tp.array_equal(out, tp.Tensor(np.array(np.where((t_cond % 2 == 0), x, y))))
 
     def test_explicit_condition(self):
         select_indices = tp.Tensor([True, False, True, False], dtype=tp.bool)
         ones = tp.ones((4,), dtype=tp.int32)
         zeros = tp.zeros((4,), dtype=tp.int32)
         w = tp.where(select_indices, ones, zeros)
-        assert cp.from_dlpack(w).get().tolist() == [1, 0, 1, 0]
+        assert tp.array_equal(w, tp.Tensor([1, 0, 1, 0]))

--- a/tripy/tripy/frontend/module/embedding.py
+++ b/tripy/tripy/frontend/module/embedding.py
@@ -54,7 +54,7 @@ class Embedding(Module):
             input = tp.Tensor([0, 2], dtype=tp.int32)
             output = embedding(input)
 
-            assert np.array_equal(cp.from_dlpack(output).get(), cp.from_dlpack(embedding.weight).get()[[0,2], :])
+            assert tp.array_equal(output, tp.Tensor(cp.from_dlpack(embedding.weight).get()[[0,2], :]))
         """
         super().__init__()
 

--- a/tripy/tripy/frontend/module/groupnorm.py
+++ b/tripy/tripy/frontend/module/groupnorm.py
@@ -72,16 +72,15 @@ class GroupNorm(Module):
             group_norm.bias = tp.zeros_like(group_norm.bias)
 
             input = tp.iota((1, 4, 2, 2), dim=1)
-            output = group_norm(input)
+            tp_out = group_norm(input)
 
-            np_out = cp.from_dlpack(output).get() # doc: omit
-            assert np_out.shape == (1, 4, 2, 2)
+            assert tp_out.shape == tp.Shape([1, 4, 2, 2]) # doc: omit
 
             torch_tensor = torch.from_dlpack(input) # doc: omit
             torch_gn = torch.nn.GroupNorm(2, 4).to(torch.device("cuda")) # doc: omit
             torch_out = cp.from_dlpack(torch_gn(torch_tensor).detach()).get() # doc: omit
-            assert np_out.shape == torch_out.shape # doc: omit
-            assert np.allclose(np_out, torch_out) # doc: omit
+            assert tp_out.shape == torch_out.shape # doc: omit
+            assert tp.allclose(tp_out, tp.Tensor(torch_out)) # doc: omit
         """
         super().__init__()
 

--- a/tripy/tripy/frontend/module/module.py
+++ b/tripy/tripy/frontend/module/module.py
@@ -92,7 +92,7 @@ class Module:
         input = tp.Tensor([1.0, 1.0], dtype=tp.float32)
         output = add_bias(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([2.0, 2.0]))
+        assert tp.array_equal(output, tp.Tensor([2.0, 2.0]))
     """
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -178,7 +178,7 @@ class Module:
 
             print(f"After: {module.param}")
 
-            assert np.array_equal(cp.from_dlpack(module.state_dict()["param"]).get(), np.array(np.zeros((2,), dtype=np.float32)))
+            assert tp.array_equal(module.state_dict()["param"], tp.Tensor(np.zeros((2,), dtype=np.float32)))
 
         .. seealso:: :func:`state_dict`
         """

--- a/tripy/tripy/frontend/ops/array_equal.py
+++ b/tripy/tripy/frontend/ops/array_equal.py
@@ -36,7 +36,7 @@ def array_equal(a: "tripy.Tensor", b: "tripy.Tensor") -> bool:
 
         # doc: print-locals a, b, is_equal
 
-        a = tp.ones((2,2))
+        a = tp.ones((2,2), dtype=tp.int32)
         b = tp.Tensor([
             [1, 1],
             [1, 1]
@@ -45,6 +45,13 @@ def array_equal(a: "tripy.Tensor", b: "tripy.Tensor") -> bool:
         assert is_equal
     """
     from tripy.frontend.trace.ops.reduce import all
+    from tripy.frontend.trace.ops.cast import cast
 
-    # `tp.Shape` overloads `__eq__`, therefore we can directly compare shapes here.
-    return a.shape == b.shape and a.dtype == b.dtype and bool(all(a == b))
+    # `tp.Shape` overloads `__ne__`, therefore we can directly compare shapes here.
+    if a.shape != b.shape:
+        return False
+
+    if a.dtype != b.dtype:
+        b = cast(b, a.dtype)
+
+    return bool(all(a == b))

--- a/tripy/tripy/frontend/ops/array_equal.py
+++ b/tripy/tripy/frontend/ops/array_equal.py
@@ -34,13 +34,17 @@ def array_equal(a: "tripy.Tensor", b: "tripy.Tensor") -> bool:
         :linenos:
         :caption: Example
 
+        # doc: print-locals a, b, is_equal
+
         a = tp.ones((2,2))
         b = tp.Tensor([
             [1, 1],
             [1, 1]
         ])
-        assert tp.array_equal(a, b)
+        is_equal = tp.array_equal(a, b)
+        assert is_equal
     """
     from tripy.frontend.trace.ops.reduce import all
 
+    # `tp.Shape` overloads `__eq__`, therefore we can directly compare shapes here.
     return a.shape == b.shape and a.dtype == b.dtype and bool(all(a == b))

--- a/tripy/tripy/frontend/ops/array_equal.py
+++ b/tripy/tripy/frontend/ops/array_equal.py
@@ -1,0 +1,46 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from tripy import export
+
+
+@export.public_api(document_under="tensor_operations")
+def array_equal(a: "tripy.Tensor", b: "tripy.Tensor") -> bool:
+    """
+    Returns True if the two arrays have the same shape and elements, False otherwise.
+
+    Args:
+        a: The LHS tensor.
+        b: The RHS tensor.
+
+    Returns:
+        A boolean value
+
+    .. code-block:: python
+        :linenos:
+        :caption: Example
+
+        a = tp.ones((2,2))
+        b = tp.Tensor([
+            [1, 1],
+            [1, 1]
+        ])
+        assert tp.array_equal(a, b)
+    """
+    from tripy.frontend.trace.ops.reduce import all
+
+    return a.shape == b.shape and a.dtype == b.dtype and bool(all(a == b))

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -58,7 +58,7 @@ def ones(
 
         output = tp.ones([2, 3])
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.ones([2, 3], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.ones([2, 3], dtype=np.float32)))
 
     .. seealso:: :func:`ones_like`, :func:`full`
     """
@@ -94,7 +94,7 @@ def zeros(
 
         output = tp.zeros([2, 3])
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.zeros([2, 3], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.zeros([2, 3], dtype=np.float32)))
 
     .. seealso:: :func:`zeros_like`, :func:`full`
     """
@@ -127,7 +127,7 @@ def ones_like(input: "tripy.Tensor", dtype: Optional[datatype.dtype] = None) -> 
         input = tp.zeros([2, 3], dtype=tp.float32)
         output = tp.ones_like(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.ones([2, 3], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.ones([2, 3], dtype=np.float32)))
 
     .. seealso:: :func:`ones`, :func:`full_like`
     """
@@ -160,7 +160,7 @@ def zeros_like(input: "tripy.Tensor", dtype: Optional[datatype.dtype] = None) ->
         input = tp.iota([2, 3], dtype=tp.float32)
         output = tp.zeros_like(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.zeros([2, 3], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.zeros([2, 3], dtype=np.float32)))
 
     .. seealso:: :func:`zeros`, :func:`full_like`
     """
@@ -199,7 +199,7 @@ def tril(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((2, 1, 3, 3), dim=2) + 1.
         output = tp.tril(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.tril(cp.from_dlpack(input).get()))
+        assert tp.array_equal(output, tp.Tensor(np.tril(cp.from_dlpack(input).get())))
 
     .. code-block:: python
         :linenos:
@@ -208,7 +208,7 @@ def tril(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((5, 5)) + 1. # doc: omit
         output = tp.tril(input, diagonal=2)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.tril(cp.from_dlpack(input).get(), 2))
+        assert tp.array_equal(output, tp.Tensor(np.tril(cp.from_dlpack(input).get(), 2)))
 
     .. code-block:: python
         :linenos:
@@ -217,7 +217,7 @@ def tril(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((5, 5)) + 1. # doc: omit
         output = tp.tril(input, diagonal=-1)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.tril(cp.from_dlpack(input).get(), -1))
+        assert tp.array_equal(output, tp.Tensor(np.tril(cp.from_dlpack(input).get(), -1)))
     """
     from tripy.common.datatype import int64
 
@@ -261,7 +261,7 @@ def triu(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((2, 1, 3, 3), dim=2) + 1.
         output = tp.triu(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.triu(cp.from_dlpack(input).get()))
+        assert tp.array_equal(output, tp.Tensor(np.triu(cp.from_dlpack(input).get())))
 
     .. code-block:: python
         :linenos:
@@ -270,7 +270,7 @@ def triu(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((5, 5)) + 1. # doc: omit
         output = tp.triu(input, diagonal=2)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.triu(cp.from_dlpack(input).get(), 2))
+        assert tp.array_equal(output, tp.Tensor(np.triu(cp.from_dlpack(input).get(), 2)))
 
     .. code-block:: python
         :linenos:
@@ -279,7 +279,7 @@ def triu(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
         input = tp.iota((5, 5)) + 1. # doc: omit
         output = tp.triu(input, diagonal=-1)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.triu(cp.from_dlpack(input).get(), -1))
+        assert tp.array_equal(output, tp.Tensor(np.triu(cp.from_dlpack(input).get(), -1)))
     """
     from tripy.common.datatype import int64
 
@@ -321,7 +321,7 @@ def arange(
 
         output = tp.arange(0.5, 2.5)
 
-        assert (cp.from_dlpack(output).get() == np.arange(0.5, 2.5, dtype=np.float32)).all()
+        assert tp.array_equal(output, tp.Tensor(np.arange(0.5, 2.5, dtype=np.float32)))
 
     .. code-block:: python
         :linenos:
@@ -376,7 +376,7 @@ def arange(stop: numbers.Number, dtype: "tripy.dtype" = datatype.float32) -> "tr
 
         output = tp.arange(5)
 
-        assert (cp.from_dlpack(output).get() == np.arange(5, dtype=np.float32)).all()
+        assert tp.array_equal(output, tp.Tensor(np.arange(5, dtype=np.float32)))
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -86,7 +86,7 @@ class Shape(Tensor):
             s = tp.Shape([1, 2, 3])
             t = s.as_tensor()
             assert isinstance(t, tp.Tensor) and not isinstance(t, tp.Shape)
-            assert np.array_equal(cp.from_dlpack(s).get(), cp.from_dlpack(t).get())
+            assert s == t
         """
         ret = Tensor(data=None, dtype=int32, name=self.name, device=self.device)
         ret.trace_tensor = self.trace_tensor

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -205,7 +205,7 @@ def __add__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
         b = tp.Tensor([2, 3])
         output = a + b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([3, 5]))
+        assert tp.array_equal(output, tp.Tensor([3, 5]))
     """
     return BinaryElementwise.build([self, other], BinaryElementwise.Kind.SUM)
 
@@ -236,7 +236,7 @@ def __sub__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
         b = tp.Tensor([1, 2])
         output = a - b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([1, 1]))
+        assert tp.array_equal(output, tp.Tensor([1, 1]))
     """
     return BinaryElementwise.build([self, other], BinaryElementwise.Kind.SUB)
 
@@ -267,7 +267,7 @@ def __rsub__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.
         b = tp.Tensor([1, 2])
         output = a - b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([0, -1]))
+        assert tp.array_equal(output, tp.Tensor([0, -1]))
     """
     return BinaryElementwise.build([other, self], BinaryElementwise.Kind.SUB)
 
@@ -298,7 +298,7 @@ def __pow__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
         b = tp.Tensor([2.0, 3.0])
         output = a ** b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([1, 8]))
+        assert tp.array_equal(output, tp.Tensor([1, 8]))
     """
     return BinaryElementwise.build([self, other], BinaryElementwise.Kind.POW)
 
@@ -329,7 +329,7 @@ def __rpow__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.
         b = tp.Tensor([2.0, 3.0])
         output = a ** b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([4.0, 8.0]))
+        assert tp.array_equal(output, tp.Tensor([4.0, 8.0]))
     """
     return BinaryElementwise.build([other, self], BinaryElementwise.Kind.POW)
 
@@ -367,7 +367,7 @@ def __mul__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
         b = tp.Tensor([2.0, 3.0])
         output = a * b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([2.0, 6.0]))
+        assert tp.array_equal(output, tp.Tensor([2.0, 6.0]))
     """
     return BinaryElementwise.build([self, other], BinaryElementwise.Kind.MUL)
 
@@ -398,7 +398,7 @@ def __truediv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", A
         b = tp.Tensor([2.0, 3.0])
         output = a / b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([2.0, 2.0]))
+        assert tp.array_equal(output, tp.Tensor([2.0, 2.0]))
     """
     return BinaryElementwise.build([self, other], BinaryElementwise.Kind.DIV)
 
@@ -429,7 +429,7 @@ def __rtruediv__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tr
         b = tp.Tensor([2.0, 3.0])
         output = a / b
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([3.0, 2.0]))
+        assert tp.array_equal(output, tp.Tensor([3.0, 2.0]))
     """
     return BinaryElementwise.build([other, self], BinaryElementwise.Kind.DIV)
 
@@ -460,7 +460,7 @@ def maximum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) ->
         b = tp.Tensor([2.0, 3.0])
         output = tp.maximum(a, b)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([2.0, 6.0]))
+        assert tp.array_equal(output, tp.Tensor([2.0, 6.0]))
     """
     return BinaryElementwise.build([lhs, rhs], BinaryElementwise.Kind.MAXIMUM)
 
@@ -491,7 +491,7 @@ def minimum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) ->
         b = tp.Tensor([2.0, 3.0])
         output = tp.minimum(a, b)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([1.0, 3.0]))
+        assert tp.array_equal(output, tp.Tensor([1.0, 3.0]))
     """
     return BinaryElementwise.build([lhs, rhs], BinaryElementwise.Kind.MINIMUM)
 

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -131,7 +131,7 @@ def cast(input: "tripy.Tensor", dtype: "tripy.dtype") -> "tripy.Tensor":
         input = tp.Tensor([1, 2], dtype=tp.int32)
         output = tp.cast(input, tp.float32)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([1, 2], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([1, 2], dtype=tp.float32))
 
     .. seealso:: :func:`quantize`, :func:`dequantize`
     """

--- a/tripy/tripy/frontend/trace/ops/concatenate.py
+++ b/tripy/tripy/frontend/trace/ops/concatenate.py
@@ -71,6 +71,6 @@ def concatenate(tensors: List[Union["tripy.Tensor"]], dim: int) -> "tripy.Tensor
 
         output = tp.concatenate([a, b], dim=0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.concatenate((cp.from_dlpack(a).get(), cp.from_dlpack(b).get()), axis=0))
+        assert tp.array_equal(output, tp.Tensor(np.concatenate((cp.from_dlpack(a).get(), cp.from_dlpack(b).get()), axis=0)))
     """
     return Concatenate.build(tensors, dim)

--- a/tripy/tripy/frontend/trace/ops/copy.py
+++ b/tripy/tripy/frontend/trace/ops/copy.py
@@ -63,7 +63,7 @@ def copy(input: "tripy.Tensor", device: "tripy.device") -> "tripy.Tensor":
         input = tp.Tensor([1, 2], device=tp.device("gpu"))
         output = tp.copy(input, tp.device("cpu"))
 
-        assert np.array_equal(np.from_dlpack(output), np.array([1, 2], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([1, 2], dtype=tp.float32))
         assert output.trace_tensor.producer.device.kind == "cpu"
     """
 

--- a/tripy/tripy/frontend/trace/ops/copy.py
+++ b/tripy/tripy/frontend/trace/ops/copy.py
@@ -63,7 +63,7 @@ def copy(input: "tripy.Tensor", device: "tripy.device") -> "tripy.Tensor":
         input = tp.Tensor([1, 2], device=tp.device("gpu"))
         output = tp.copy(input, tp.device("cpu"))
 
-        assert tp.array_equal(output, tp.Tensor([1, 2], dtype=tp.float32))
+        assert output.tolist() == [1, 2]
         assert output.trace_tensor.producer.device.kind == "cpu"
     """
 

--- a/tripy/tripy/frontend/trace/ops/dequantize.py
+++ b/tripy/tripy/frontend/trace/ops/dequantize.py
@@ -157,7 +157,7 @@ def dequantize(
         output = tp.dequantize(input, scale, tp.float32)
 
         expected = (np.array([1, 2, 3], dtype=np.int8) * scale).astype(np.float32) # doc: omit
-        assert np.array_equal(cp.from_dlpack(output).get(), expected)
+        assert tp.array_equal(output, tp.Tensor(expected))
 
     .. code-block:: python
         :linenos:
@@ -168,7 +168,7 @@ def dequantize(
         output = tp.dequantize(input, scale, tp.float32, dim=0)
 
         expected = (np.array([[1, 2, 3], [4, 5, 6]]) * np.array(scale).reshape(2, 1)).astype(np.float32) # doc: omit
-        assert np.array_equal(cp.from_dlpack(output).get(), expected)
+        assert tp.array_equal(output, tp.Tensor(expected))
 
     .. code-block:: python
         :linenos:
@@ -181,7 +181,7 @@ def dequantize(
         quant = tp.quantize(input, scale, tp.int4)
         output = tp.dequantize(quant, scale, tp.float32)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([[0, 1], [2, 3]], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([[0, 1], [2, 3]], dtype=tp.float32))
 
     .. seealso:: :func:`quantize`
     """

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -102,8 +102,11 @@ def expand(input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int
 
         input = tp.iota((2, 1), dtype=tp.float32)
         output = tp.expand(input, (-1, 4))
-
-        assert tp.array_equal(output, tp.Tensor(np.broadcast_to(cp.from_dlpack(input).get(), (2, 4))))
+        expected = tp.Tensor([
+            [0., 0., 0., 0.],
+            [1., 1., 1., 1.]
+        ])
+        assert tp.array_equal(output, expected)
 
     .. code-block:: python
         :linenos:
@@ -111,8 +114,10 @@ def expand(input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int
 
         input = tp.iota((1, 1), dtype=tp.float32)
         output = tp.expand(input, (3, -1, -1))
-
-        assert tp.array_equal(output, tp.Tensor(np.broadcast_to(cp.from_dlpack(input).get(), (3, 1, 1))))
+        expected = tp.Tensor([
+            [[0.]], [[0.]], [[0.]]
+        ])
+        assert tp.array_equal(output, expected)
     """
     from tripy.frontend.tensor import Tensor
 

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -103,7 +103,7 @@ def expand(input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int
         input = tp.iota((2, 1), dtype=tp.float32)
         output = tp.expand(input, (-1, 4))
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.broadcast_to(cp.from_dlpack(input).get(), (2, 4)))
+        assert tp.array_equal(output, tp.Tensor(np.broadcast_to(cp.from_dlpack(input).get(), (2, 4))))
 
     .. code-block:: python
         :linenos:
@@ -112,7 +112,7 @@ def expand(input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int
         input = tp.iota((1, 1), dtype=tp.float32)
         output = tp.expand(input, (3, -1, -1))
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.broadcast_to(cp.from_dlpack(input).get(), (3, 1, 1)))
+        assert tp.array_equal(output, tp.Tensor(np.broadcast_to(cp.from_dlpack(input).get(), (3, 1, 1))))
     """
     from tripy.frontend.tensor import Tensor
 

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -115,7 +115,7 @@ def full(
 
         output = tp.full(shape=[2, 3], value=2)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.full([2, 3], 2, dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.full([2, 3], 2, dtype=np.float32)))
     """
     output_rank = len(shape) if isinstance(shape, Sequence) else None
     return full_impl(shape, value, dtype, output_rank)
@@ -149,6 +149,6 @@ def full_like(input: "tripy.Tensor", value: numbers.Number, dtype: Optional["tri
         input = tp.Tensor([[1, 2], [3, 4]])
         output = tp.full_like(input, value=2)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([[2, 2], [2, 2]], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.array([[2, 2], [2, 2]], dtype=np.float32)))
     """
     return full_impl(input.shape, value, utils.default(dtype, input.dtype), input.rank)

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -126,8 +126,9 @@ def gather(input: "tripy.Tensor", dim: int, index: "tripy.Tensor") -> "tripy.Ten
         data = tp.iota((3, 3, 2))
         indices = tp.Tensor([0, 2], dtype=tp.int32)
         output = tp.gather(data, 1, indices)
+        expected = tp.Tensor(np.take(cp.from_dlpack(data).get(), cp.from_dlpack(indices).get(), axis=1)) # doc: omit
 
-        assert tp.array_equal(output, tp.Tensor(np.take(cp.from_dlpack(data).get(), cp.from_dlpack(indices).get(), axis=1)))
+        assert tp.array_equal(output, expected)
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -127,7 +127,7 @@ def gather(input: "tripy.Tensor", dim: int, index: "tripy.Tensor") -> "tripy.Ten
         indices = tp.Tensor([0, 2], dtype=tp.int32)
         output = tp.gather(data, 1, indices)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.take(cp.from_dlpack(data).get(), cp.from_dlpack(indices).get(), axis=1))
+        assert tp.array_equal(output, tp.Tensor(np.take(cp.from_dlpack(data).get(), cp.from_dlpack(indices).get(), axis=1)))
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -126,9 +126,15 @@ def gather(input: "tripy.Tensor", dim: int, index: "tripy.Tensor") -> "tripy.Ten
         data = tp.iota((3, 3, 2))
         indices = tp.Tensor([0, 2], dtype=tp.int32)
         output = tp.gather(data, 1, indices)
-        expected = tp.Tensor(np.take(cp.from_dlpack(data).get(), cp.from_dlpack(indices).get(), axis=1)) # doc: omit
-
-        assert tp.array_equal(output, expected)
+        expected = [
+            [[0.0000, 0.0000],
+             [0.0000, 0.0000]],
+            [[1.0000, 1.0000],
+             [1.0000, 1.0000]],
+            [[2.0000, 2.0000],
+             [2.0000, 2.0000]]
+        ]
+        assert output.tolist() == expected
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -110,7 +110,7 @@ def iota(
 
         output = tp.iota((3,), dim=-1)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.arange(0, 3, dtype=np.float32)))
     """
     from tripy.common.datatype import int64
 
@@ -149,7 +149,7 @@ def iota_like(input: "tripy.Tensor", dim: int = 0, dtype: Optional[datatype.dtyp
         input = tp.Tensor([1, 2, 3])
         output = tp.iota_like(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.arange(0, 3, dtype=np.float32)))
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -242,7 +242,7 @@ def __matmul__(self: "tripy.Tensor", other: "tripy.Tensor") -> "tripy.Tensor":
         b = tp.iota((3, 2), dtype=tp.float32)
 
         output = a @ b
-        assert np.array_equal(cp.from_dlpack(output).get(), cp.from_dlpack(a).get() @ cp.from_dlpack(b).get())
+        assert tp.array_equal(output, tp.Tensor(cp.from_dlpack(a).get() @ cp.from_dlpack(b).get()))
     """
     from tripy.common.datatype import int64
 

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -78,9 +78,13 @@ def transpose(input: "tripy.Tensor", dim0: int, dim1: int) -> "tripy.Tensor":
 
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.transpose(input, 0, 1)
-        expected = tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0)))
+        expected = [
+            [0., 3.],
+            [1., 4.],
+            [2., 5.]
+        ]
 
-        assert tp.array_equal(output, expected)
+        assert output.tolist() == expected
     """
     return Transpose.build([input], None, dim0, dim1)
 
@@ -109,7 +113,12 @@ def permute(input: "tripy.Tensor", perm: Sequence[int]) -> "tripy.Tensor":
 
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.permute(input, (1, 0))
+        expected = [
+            [0., 3.],
+            [1., 4.],
+            [2., 5.]
+        ]
 
-        assert tp.array_equal(output, tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0))))
+        assert output.tolist() == expected
     """
     return Permute.build([input], perm)

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -79,7 +79,7 @@ def transpose(input: "tripy.Tensor", dim0: int, dim1: int) -> "tripy.Tensor":
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.transpose(input, 0, 1)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0)))
+        assert tp.array_equal(output, tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0))))
     """
     return Transpose.build([input], None, dim0, dim1)
 
@@ -109,6 +109,6 @@ def permute(input: "tripy.Tensor", perm: Sequence[int]) -> "tripy.Tensor":
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.permute(input, (1, 0))
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0)))
+        assert tp.array_equal(output, tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0))))
     """
     return Permute.build([input], perm)

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -78,8 +78,9 @@ def transpose(input: "tripy.Tensor", dim0: int, dim1: int) -> "tripy.Tensor":
 
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.transpose(input, 0, 1)
+        expected = tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0)))
 
-        assert tp.array_equal(output, tp.Tensor(np.transpose(np.arange(6, dtype=np.float32).reshape(2, 3), (1, 0))))
+        assert tp.array_equal(output, expected)
     """
     return Transpose.build([input], None, dim0, dim1)
 

--- a/tripy/tripy/frontend/trace/ops/quantize.py
+++ b/tripy/tripy/frontend/trace/ops/quantize.py
@@ -210,7 +210,7 @@ def quantize(
         quant = tp.quantize(input, scale, tp.int4)
         output = tp.dequantize(quant, scale, tp.float32)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([[0, 1], [2, 3]], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([[0, 1], [2, 3]], dtype=tp.float32))
 
     .. seealso:: :func:`dequantize`
     """

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -165,7 +165,7 @@ def sum(
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.sum(input, 0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.sum(np.arange(6, dtype=np.float32).reshape((2, 3)), 0))
+        assert tp.array_equal(output, tp.Tensor(np.sum(np.arange(6, dtype=np.float32).reshape((2, 3)), 0)))
     """
     from tripy.common.datatype import int64
 
@@ -202,7 +202,7 @@ def all(
         :caption: Example
 
         input = tp.Tensor([True, True], dtype=tp.bool)
-        assert tp.all(input) == tp.Tensor([True], dtype=tp.bool)
+        assert tp.all(input)
     """
     return _reduce_impl(input, Reduce.Kind.AND, dim, keepdim)
 
@@ -235,7 +235,7 @@ def any(
         :caption: Example
 
         input = tp.Tensor([True, False], dtype=tp.bool)
-        assert tp.any(input) == tp.Tensor([True], dtype=tp.bool)
+        assert tp.any(input)
     """
     return _reduce_impl(input, Reduce.Kind.OR, dim, keepdim)
 
@@ -270,7 +270,7 @@ def max(
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.max(input, 0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.max(np.arange(6, dtype=np.float32).reshape((2, 3)), 0))
+        assert tp.array_equal(output, tp.Tensor(np.max(np.arange(6, dtype=np.float32).reshape((2, 3)), 0)))
     """
     from tripy.common.datatype import int64
 
@@ -309,7 +309,7 @@ def prod(
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.prod(input, 0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.prod(np.arange(6, dtype=np.float32).reshape((2, 3)), 0))
+        assert tp.array_equal(output, tp.Tensor(np.prod(np.arange(6, dtype=np.float32).reshape((2, 3)), 0)))
     """
     from tripy.common.datatype import int64
 
@@ -370,7 +370,7 @@ def mean(
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.mean(input, dim=1, keepdim=True)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.mean(np.arange(6, dtype=np.float32).reshape((2, 3)), axis=1, keepdims=True))
+        assert tp.array_equal(output, tp.Tensor(np.mean(np.arange(6, dtype=np.float32).reshape((2, 3)), axis=1, keepdims=True)))
     """
     from tripy.common.datatype import int64
 
@@ -418,7 +418,7 @@ def var(
         output = tp.var(input, dim=1, keepdim=True)
 
         torch_input = torch.arange(6, dtype=torch.float32).reshape((2, 3)) # doc: omit
-        assert np.array_equal(cp.from_dlpack(output).get(), np.from_dlpack(torch_input.var(dim=1, keepdim=True)))
+        assert tp.array_equal(output, tp.Tensor(np.from_dlpack(torch_input.var(dim=1, keepdim=True))))
     """
     from tripy.frontend.trace.ops.binary_elementwise import maximum
 
@@ -474,7 +474,7 @@ def argmax(input: "tripy.Tensor", dim: Optional[int] = None, keepdim: bool = Fal
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.argmax(input, 0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.argmax(np.arange(6, dtype=np.float32).reshape((2, 3)), 0))
+        assert tp.array_equal(output, tp.Tensor(np.argmax(np.arange(6, dtype=np.float32).reshape((2, 3)), 0)))
     """
     return _arg_min_max_impl(input, ArgMinMax.Kind.ARG_MAX, dim, keepdim)
 
@@ -508,6 +508,6 @@ def argmin(input: "tripy.Tensor", dim: Optional[int] = None, keepdim: bool = Fal
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (2, 3))
         output = tp.argmin(input, 0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.argmin(np.arange(6, dtype=np.float32).reshape((2, 3)), 0))
+        assert tp.array_equal(output, tp.Tensor(np.argmin(np.arange(6, dtype=np.float32).reshape((2, 3)), 0)))
     """
     return _arg_min_max_impl(input, ArgMinMax.Kind.ARG_MIN, dim, keepdim)

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -418,7 +418,8 @@ def var(
         output = tp.var(input, dim=1, keepdim=True)
 
         torch_input = torch.arange(6, dtype=torch.float32).reshape((2, 3)) # doc: omit
-        assert tp.array_equal(output, tp.Tensor(np.from_dlpack(torch_input.var(dim=1, keepdim=True))))
+        expected = tp.Tensor(torch_input.var(dim=1, keepdim=True)) # doc: omit
+        assert tp.array_equal(output, expected)
     """
     from tripy.frontend.trace.ops.binary_elementwise import maximum
 

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -100,7 +100,7 @@ def reshape(input: "tripy.Tensor", shape: Union["tripy.Shape", Sequence[Union[in
         input = tp.iota((2, 3), dtype=tp.float32)
         output = tp.reshape(input, (1, 6))
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.reshape(cp.from_dlpack(input).get(), (1, 6)))
+        assert tp.array_equal(output, tp.Tensor(np.reshape(cp.from_dlpack(input).get(), (1, 6))))
     """
     from tripy.frontend.tensor import Tensor
     from tripy.frontend.shape import Shape
@@ -235,7 +235,7 @@ def squeeze(input: "tripy.Tensor", dims: Union[Tuple, int] = None) -> "tripy.Ten
 
         input = tp.iota((1, 2, 1), dtype=tp.float32)
         output = tp.squeeze(input, dims=(0, 2))
-        assert np.array_equal(cp.from_dlpack(output).get(), np.squeeze(cp.from_dlpack(input).get()))
+        assert tp.array_equal(output, tp.Tensor(np.squeeze(cp.from_dlpack(input).get())))
 
 
     .. code-block:: python
@@ -244,7 +244,7 @@ def squeeze(input: "tripy.Tensor", dims: Union[Tuple, int] = None) -> "tripy.Ten
 
         input = tp.iota((1, 2, 1), dtype=tp.float32)
         output = tp.squeeze(input, 0)
-        assert np.array_equal(cp.from_dlpack(output).get(), np.squeeze(cp.from_dlpack(input).get(), 0))
+        assert tp.array_equal(output, tp.Tensor(np.squeeze(cp.from_dlpack(input).get(), 0)))
 
     .. code-block:: python
         :linenos:
@@ -253,7 +253,7 @@ def squeeze(input: "tripy.Tensor", dims: Union[Tuple, int] = None) -> "tripy.Ten
         input = tp.iota((1, 2, 1), dtype=tp.float32)
         output = tp.squeeze(input, (0, 2))
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.squeeze(cp.from_dlpack(input).get(), (0, 2)))
+        assert tp.array_equal(output, tp.Tensor(np.squeeze(cp.from_dlpack(input).get(), (0, 2))))
     """
 
     if isinstance(dims, int):

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -71,6 +71,6 @@ def shape(self: "tripy.Tensor") -> "tripy.Tensor":
         input = tp.ones((8, 2))
         shape = input.shape
 
-        assert np.array_equal(cp.from_dlpack(shape).get(), np.array([8, 2]))
+        assert shape == tp.Shape([8, 2])
     """
     return Shape.build([self])

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -203,7 +203,8 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
 
         input = tp.arange(10, dtype=tp.int32)
         output = input[8:2:-1]
-        assert tp.array_equal(output, tp.Tensor(np.arange(10, dtype=np.int32)[8:2:-1]))
+        expected = tp.Tensor([8, 7, 6, 5, 4, 3]) # doc: omit
+        assert tp.array_equal(output, expected)
     """
     from tripy.frontend.shape import Shape
     from tripy.frontend.tensor import Tensor

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -195,16 +195,15 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
 
         input = tp.reshape(tp.arange(6, dtype=tp.float32), (1, 2, 3, 1))
         output = input[:, 1:2, :-1, 0]
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(6, dtype=np.float32).reshape((1, 2, 3, 1))[:, 1:2, :-1, 0])
+        assert tp.array_equal(output, tp.Tensor(np.arange(6, dtype=np.float32).reshape((1, 2, 3, 1))[:, 1:2, :-1, 0]))
 
     .. code-block:: python
         :linenos:
         :caption: Negative step size
 
-        input = tp.arange(10)
+        input = tp.arange(10, dtype=tp.int32)
         output = input[8:2:-1]
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(10)[8:2:-1])
-
+        assert tp.array_equal(output, tp.Tensor(np.arange(10, dtype=np.int32)[8:2:-1]))
     """
     from tripy.frontend.shape import Shape
     from tripy.frontend.tensor import Tensor

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -234,8 +234,8 @@ def split(
 
         input = tp.reshape(tp.arange(16, dtype=tp.float32), (4, 4))
         outputs = tp.split(input, 2, dim=0)
-        assert np.array_equal(cp.from_dlpack(outputs[0]).get(), cp.from_dlpack(input[:2, :]).get())
-        assert np.array_equal(cp.from_dlpack(outputs[1]).get(), cp.from_dlpack(input[2:, :]).get())
+        assert tp.array_equal(outputs[0], input[:2, :])
+        assert tp.array_equal(outputs[1], input[2:, :])
 
     .. code-block:: python
         :linenos:
@@ -243,8 +243,8 @@ def split(
 
         input = tp.reshape(tp.arange(16, dtype=tp.float32), (4, 4))
         outputs = tp.split(input, 2, dim=1)
-        assert np.array_equal(cp.from_dlpack(outputs[0]).get(), cp.from_dlpack(input[:, :2]).get())
-        assert np.array_equal(cp.from_dlpack(outputs[1]).get(), cp.from_dlpack(input[:, 2:]).get())
+        assert tp.array_equal(outputs[0], input[:, :2])
+        assert tp.array_equal(outputs[1], input[:, 2:])
 
     .. code-block:: python
         :linenos:
@@ -252,9 +252,9 @@ def split(
 
         input = tp.reshape(tp.arange(16, dtype=tp.float32), (4, 4))
         outputs = tp.split(input, [1, 2])
-        assert np.array_equal(cp.from_dlpack(outputs[0]).get(), cp.from_dlpack(input[:1, :]).get())
-        assert np.array_equal(cp.from_dlpack(outputs[1]).get(), cp.from_dlpack(input[1:2, :]).get())
-        assert np.array_equal(cp.from_dlpack(outputs[2]).get(), cp.from_dlpack(input[2:, :]).get())
+        assert tp.array_equal(outputs[0], input[:1, :])
+        assert tp.array_equal(outputs[1], input[1:2, :])
+        assert tp.array_equal(outputs[2], input[2:, :])
     """
     if dim < 0 or dim >= input.rank:
         raise_error(f"Invalid split dimension {dim}", details=[input])

--- a/tripy/tripy/frontend/trace/ops/unary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/unary_elementwise.py
@@ -285,7 +285,7 @@ def abs(input: "tripy.Tensor") -> "tripy.Tensor":
         input = tp.Tensor([-1, -2], dtype=tp.int32)
         output = tp.abs(input)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([1, 2], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor(np.array([1, 2], dtype=np.float32)))
     """
     from tripy.frontend import Tensor
     from tripy.common.datatype import int64

--- a/tripy/tripy/frontend/trace/ops/unsqueeze.py
+++ b/tripy/tripy/frontend/trace/ops/unsqueeze.py
@@ -81,7 +81,7 @@ def unsqueeze(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":
         input = tp.iota((2, 2), dtype=tp.float32)
         output = tp.unsqueeze(input, 1)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.expand_dims(cp.from_dlpack(input).get(), 1))
+        assert tp.array_equal(output, tp.Tensor(np.expand_dims(cp.from_dlpack(input).get(), 1)))
     """
     from tripy.frontend.trace.ops.concatenate import concatenate
 

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -172,7 +172,7 @@ def where(condition: "tripy.Tensor", input: "tripy.Tensor", other: "tripy.Tensor
         other = tp.zeros([2, 2], dtype=tp.float32)
         output = tp.where(condition, input, other)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([[1, 0], [1, 1]], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([[1, 0], [1, 1]], dtype=tp.float32))
     """
     return Where.build([condition, input, other])
 
@@ -206,7 +206,7 @@ def masked_fill(input: "tripy.Tensor", mask: "tripy.Tensor", value: numbers.Numb
         input = tp.zeros([2, 2])
         output = tp.masked_fill(input, mask, -1.0)
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.array([[-1, 0], [-1, -1]], dtype=np.float32))
+        assert tp.array_equal(output, tp.Tensor([[-1, 0], [-1, -1]], dtype=tp.float32))
     """
     from tripy.frontend.trace.ops.fill import full_like
 


### PR DESCRIPTION
While working on #37, noticed that we were using `tp.allclose` in contexts where we should probably be using something similar to `np.array_equal` instead. This MR will:
1. Add `tp.array_equal`
2. Correct the test cases with improper usage of `tp.allclose` (we should probably only be using `tp.allclose` when working with float tensors)
3. Change the test cases which are using the `np.array_equal(cp.from_dlpack(_).get()` trick to use `tp.array_equal`