### PR TITLE
Adds test profiling, speeds up tests

### DIFF
--- a/tripy/.gitignore
+++ b/tripy/.gitignore
@@ -85,3 +85,6 @@ core*
 
 # IDEs
 .vscode
+
+# PyTest profiling results
+*.prof

--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Thank you for considering contributing to Tripy!
         Next, pull and launch the container. From the [`tripy` root directory](.), run:
 
         ```bash
-        docker run --pull always --gpus all -it -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
+        docker run --pull always --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
         ```
 
     - Otherwise, you can build the container locally and launch it.
@@ -36,7 +36,7 @@ Thank you for considering contributing to Tripy!
 
         ```bash
         docker build -t tripy .
-        docker run --gpus all -it -v $(pwd):/tripy/ --rm tripy:latest
+        docker run --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ --rm tripy:latest
         ```
 
 3. You should now be able to use `tripy` in the container. To test it out, you can run a quick sanity check:
@@ -155,7 +155,7 @@ The Tripy container includes a build of MLIR-TensorRT, but in some cases, you ma
 
 2. Launch the container with mlir-tensorrt repository mapped for accessing wheels files; from the [`tripy` root directory](.), run:
     ```bash
-    docker run --gpus all -it -v $(pwd):/tripy/ -v $(pwd)/../mlir-tensorrt:/mlir-tensorrt  --rm tripy:latest
+    docker run --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ -v $(pwd)/../mlir-tensorrt:/mlir-tensorrt  --rm tripy:latest
     ```
 
 3. Install MLIR-TensorRT wheels

--- a/tripy/docs/post0_developer_guides/debugging.md
+++ b/tripy/docs/post0_developer_guides/debugging.md
@@ -19,6 +19,6 @@ In order to use `lldb` in tripy container, launch the container with extra secur
 ```bash
 docker run --gpus all --cap-add=SYS_PTRACE \
 	--security-opt seccomp=unconfined --security-opt apparmor=unconfined \
-	-v $(pwd):/tripy/ -it --rm tripy:latest
+	-p 8080:8080 -v $(pwd):/tripy/ -it --rm tripy:latest
 ```
 See https://forums.swift.org/t/debugging-using-lldb/18046 for more details.

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -48,7 +48,9 @@ docs = [
 test = [
   "pytest==7.1.3",
   "pytest-virtualenv==1.7.0",
+  "pytest-profiling==1.7.0",
   "pytest-cov==4.1.0",
+  "snakeviz==2.2.0",
   "coverage==7.4.1",
   "vulture==2.11",
   "tripy[doc_test_common]",

--- a/tripy/tests/README.md
+++ b/tripy/tests/README.md
@@ -21,6 +21,36 @@ L0 tests, use:
 pytest tests/ -v -m "not l1 and not manual"
 ```
 
+
+## Profiling
+
+You can profile test runtimes in the development container using the
+`--profile` option, which will generate `pstats` files for each test
+in a `prof/` directory, along with a `combined.prof` file for all the
+tests together.
+
+For example, to profile L0 tests, run:
+
+```bash
+pytest tests/ -v -m "not l1 and not manual" --profile
+```
+
+You can visualize the results using `snakeviz`.
+
+*NOTE: Ensure that you launched the development container with port forwarding,*
+*i.e. the `-p 8080:8080` option.*
+
+For example:
+
+```bash
+snakeviz prof/combined.prof -s --hostname 0.0.0.0
+```
+
+Then, in a browser, navigate to:
+http://localhost:8080/snakeviz/%2Ftripy%2Fprof%2Fcombined.prof
+
+
+
 ## Coverage Reports
 
 You can generate code coverage reports locally by running:

--- a/tripy/tests/frontend/test_tensor.py
+++ b/tripy/tests/frontend/test_tensor.py
@@ -107,6 +107,7 @@ class TestTensor:
     )
     def test_stack_info_is_populated(self, build_func, expected_line_number):
         a = build_func()
+        a.stack_info.fetch_source_code()
 
         assert a.stack_info[0] == SourceInfo(
             inspect.getmodule(tp.Tensor).__name__,
@@ -158,6 +159,7 @@ class TestTensor:
     def test_stack_depth_sanity(self):
         # Makes sure STACK_DEPTH_OF_BUILD is correct
         a = tp.ones((2, 3))
+        a.stack_info.fetch_source_code()
 
         def find_frame(func_name):
             for frame in a.stack_info:

--- a/tripy/tests/utils/test_stack_info.py
+++ b/tripy/tests/utils/test_stack_info.py
@@ -33,6 +33,7 @@ class TestGetStackInfo:
         # Make sure these two lines remain adjacent since we need to know the offset to use for the line number.
         expected_outer_line_num = sys._getframe().f_lineno + 1
         stack_info, expected_inner_line_num = func()
+        stack_info.fetch_source_code()
 
         assert stack_info[0] == SourceInfo(
             __name__,
@@ -58,6 +59,8 @@ class TestGetStackInfo:
         # We should include code for all frames up to user code. If the index is past the user frame,
         # then code is included only for the user frame.
         stack_info = tripy.utils.get_stack_info(include_code_index=include_code_index)
+        stack_info.fetch_source_code()
+
         num_frames_with_code = len([frame for frame in stack_info if frame.code])
         USER_FRAME_INDEX = 1
         assert num_frames_with_code == max(

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -124,6 +124,8 @@ def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool =
 
     frame_strs = []
     num_frames_printed = 0
+
+    stack_info.fetch_source_code()
     for index, source_info in enumerate(stack_info):
         if source_info.code is None:
             continue
@@ -175,6 +177,7 @@ def raise_error(summary: str, details: List[Any] = []):
     stack_info = utils.get_stack_info()
     user_frame_index = stack_info.get_first_user_frame_index()
     if user_frame_index is not None:
+        stack_info.fetch_source_code()
         pre_summary = str_from_source_info(stack_info[user_frame_index])
 
     detail_msg = ""

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -79,6 +79,7 @@ def convert_inputs_to_tensors(
             def add_column_info_for_non_tensor(arg, arg_index, is_kwarg, dtype, list_index=None):
                 assert not isinstance(arg, Tensor)
                 arg = Tensor(arg, dtype=dtype)
+                arg.stack_info.fetch_source_code()
 
                 # This is the stack depth in arg.stack_info where we find the function
                 # that's decorated with `convert_inputs_to_tensors()`.


### PR DESCRIPTION
Enables pytest profiling
- Updates container to include tooling to enable profiling our test suite.
- Updates README with instructions on how to use profiling tooling.


Greatly speeds up `get_stack_info()`

- Updates `get_stack_info()` to no longer use `inspect` APIs, which are extremely
     slow, but instead work with the frames directly.

- Updates `StackInfo` with a `fetch_source_code()` method which allows us to defer
     the fetching of source code (extremely slow due to file I/O) until the point
     where we actually require it, which is typically when we throw an exception.

This greatly speeds up Tripy execution in general, including our tests:
Before:
```
=================== 1691 passed, 54 skipped, 2549 deselected in 311.22s (0:05:11) ==================
=
```

After:
```
===================== 1691 passed, 54 skipped, 2549 deselected in 64.83s (0:01:04) =====================
```