### PR TITLE
[Tripy] Add iterator implementation for `tp.Shape`

### DIFF
--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -268,6 +268,11 @@ class TestShape:
         s1 = tp.Shape(values)
         assert len(s1[slice_value]) == len(values[slice_value])
 
+    def test_iteration(self, values):
+        s = tp.Shape(values)
+        for i, v in enumerate(s):
+            assert cp.from_dlpack(v).get() == values[i]
+
     def test_reduce(self, values):
         from tripy.frontend.trace.ops.reduce import Reduce
 
@@ -456,4 +461,3 @@ class TestShape:
         a = tp.Shape([1])
         b = tp.Shape([1, 2])
         assert a != b
- 

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -163,7 +163,7 @@ class Shape(Tensor):
         # `.shape` will contain a single int. To avoid endlessly calling
         # Shape.__eq__, we can compare the int's directly using `.data()`
         if len(self.shape) != len(other.shape):
-            return False 
+            return False
 
         return bool(all(self.as_tensor() == other.as_tensor()))
 
@@ -175,3 +175,24 @@ class Shape(Tensor):
         from tripy.frontend.trace.ops import utils as op_utils
 
         return op_utils.get_trace_shape(self.trace_tensor)[0]
+
+    class ShapeIter:
+        """
+        Since it is generally simple to get the length of a shape, we can define
+        iteration for Shapes even if we don't permit it for other tensors.
+        """
+
+        def __init__(self, shape):
+            self.shape = shape
+            self.idx = 0
+
+        def __next__(self):
+            if self.idx >= len(self.shape):
+                raise StopIteration
+
+            ret = self.shape[self.idx]
+            self.idx += 1
+            return ret
+
+    def __iter__(self):
+        return Shape.ShapeIter(self)


### PR DESCRIPTION
Since we are treating `tp.Shape` as a collection, it may also make sense to iterate over them. This PR adds a very simple iterator implementation to `tp.Shape`. Another way we could implement it would be to override `__getitem__` to throw an exception if it gives an out-of-bounds access and then use the default iterator, but this is likely simpler.