### PR TITLE
[Tripy] Add `__len__` for `tp.Shape` and infer length statically when possible

### DIFF
--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -161,3 +161,9 @@ class Shape(Tensor):
         from tripy.frontend.trace.ops.reduce import all
 
         return bool(all(self.as_tensor() == other.as_tensor()))
+
+    # __len__ for shapes gives the number of dims in the shape, i.e., the first dimension of the shape's shape
+    def __len__(self):
+        from tripy.frontend.trace.ops import utils as op_utils
+
+        return op_utils.get_op_input_shape(self.trace_tensor)[0]

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -166,4 +166,4 @@ class Shape(Tensor):
     def __len__(self):
         from tripy.frontend.trace.ops import utils as op_utils
 
-        return op_utils.get_op_input_shape(self.trace_tensor)[0]
+        return op_utils.get_trace_shape(self.trace_tensor)[0]

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -74,7 +74,7 @@ class BinaryElementwise(BaseTraceOp):
         # For the shape case, the result will be broadcast to the max of the input shapes
         input_lengths = []
         for inp in self.inputs:
-            shape = op_utils.get_op_input_shape(inp)
+            shape = op_utils.get_trace_shape(inp)
             if len(shape) != 0:
                 input_lengths.append(shape[0])
         return [max(input_lengths)]

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -70,6 +70,15 @@ class BinaryElementwise(BaseTraceOp):
         else:
             return Result.ok([])
 
+    def infer_len(self):
+        # For the shape case, the result will be broadcast to the max of the input shapes
+        input_lengths = []
+        for inp in self.inputs:
+            shape = op_utils.get_op_input_shape(inp)
+            if len(shape) != 0:
+                input_lengths.append(shape[0])
+        return [max(input_lengths)]
+
     def infer_dtypes(self):
         op_utils.check_input_dtypes_match(self, self.kind.strip())
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -18,6 +18,7 @@
 from dataclasses import dataclass
 from tripy import export, dtype_info
 from tripy.frontend.trace.ops.base import BaseTraceOp
+from tripy.frontend.trace.ops.utils import InferLenPolicies
 
 
 @dataclass(repr=False)
@@ -34,6 +35,8 @@ class Cast(BaseTraceOp):
             if self.dtype == int32:
                 return Result.ok([0])
         return Result.ok([])
+
+    infer_len = InferLenPolicies.infer_same_as_first_input
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.dtype

--- a/tripy/tripy/frontend/trace/ops/concatenate.py
+++ b/tripy/tripy/frontend/trace/ops/concatenate.py
@@ -29,6 +29,13 @@ class Concatenate(BaseTraceOp):
     def infer_devices(self):
         self.outputs[0].device = self.inputs[0].device
 
+    def infer_len(self):
+        # for shapes, only have to sum the input shapes
+        from tripy.frontend.trace.ops import utils as op_utils
+
+        out_length = sum(map(lambda inp: op_utils.get_op_input_shape(inp)[0], self.inputs))
+        return [out_length]
+
     def to_flat_ir(self, inputs, outputs):
         from tripy.flat_ir.ops import ConcatenateOp
 

--- a/tripy/tripy/frontend/trace/ops/concatenate.py
+++ b/tripy/tripy/frontend/trace/ops/concatenate.py
@@ -33,7 +33,7 @@ class Concatenate(BaseTraceOp):
         # for shapes, only have to sum the input shapes
         from tripy.frontend.trace.ops import utils as op_utils
 
-        out_length = sum(map(lambda inp: op_utils.get_op_input_shape(inp)[0], self.inputs))
+        out_length = sum(map(lambda inp: op_utils.get_trace_shape(inp)[0], self.inputs))
         return [out_length]
 
     def to_flat_ir(self, inputs, outputs):

--- a/tripy/tripy/frontend/trace/ops/copy.py
+++ b/tripy/tripy/frontend/trace/ops/copy.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from tripy import export
 from tripy.common.device import device
 from tripy.frontend.trace.ops.base import BaseTraceOp
+from tripy.frontend.trace.ops.utils import InferLenPolicies
 
 
 @dataclass(repr=False)
@@ -28,6 +29,8 @@ class Copy(BaseTraceOp):
 
     def infer_devices(self):
         self.outputs[0].device = self.target
+
+    infer_len = InferLenPolicies.infer_same_as_first_input
 
     def to_flat_ir(self, inputs, outputs):
         from tripy.flat_ir.ops import CopyOp

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -50,7 +50,7 @@ class Expand(BaseTraceOp):
 
     def infer_rank(self):
         if self.output_rank is None:
-            out_shape = op_utils.get_op_input_shape(self.inputs[1])
+            out_shape = op_utils.get_trace_shape(self.inputs[1])
             assert len(out_shape) == 1
             assert out_shape[0] >= 0, f"incorrect shape computation {out_shape}"
             self.output_rank = out_shape[0]

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -29,7 +29,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 @dataclass(repr=False)
 class Expand(BaseTraceOp):
     output_rank: int
-    output_len: Optional[int]
+    output_len: Optional[int]  # only used to help with infer_len for a shape input
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -29,7 +29,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 @dataclass(repr=False)
 class Expand(BaseTraceOp):
     output_rank: int
-    output_len: Optional[int]  # only used to help with infer_len for a shape input
+    output_len: Optional[int] = None  # only used to help with infer_len for a shape input
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -46,16 +46,12 @@ class Fill(BaseTraceOp):
 
     def infer_rank(self):
         if self.output_rank is None:
-            if self.inputs[0].shape is None:
-                from tripy.backend.mlir.utils import ShapeContext
-
-                out_shape = ShapeContext().get_shape_of_dynamic_trace_tensor(self.inputs[0])
-                assert len(out_shape) == 1, f"Expected rank of shape tensor to be 1, got {len(out_shape)}"
-                assert (
-                    out_shape[0] >= 0
-                ), f"Incorrect shape of shape tensor, expected shape to be positive, got {out_shape[0]}"
-                self.inputs[0].shape = out_shape
-            self.output_rank = self.inputs[0].shape[0]
+            input_shape = op_utils.get_op_input_shape(self.inputs[0])
+            assert len(input_shape) == 1, f"Expected rank of shape tensor to be 1, got {len(input_shape)}"
+            assert (
+                input_shape[0] >= 0
+            ), f"Incorrect shape of shape tensor, expected shape to be positive, got {input_shape[0]}"
+            self.output_rank = input_shape[0]
         self.outputs[0].rank = self.output_rank
 
     def to_flat_ir(self, inputs, outputs):

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -46,7 +46,7 @@ class Fill(BaseTraceOp):
 
     def infer_rank(self):
         if self.output_rank is None:
-            input_shape = op_utils.get_op_input_shape(self.inputs[0])
+            input_shape = op_utils.get_trace_shape(self.inputs[0])
             assert len(input_shape) == 1, f"Expected rank of shape tensor to be 1, got {len(input_shape)}"
             assert (
                 input_shape[0] >= 0

--- a/tripy/tripy/frontend/trace/ops/flip.py
+++ b/tripy/tripy/frontend/trace/ops/flip.py
@@ -21,6 +21,7 @@ from typing import Optional, Sequence, Union
 from tripy import export, utils
 from tripy.common.exception import raise_error
 from tripy.frontend.trace.ops.base import BaseTraceOp
+from tripy.frontend.trace.ops import utils as op_utils
 
 
 @dataclass(repr=False)
@@ -29,6 +30,8 @@ class Flip(BaseTraceOp):
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank
+
+    infer_len = op_utils.InferLenPolicies.infer_same_as_first_input
 
     def to_flat_ir(self, inputs, outputs):
         from tripy.flat_ir.ops import FlipOp

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -32,6 +32,10 @@ class Gather(BaseTraceOp):
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank + self.inputs[1].rank - 1
 
+    def infer_len(self):
+        # in the shape case, the resulting shape is comprised _only_ of the selected indices
+        return [op_utils.get_op_input_shape(self.inputs[1])[0]]
+
     def infer_dtypes(self):
         from tripy import int32
 

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -34,7 +34,7 @@ class Gather(BaseTraceOp):
 
     def infer_len(self):
         # in the shape case, the resulting shape is comprised _only_ of the selected indices
-        return [op_utils.get_op_input_shape(self.inputs[1])[0]]
+        return [op_utils.get_trace_shape(self.inputs[1])[0]]
 
     def infer_dtypes(self):
         from tripy import int32

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -30,6 +30,8 @@ class Permute(BaseTraceOp):
     # note that permuting a shape would not do anything
     infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
 
+    infer_len = op_utils.InferLenPolicies.infer_same_as_first_input
+
     def to_flat_ir(self, inputs, outputs):
         from tripy.flat_ir.ops import TransposeOp
 

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -52,7 +52,7 @@ class Reshape(BaseTraceOp):
 
     def infer_rank(self):
         if self.output_rank is None:
-            shape_of_shape_input = op_utils.get_op_input_shape(self.inputs[1])
+            shape_of_shape_input = op_utils.get_trace_shape(self.inputs[1])
             assert len(shape_of_shape_input) == 1
             assert shape_of_shape_input[0] >= 0, f"incorrect shape computation {shape_of_shape_input}"
             self.outputs[0].rank = shape_of_shape_input[0]
@@ -159,7 +159,7 @@ class Squeeze(BaseTraceOp):
         else:
             from tripy.backend.mlir.utils import ShapeContext
 
-            input_0_shape = op_utils.get_op_input_shape(self.inputs[0])
+            input_0_shape = op_utils.get_trace_shape(self.inputs[0])
 
             def squeeze_shape(shape, indices_to_squeeze):
                 # Convert shape to list if it's not already

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -36,7 +36,7 @@ class Reshape(BaseTraceOp):
 
     def infer_len(self):
         if self.output_len is not None:
-            return self.output_len
+            return [self.output_len]
         # skip inference for now because it requires obtaining the concrete _value_ of the second input,
         # not just its shape
         return [None]

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -29,7 +29,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 class Reshape(BaseTraceOp):
 
     output_rank: int
-    output_len: Optional[int]
+    output_len: Optional[int]  # only used to help with infer_len for a shape input
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -29,7 +29,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 class Reshape(BaseTraceOp):
 
     output_rank: int
-    output_len: Optional[int]  # only used to help with infer_len for a shape input
+    output_len: Optional[int] = None  # only used to help with infer_len for a shape input
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -29,6 +29,9 @@ class Shape(BaseTraceOp):
     def infer_shape_output_idxs(self, inputs) -> Result:
         return Result.ok([0])
 
+    def infer_len(self):
+        return [self.inputs[0].rank]
+
     def infer_rank(self):
         assert len(self.inputs) == 1, "ShapeOf operation should have exactly one input!"
         self.outputs[0].rank = 1

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -17,7 +17,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 from tripy import utils
 from tripy.frontend.ops.registry import TENSOR_METHOD_REGISTRY
 from tripy.frontend.trace.ops import utils as op_utils
@@ -30,6 +30,8 @@ from tripy.common.exception import raise_error
 
 @dataclass(repr=False)
 class Slice(BaseTraceOp):
+    shape_slice: Optional[slice] = None  # only used for inferring the length of a shape result
+
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype
 
@@ -38,8 +40,43 @@ class Slice(BaseTraceOp):
         self.outputs[0].rank = self.inputs[0].rank
 
     def infer_len(self):
-        # Skipping inference here since it depends on the concrete _values_ of the inputs
-        # rather than their shapes. This can be revisited if necessary
+        # Only infer if we have concrete values to use. Note that the result is only a Shape if these are *slices*,
+        # not single indices, so a slice is the only case that needs to be considered
+        if self.shape_slice is not None:
+            input_len = op_utils.get_trace_shape(self.inputs[0])[0]
+
+            def convert_to_positive_idx(idx):
+                return idx if idx >= 0 else input_len + idx
+
+            def clamp_bound(idx):
+                return 0 if idx < 0 else (idx if idx <= input_len else input_len)
+
+            stride = utils.default(self.shape_slice.step, 1)
+            if stride > 0:
+                start = 0 if self.shape_slice.start is None else convert_to_positive_idx(self.shape_slice.start)
+                stop = input_len if self.shape_slice.stop is None else convert_to_positive_idx(self.shape_slice.stop)
+            else:
+                # for negative stride, we compute the indices as they would be on the flipped list, see comments below
+                start = (
+                    0
+                    if self.shape_slice.start is None
+                    else input_len - convert_to_positive_idx(self.shape_slice.start) - 1
+                )
+                stop = (
+                    input_len
+                    if self.shape_slice.stop is None
+                    else input_len - convert_to_positive_idx(self.shape_slice.stop) - 1
+                )
+
+            start_point = clamp_bound(start)
+            end_point = clamp_bound(stop)
+            if start_point >= end_point:
+                return [0]
+
+            # - 1 because the end_point is exclusive. Use // so we round down
+            strides_in_range = (end_point - start_point - 1) // abs(stride)
+            # + 1 because we include the starting point and then make strides
+            return [1 + strides_in_range]
         return [None]
 
     # we only care about the data input
@@ -166,6 +203,7 @@ def __getitem__(self, index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "
         assert np.array_equal(cp.from_dlpack(output).get(), np.arange(10)[8:2:-1])
 
     """
+    from tripy.frontend.shape import Shape
     from tripy.frontend.tensor import Tensor
     from tripy.frontend.trace.ops.flip import flip
     from tripy.frontend.trace.ops.reshape import reshape, squeeze
@@ -175,6 +213,11 @@ def __getitem__(self, index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "
     # If a tensor is indexed by another tensor, this operation is equivalent to a gather operation.
     if isinstance(index, Tensor):
         return gather(self, 0, index)
+
+    # if we are taking a literal slice of a shape, we can pass on the slice to infer the length of the shape statically
+    shape_slice = None
+    if isinstance(self, Shape) and isinstance(index, slice):
+        shape_slice = index
 
     index = make_tuple(index)
     if len(index) > self.rank:
@@ -238,7 +281,7 @@ def __getitem__(self, index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "
     if flip_dims:
         input_tensor = flip(input_tensor, dims=flip_dims)
 
-    out = slice_helper(input_tensor, *args)
+    out = slice_helper(input_tensor, *args, shape_slice=shape_slice)
 
     squeeze_dims = []
     for i, idx in enumerate(index):
@@ -255,6 +298,6 @@ def __getitem__(self, index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "
 # Conveniently converts the inputs to tensors. The decorator also fills in column info for the converted tensors.
 # Because the helper is called inside another function, we need to skip one entry in the call stack to find
 # the original call to user code.
-@frontend_utils.convert_inputs_to_tensors(skip_num_stack_entries=1)
-def slice_helper(tensor, *slice_params):
-    return Slice.build(inputs=[tensor, *slice_params])
+@frontend_utils.convert_inputs_to_tensors(exclude=["shape_slice"], skip_num_stack_entries=1)
+def slice_helper(tensor, *slice_params, shape_slice: Optional[slice] = None):
+    return Slice.build(inputs=[tensor, *slice_params], shape_slice=shape_slice)

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -37,6 +37,11 @@ class Slice(BaseTraceOp):
         # How can we compute the output rank in the case when start, size, stride tensors are dynamic?
         self.outputs[0].rank = self.inputs[0].rank
 
+    def infer_len(self):
+        # Skipping inference here since it depends on the concrete _values_ of the inputs
+        # rather than their shapes. This can be revisited if necessary
+        return [None]
+
     # we only care about the data input
     infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
 

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -42,7 +42,7 @@ class Split(BaseTraceOp):
 
     def infer_len(self):
         # since this only runs in the shape case, this is rank 1
-        shape_len = op_utils.get_op_input_shape(self.inputs[0])[0]
+        shape_len = op_utils.get_trace_shape(self.inputs[0])[0]
         if isinstance(self.indices_or_sections, int):
             # Note: Important to use //, as if the result is a float, MLIR compilation will fail
             out_len = shape_len // self.indices_or_sections

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -40,6 +40,25 @@ class Split(BaseTraceOp):
     # we only care about the data input
     infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
 
+    def infer_len(self):
+        # since this only runs in the shape case, this is rank 1
+        shape_len = op_utils.get_op_input_shape(self.inputs[0])[0]
+        if isinstance(self.indices_or_sections, int):
+            # Note: Important to use //, as if the result is a float, MLIR compilation will fail
+            out_len = shape_len // self.indices_or_sections
+            ret = [out_len] * self.indices_or_sections
+            return ret
+
+        out_lengths = []
+        start_idx = 0
+        for idx in self.indices_or_sections:
+            out_len = idx - start_idx
+            start_idx = idx
+            out_lengths.append(out_len)
+        # final slice
+        out_lengths.append(shape_len - start_idx)
+        return out_lengths
+
     def infer_devices(self):
         for i in range(self.num_outputs()):
             self.outputs[i].device = self.inputs[0].device

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 from tripy import utils
 from tripy.utils import Result
@@ -111,6 +111,29 @@ class ShapeOutputIdxPolicies:
         Accepts shapes but the result is always no shape indices
         """
         return Result.ok([])
+
+
+##
+## Inferring shape lengths (helpers)
+##
+
+
+def get_op_input_shape(input: "TraceTensor") -> Sequence[int]:
+    """
+    Given an operator input tensor, return its shape if it has already been given
+    or get its shape from the shape context if it's needed.
+    """
+    if input.shape is None:
+        from tripy.backend.mlir.utils import ShapeContext
+
+        # memoize while we're at it
+        input.shape = ShapeContext().get_shape_of_dynamic_trace_tensor(input)
+    return input.shape
+
+
+class InferLenPolicies:
+    def infer_same_as_first_input(self):
+        return [get_op_input_shape(self.inputs[0])[0]]
 
 
 ##

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -118,7 +118,7 @@ class ShapeOutputIdxPolicies:
 ##
 
 
-def get_op_input_shape(input: "TraceTensor") -> Sequence[int]:
+def get_trace_shape(input: "TraceTensor") -> Sequence[int]:
     """
     Given an operator input tensor, return its shape if it has already been given
     or get its shape from the shape context if it's needed.
@@ -133,7 +133,7 @@ def get_op_input_shape(input: "TraceTensor") -> Sequence[int]:
 
 class InferLenPolicies:
     def infer_same_as_first_input(self):
-        return [get_op_input_shape(self.inputs[0])[0]]
+        return [get_trace_shape(self.inputs[0])[0]]
 
 
 ##

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -53,6 +53,10 @@ class Where(BaseTraceOp):
                 ]
             )
 
+    def infer_len(self):
+        # broadcast to the largest of the input lengths
+        return [max(map(lambda inp: op_utils.get_op_input_shape(inp)[0], self.inputs))]
+
     def infer_dtypes(self):
         assert len(self.inputs) == 3, "Select operation should have exactly 3 inputs!"
         if self.inputs[0].dtype != datatype.bool:

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -55,7 +55,7 @@ class Where(BaseTraceOp):
 
     def infer_len(self):
         # broadcast to the largest of the input lengths
-        return [max(map(lambda inp: op_utils.get_op_input_shape(inp)[0], self.inputs))]
+        return [max(map(lambda inp: op_utils.get_trace_shape(inp)[0], self.inputs))]
 
     def infer_dtypes(self):
         assert len(self.inputs) == 3, "Select operation should have exactly 3 inputs!"


### PR DESCRIPTION
For some cases, it is useful to know the length of a `tp.Shape` without executing the model. This PR adds a method `infer_len` that allows operators to specify how to statically infer the length of `Shape` outputs when possible (it is always optional). Test cases are added.