### PR TITLE
[Tripy][Docs] Recommend the use of `--pull always` to update the image in the contributing doc

### DIFF
--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Thank you for considering contributing to Tripy!
         docker run --gpus all -it -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
         ```
 
+        If you have pulled the image in the past and need to update it, you should add `--pull=always` to the above command or separately call `docker pull ghcr.io/nvidia/tensorrt-incubator/tripy`.
+
     - Otherwise, you can build the container locally and launch it.
         From the [`tripy` root directory](.), run:
 

--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -28,10 +28,8 @@ Thank you for considering contributing to Tripy!
         Next, pull and launch the container. From the [`tripy` root directory](.), run:
 
         ```bash
-        docker run --gpus all -it -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
+        docker run --pull always --gpus all -it -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
         ```
-
-        If you have pulled the image in the past and need to update it, you should add `--pull=always` to the above command or separately call `docker pull ghcr.io/nvidia/tensorrt-incubator/tripy`.
 
     - Otherwise, you can build the container locally and launch it.
         From the [`tripy` root directory](.), run:


### PR DESCRIPTION
`docker run` by default will only pull an image if it is entirely missing, so the command given in `CONTRIBUTING.md` will not update the image if it had been pulled before. This change adds the `--pull always` setting in the example command so that it would check for an update before running.