### PR TITLE
Allow containers of homogenous superclass in state dict

### DIFF
--- a/tripy/tests/frontend/module/conftest.py
+++ b/tripy/tests/frontend/module/conftest.py
@@ -49,7 +49,7 @@ class Network(tp.Module):
 
     def __call__(self):
         return self.param + self.dummy1() + self.dummy2()
-
+    
 
 class ListNetwork(tp.Module):
     def __init__(self):
@@ -78,6 +78,16 @@ class DictNetwork(tp.Module):
         for op_name in self.dummy_dict:
             out = out + self.dummy_dict[op_name]
         return out
+
+
+class MixedNetwork(tp.Module):
+    def __init__(self):
+        super().__init__()
+        self.mixed_list = [DummyOp(tp.zeros((2,), dtype=tp.float32)), DummyNestedOp(tp.ones((2,), dtype=tp.float32))]
+        self.mixed_dict = {"dummy": DummyOp(tp.zeros((2,), dtype=tp.float32)), "dummy_nested": DummyNestedOp(tp.ones((2,), dtype=tp.float32))}
+
+    def __call__(self):
+        return self.mixed_list[0]() + self.mixed_list[1]() + self.mixed_dict["dummy"]() + self.mixed_dict["dummy_nested"]()
 
 
 class ComplexNetwork(tp.Module):
@@ -114,6 +124,10 @@ def list_network():
 @pytest.fixture
 def dict_network():
     yield DictNetwork()
+
+@pytest.fixture
+def mixed_network():
+    yield MixedNetwork()    
 
 
 @pytest.fixture

--- a/tripy/tests/frontend/module/test_module.py
+++ b/tripy/tests/frontend/module/test_module.py
@@ -234,6 +234,32 @@ class TestModuleWithDict:
         assert tripy_params["new_params.param0"] is param0
         assert tripy_params["new_params.param1"] is param1
 
+class TestMixedModule:
+    def test_basic_structure(self, mixed_network):
+        module = mixed_network
+        assert hasattr(module, "mixed_list")
+        assert hasattr(module, "mixed_dict")
+        assert isinstance(module.mixed_list, list)
+        assert isinstance(module.mixed_dict, dict)
+        assert all(isinstance(list_module, tp.Module) for list_module in module.mixed_list)
+        assert all(isinstance(dict_module, tp.Module) for dict_module in module.mixed_dict.values())
+    
+    def test_state_dict(self, mixed_network):
+        module = mixed_network
+        print(module.state_dict())
+        tensor = tp.ones((2,))
+        external_state_dict = {
+            "mixed_list.0.nested.param": tensor,
+            "mixed_list.1.param": tensor,
+            "mixed_dict.dummy.nested.param": tensor,
+            "mixed_dict.dummy_nested.param": tensor,
+        }
+        module.load_from_state_dict(external_state_dict)
+        assert module.mixed_list[0].nested.param is tensor
+        assert module.mixed_list[1].param is tensor
+        assert module.mixed_dict["dummy"].nested.param is tensor
+        assert module.mixed_dict["dummy_nested"].param is tensor
+
 
 class TestComplexModule:
     def test_basic_structure(self, complex_network):

--- a/tripy/tripy/frontend/module/module.py
+++ b/tripy/tripy/frontend/module/module.py
@@ -40,8 +40,8 @@ def _check_param_compatible(original_param, new_param, param_name):
         )
 
 
-def _is_homogeneous_container(container: Sequence, types: List[T]):
-    return any(all(isinstance(op, typ) for op in container) for typ in types)
+def _is_homogeneous_container(container: Sequence, typ: T):
+    return all(isinstance(op, typ) for op in container)
 
 
 def _contains_types(container: Sequence, types: type):
@@ -106,7 +106,7 @@ class Module:
 
         if isinstance(value, List) or isinstance(value, Dict):
             container = value if isinstance(value, List) else value.values()
-            if _contains_types(container, [Parameter, Module]) and not _is_homogeneous_container(container, [Module, Parameter]):
+            if _contains_types(container, [Parameter, Module]) and not _is_homogeneous_container(container, Parameter):
                 logger.warning("A container of mixed types will not be registered with this module's state_dict().")
 
     def state_dict(self) -> Dict[str, Parameter]:
@@ -276,13 +276,13 @@ class Module:
         for name, value in vars(self).items():
             if isinstance(value, typ):
                 yield name, value
-            elif isinstance(value, List) and _contains_types(value, [typ]) and _is_homogeneous_container(value, [Module, Parameter]):
+            elif isinstance(value, List) and _contains_types(value, [typ]) and _is_homogeneous_container(value, typ):
                 for i, obj in enumerate(value):
                     yield f"{name}.{i}", obj
             elif (
                 isinstance(value, Dict)
                 and _contains_types(value.values(), [typ])
-                and _is_homogeneous_container(value.values(), [Module, Parameter])
+                and _is_homogeneous_container(value.values(), typ)
             ):
                 for key, obj in value.items():
                     yield f"{name}.{key}", obj

--- a/tripy/tripy/frontend/module/module.py
+++ b/tripy/tripy/frontend/module/module.py
@@ -40,8 +40,8 @@ def _check_param_compatible(original_param, new_param, param_name):
         )
 
 
-def _is_homogeneous_container(container: Sequence):
-    return len(set(map(type, container))) == 1
+def _is_homogeneous_container(container: Sequence, types: List[T]):
+    return any(all(isinstance(op, typ) for op in container) for typ in types)
 
 
 def _contains_types(container: Sequence, types: type):
@@ -106,7 +106,7 @@ class Module:
 
         if isinstance(value, List) or isinstance(value, Dict):
             container = value if isinstance(value, List) else value.values()
-            if _contains_types(container, [Parameter, Module]) and not _is_homogeneous_container(container):
+            if _contains_types(container, [Parameter, Module]) and not _is_homogeneous_container(container, [Module, Parameter]):
                 logger.warning("A container of mixed types will not be registered with this module's state_dict().")
 
     def state_dict(self) -> Dict[str, Parameter]:
@@ -276,13 +276,13 @@ class Module:
         for name, value in vars(self).items():
             if isinstance(value, typ):
                 yield name, value
-            elif isinstance(value, List) and _contains_types(value, [typ]) and _is_homogeneous_container(value):
+            elif isinstance(value, List) and _contains_types(value, [typ]) and _is_homogeneous_container(value, [Module, Parameter]):
                 for i, obj in enumerate(value):
                     yield f"{name}.{i}", obj
             elif (
                 isinstance(value, Dict)
                 and _contains_types(value.values(), [typ])
-                and _is_homogeneous_container(value.values())
+                and _is_homogeneous_container(value.values(), [Module, Parameter])
             ):
                 for key, obj in value.items():
                     yield f"{name}.{key}", obj


### PR DESCRIPTION
Updates homogenous container check to allow subclasses that all derive from the same superclass to be "mixed" in the same container. This effectively allows lists/dicts of modules or params to be registered in the state dict. 

L0 test: 1959 passed, 47 skipped, 1 deselected, 1 warning