### PR TITLE
[Tripy][Bugfix] Ensure shape `__eq__` works with different lengths

### DIFF
--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -445,14 +445,20 @@ class TestShape:
         a = tp.Shape([4, 5])
         if isinstance(other_values, np.ndarray):
             pytest.skip("numpy array cannot be implicitly cast to Shape type")
-        assert isinstance(a == other_values, bool)
+        eq = a == other_values
+        assert isinstance(eq, bool)
+        assert eq
 
     def test_shape_inequality(self):
         a = tp.Shape([1, 2, 3])
         b = tp.Shape([1, 4, 5])
         assert a != b
 
-    def test_shape_inequality_different_ranks(self):
+    def test_shape_inequality_different_lengths(self):
         a = tp.Shape([1])
         b = tp.Shape([1, 2])
         assert a != b
+
+        c = tp.Shape([1, 2, 3])
+        assert a != c
+        assert b != c

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -153,9 +153,7 @@ class Shape(Tensor):
     def __eq__(self, other):
         from tripy.frontend.trace.ops.reduce import all
 
-        # `.shape` will contain a single int. To avoid endlessly calling
-        # Shape.__eq__, we can compare the int's directly using `.data()`
-        if len(self.shape) != len(other.shape):
+        if len(self) != len(other):
             return False
 
         return bool(all(self.as_tensor() == other.as_tensor()))


### PR DESCRIPTION
This PR corrects a small bug with the `__eq__` implementation for `tp.Shape`: The comparison was checking the `len` of the `shape` field of the shape, but it should actually be checking the length of the `tp.Shape` itself. 

Note: The test case that was included in the unit tests worked "by accident" because the shape in it was length 1, which is broadcasted up to other shapes' lengths. Without this change, the test would fail if comparing two shapes of different lengths where neither is length 1.