### PR TITLE
Make `tp.Layernorm` 1:1 with torch

### DIFF
--- a/tripy/tests/integration/test_groupnorm.py
+++ b/tripy/tests/integration/test_groupnorm.py
@@ -29,9 +29,9 @@ DTYPES = [
 
 class TestGroupNorm:
     @pytest.mark.parametrize("torch_dtype, tp_dtype", DTYPES)
-    @pytest.mark.parametrize("input_shape", [(2, 2, 2)])
-    @pytest.mark.parametrize("num_groups", [2, 4])
-    @pytest.mark.parametrize("num_channels", [2])
+    @pytest.mark.parametrize("input_shape", [(1, 10, 2)])
+    @pytest.mark.parametrize("num_groups", [2, 5])
+    @pytest.mark.parametrize("num_channels", [10])
     @pytest.mark.parametrize("eps", [1e-5, 1e-3])
     def test_groupnorm_accuracy(self, torch_dtype, tp_dtype, input_shape, num_groups, num_channels, eps):
         groupnorm = torch.nn.GroupNorm(

--- a/tripy/tests/integration/test_groupnorm.py
+++ b/tripy/tests/integration/test_groupnorm.py
@@ -1,0 +1,61 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import torch
+import pytest
+
+import tripy as tp
+from tripy.common.exception import TripyException
+
+DTYPES = [
+    (torch.float16, tp.float16),
+    (torch.float32, tp.float32)
+]
+
+class TestGroupNorm:
+    @pytest.mark.parametrize("torch_dtype, tp_dtype", DTYPES)
+    @pytest.mark.parametrize("input_shape", [(2, 2, 2)])
+    @pytest.mark.parametrize("num_groups", [2, 4])
+    @pytest.mark.parametrize("num_channels", [2])
+    @pytest.mark.parametrize("eps", [1e-5, 1e-3])
+    def test_groupnorm_accuracy(self, torch_dtype, tp_dtype, input_shape, num_groups, num_channels, eps):
+        groupnorm = torch.nn.GroupNorm(
+            num_groups=num_groups,
+            num_channels=num_channels,
+            eps=eps,
+            dtype=torch_dtype,
+        )
+        tp_groupnorm = tp.GroupNorm(
+            num_groups=num_groups,
+            num_channels=num_channels,
+            eps=eps,
+            dtype=tp_dtype,
+        )
+
+        tp_groupnorm.weight = tp.Parameter(groupnorm.weight)
+        tp_groupnorm.bias = tp.Parameter(groupnorm.bias)
+
+        input = torch.arange(torch.prod(torch.Tensor(input_shape))).reshape(input_shape).to(torch_dtype)
+        tp_input = tp.Tensor(input, dtype=tp_dtype)
+
+        output = tp_groupnorm(tp_input)
+        expected = tp.Tensor(groupnorm(input), device=tp.device("cpu"))
+
+        rtol_ = 2e-6 if tp_dtype == tp.float32 else 1e-3
+        assert output.shape == expected.shape
+        assert tp.allclose(output, expected, rtol=rtol_)

--- a/tripy/tests/integration/test_layernorm.py
+++ b/tripy/tests/integration/test_layernorm.py
@@ -1,0 +1,62 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import torch
+import pytest
+
+import tripy as tp
+
+DTYPES = [
+    (torch.float16, tp.float16),
+    (torch.float32, tp.float32),
+]
+
+@pytest.mark.parametrize("torch_dtype, tp_dtype", DTYPES)
+@pytest.mark.parametrize("device", ["gpu", "cpu"])
+class TestLayerNorm:
+    @pytest.mark.parametrize("input_shape", [(10, 10, 5)])
+    @pytest.mark.parametrize("normalized_shape", [(10, 5), (5,)])
+    @pytest.mark.parametrize("eps", [1e-5, 1e-3])
+    def test_layernorm_module(self, torch_dtype, tp_dtype, device, input_shape, normalized_shape, eps):
+        torch_device = "cuda" if device == "gpu" else device
+        tp_layernorm = tp.LayerNorm(
+            normalized_shape=normalized_shape,
+            eps=eps,
+            dtype=tp_dtype,
+        )
+        layernorm = torch.nn.LayerNorm(
+            normalized_shape=normalized_shape,
+            eps=eps,
+            dtype=torch_dtype,
+            device=torch_device
+        )
+
+        # use Tripy's parameters
+        layernorm.weight = torch.nn.Parameter(torch.from_dlpack(tp_layernorm.weight.__dlpack__()).to(torch_device))
+        layernorm.bias = torch.nn.Parameter(torch.from_dlpack(tp_layernorm.bias.__dlpack__()).to(torch_device))
+
+        input = torch.arange(torch.prod(torch.Tensor(input_shape))).reshape(input_shape).to(torch_device).to(torch_dtype)
+        tp_input = tp.Tensor(input, dtype=tp_dtype, device=tp.device(device))
+
+        output = tp_layernorm(tp_input)
+        expected = layernorm(input).to("cpu")
+
+        output_torch = torch.from_dlpack(output).to("cpu")
+        rtol_ = 2e-7 if tp_dtype == tp.float32 else 1.5e-3
+        assert torch.allclose(output_torch, expected, rtol=rtol_)
+        assert output_torch.shape == expected.shape

--- a/tripy/tripy/frontend/module/groupnorm.py
+++ b/tripy/tripy/frontend/module/groupnorm.py
@@ -55,7 +55,7 @@ class GroupNorm(Module):
     eps: float
     """A value added to the denominator to prevent division by zero. Defaults to 1e-5."""
 
-    def __init__(self, num_groups: int, num_channels: int, dtype: datatype.dtype = datatype.float32) -> None:
+    def __init__(self, num_groups: int, num_channels: int, dtype: datatype.dtype = datatype.float32, eps: float = 1e-5) -> None:
         """
         Args:
             num_groups: The number of groups to split the channels into.
@@ -97,7 +97,7 @@ class GroupNorm(Module):
         # Replace with random weights when #74 is completed.
         self.weight = DefaultParameter((num_channels,), dtype=dtype)
         self.bias = DefaultParameter((num_channels,), dtype=dtype)
-        self.eps = 1e-5
+        self.eps = eps
 
     def __call__(self, x: "tripy.Tensor") -> "tripy.Tensor":
         r"""

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -112,7 +112,9 @@ class LayerNorm(Module):
         D = len(self.normalized_shape)
 
         if x.shape[-D:] != self.normalized_shape:
-            raise_error(f"The input's last {D} dimensions must have a shape of {self.normalized_shape} and received {x.shape[-D:].as_tensor().data()}")
+            raise_error("Unexpected input shape",
+                [f"The input's last {D} dimensions must have a shape of {self.normalized_shape} and received {x.shape[-D:].data()}"]
+            )
 
         reduce_dims = tuple(-i for i in range(D, 0, -1))
         mean_val = mean(x, dim=reduce_dims, keepdim=True)

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -109,14 +109,14 @@ class LayerNorm(Module):
             A tensor of the same shape as the input.
         """
         from tripy.frontend.trace.ops.reduce import mean, var
+        from tripy.frontend.shape import Shape
         from tripy.frontend.trace.ops.unary_elementwise import rsqrt
         from tripy.common.exception import raise_error
-        import tripy as tp
 
         # The mean and the variance are computed over the last D dimensions
         D = len(self.normalized_shape)
 
-        if x.shape[-D:] != tp.Shape(self.normalized_shape):
+        if x.shape[-D:] != Shape(self.normalized_shape):
             raise_error(f"The input's last {D} dimensions must have a shape of {self.normalized_shape} and received {x.shape[-D:].as_tensor().data()}")
 
         reduce_dims = tuple(-i for i in range(D, 0, -1))

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -35,7 +35,7 @@ class LayerNorm(Module):
 
     where :math:`\bar{x}` is the mean and :math:`\sigma^2` is the variance.
 
-    The mean the standard deviation are calculated over the last :math:`D`
+    The mean and standard deviation are calculated over the last :math:`D`
     dimensions, where :math:`D` is the dimension of `normalized_shape`.
     """
 
@@ -111,7 +111,7 @@ class LayerNorm(Module):
         # The mean and the variance are computed over the last D dimensions
         D = len(self.normalized_shape)
 
-        if x.shape[-D:] != Shape(self.normalized_shape):
+        if x.shape[-D:] != self.normalized_shape:
             raise_error(f"The input's last {D} dimensions must have a shape of {self.normalized_shape} and received {x.shape[-D:].as_tensor().data()}")
 
         reduce_dims = tuple(-i for i in range(D, 0, -1))

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -26,7 +26,7 @@ from tripy.frontend.module.parameter import Parameter, DefaultParameter
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["dtype"])
+@utils.constant_fields(["dtype", "normalized_shape"])
 class LayerNorm(Module):
     r"""
     Applies layer normalization over the input tensor:
@@ -54,10 +54,7 @@ class LayerNorm(Module):
     eps: float
     """A value added to the denominator to prevent division by zero."""
 
-    correction: int
-    """Difference between the sample size and the degrees of freedom."""
-
-    def __init__(self, normalized_shape: Union[int, Tuple[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5, correction: int = 0) -> None:
+    def __init__(self, normalized_shape: Union[int, Tuple[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5) -> None:
         """
         Args:
             normalized_shape: The size of the feature dimension of the input over which normalization is performed.
@@ -98,8 +95,6 @@ class LayerNorm(Module):
 
         self.eps = eps
 
-        self.correction = correction
-
     def __call__(self, x: "tripy.Tensor") -> "tripy.Tensor":
         r"""
         Args:
@@ -121,6 +116,6 @@ class LayerNorm(Module):
 
         reduce_dims = tuple(-i for i in range(D, 0, -1))
         mean_val = mean(x, dim=reduce_dims, keepdim=True)
-        var_val = var(x, dim=reduce_dims, keepdim=True, correction=self.correction) + self.eps
+        var_val = var(x, dim=reduce_dims, keepdim=True, correction=0) + self.eps
         x = (x - mean_val) * rsqrt(var_val)
         return self.weight * x + self.bias


### PR DESCRIPTION
- Make  the `normalized_shape` argument 1:1 with Torch. Previously, our API only supported taking a single integer for the normalization dimension. Now, a list of integers can be provided.
- Add integration tests for `tp.LayerNorm` and `tp.GroupNorm`