### PR TITLE
Add `Shape.__ne__()`

### DIFF
--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -446,3 +446,14 @@ class TestShape:
         if isinstance(other_values, np.ndarray):
             pytest.skip("numpy array cannot be implicitly cast to Shape type")
         assert isinstance(a == other_values, bool)
+
+    def test_shape_inequality(self):
+        a = tp.Shape([1, 2, 3])
+        b = tp.Shape([1, 4, 5])
+        assert a != b
+
+    def test_shape_inequality_different_ranks(self):
+        a = tp.Shape([1])
+        b = tp.Shape([1, 2])
+        assert a != b
+ 

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -160,7 +160,15 @@ class Shape(Tensor):
     def __eq__(self, other):
         from tripy.frontend.trace.ops.reduce import all
 
+        # `.shape` will contain a single int. To avoid endlessly calling
+        # Shape.__eq__, we can compare the int's directly using `.data()`
+        if self.shape.data() != other.shape.data():
+            return False 
+
         return bool(all(self.as_tensor() == other.as_tensor()))
+
+    def __ne__(self, other):
+        return not (self == other)
 
     # __len__ for shapes gives the number of dims in the shape, i.e., the first dimension of the shape's shape
     def __len__(self):

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -162,7 +162,7 @@ class Shape(Tensor):
 
         # `.shape` will contain a single int. To avoid endlessly calling
         # Shape.__eq__, we can compare the int's directly using `.data()`
-        if self.shape.data() != other.shape.data():
+        if len(self.shape) != len(other.shape):
             return False 
 
         return bool(all(self.as_tensor() == other.as_tensor()))


### PR DESCRIPTION
- Adds `Shape.__ne__()` method so that shapes can be conveniently checked for inequality.
- Fixes logic error where `Shape.__eq__()` would ignore checking rank. This would lead to an error when comparing shape's with different ranks.
- Adds shape inequality test cases for shapes with different and same ranks. 