### PR TITLE
[mlir-tensorrt] fix failure due to double registration

### DIFF
--- a/mlir-tensorrt/compiler/lib/Conversion/StablehloToTensorRT/CMakeLists.txt
+++ b/mlir-tensorrt/compiler/lib/Conversion/StablehloToTensorRT/CMakeLists.txt
@@ -7,14 +7,16 @@ add_mlir_tensorrt_library(MLIRTensorRTStablehloToTensorRT
   MLIRTensorRTConversionPassIncGen
 
   LINK_LIBS PUBLIC
+  ChloOps
+  MLIRFuncTransforms
+  MLIRQuantDialect
   MLIRRewrite
+  MLIRTensorRTConvertToTensorRTCommon
+  MLIRTensorRTDialect
+  MLIRTensorRTStableHloExtUtils
+  MLIRTensorRTStablehloInputPreprocessing
+  MLIRTensorRTTensorRTUtils
   MLIRTransforms
   MLIRTransformUtils
-  MLIRTensorRTConvertToTensorRTCommon
-  MLIRQuantDialect
-  MLIRTensorRTDialect
-  MLIRTensorRTTensorRTUtils
-  MLIRFuncTransforms
-  ChloOps
   StablehloOps
 )

--- a/mlir-tensorrt/tools/MlirTensorRtOpt.cpp
+++ b/mlir-tensorrt/tools/MlirTensorRtOpt.cpp
@@ -57,7 +57,6 @@ int main(int argc, char **argv) {
   mlir::tensorrt::registerTensorRTTranslationPasses();
 #endif
   mlir::tensorrt::registerAllMlirTensorRtPasses();
-  mlirtrt::compiler::registerStablehloClusteringPipelines();
 #ifdef MLIR_TRT_ENABLE_TESTING
   registerTestPasses();
 #endif


### PR DESCRIPTION
    [mlir-tensorrt] fix failure due to double registration and missing link deps
    
    This change fixes a test failure that arises only when assertions are on:
    the registration for one of the passes/pipelines was being called twice.
    
    This also fixes a sporadic build failure to to missing dependencies listed
    in the StableHLOToTensorRT conversion library declaration.
    
    Signed-off-by: Christopher Bate <cbate@nvidia.com>