### PR TITLE
Report informative error when input shapes are out of bounds.

### DIFF
--- a/tripy/tests/backend/test_compiler_api.py
+++ b/tripy/tests/backend/test_compiler_api.py
@@ -260,6 +260,16 @@ class TestCompile:
             )
             compiled_add(a, a)
 
+    def test_incorrect_shape_rejected(self):
+        compiler = tp.Compiler(add)
+        a = tp.ones((1, 2), dtype=tp.float32)
+
+        with helper.raises(tp.TripyException, "Unexpected tensor shape.", has_stack_info_for=[a]):
+            compiled_add = compiler.compile(
+                tp.InputInfo((2, 2), dtype=tp.float32), tp.InputInfo((2, 2), dtype=tp.float32)
+            )
+            compiled_add(a, a)
+
     @pytest.mark.skip("TODO (#155): Re-enable once we no longer implicitly copy inputs to device")
     def test_incorrect_device_rejected(self):
         compiler = tp.Compiler(add)

--- a/tripy/tripy/backend/compiler_api.py
+++ b/tripy/tripy/backend/compiler_api.py
@@ -222,6 +222,19 @@ class Executable:
                                 tensor,
                             ],
                         )
+            elif "InternalError: failed to set input shape" in str(err) or "Runtime shape mismatch" in str(err):
+                expected_input_shapes = [info.shape_bounds for info in self.get_input_info()]
+                for tensor, expected_bounds, arg_name in zip(input_tensors, expected_input_shapes, self._arg_names):
+                    shape = tensor.shape.data().data()
+                    for i in range(len(shape)):
+                        if shape[i] < expected_bounds[i][0] or shape[i] > expected_bounds[i][1]:
+                            raise_error(
+                                f"Unexpected tensor shape.",
+                                [
+                                    f"For parameter `{arg_name}`, expected the tensor shape `{tensor.shape}` to be within bounds for all dimensions. However, dimension {i} has a shape of {shape[i]}, which is not within the expected bounds of {expected_bounds[i]}. Note: The provided argument was: ",
+                                    tensor,
+                                ],
+                            )
             raise
 
         # TODO (#192): avoid get_stack_info in runtime


### PR DESCRIPTION
Catch (and replace with more informative) the error thrown by backend when input shapes don't match expected bounds