### PR TITLE
Disable doc deployment in L1

### DIFF
--- a/.github/workflows/tripy-l1.yml
+++ b/.github/workflows/tripy-l1.yml
@@ -43,9 +43,9 @@ jobs:
     - uses: actions/upload-pages-artifact@v3
       with:
         path: "/tripy/build/docs"
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+    # - name: Deploy to GitHub Pages
+    #   id: deployment
+    #   uses: actions/deploy-pages@v4
     - name: l1-test
       run: |
         cd /tripy/


### PR DESCRIPTION
Not successful figuring out how to commit to `gh-pages` branch, the contents are very different. Disabling the doc deployment job for now.