### PR TITLE
[Tripy] Override `__mul__` for `tp.Shape`s to work like `__mul__` for Python lists

### DIFF
--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -30,7 +30,7 @@ class Shape(Tensor):
     A Shape is a tensor used to represent a tensor shape.
     Shapes are vectors (rank 1) of non-negative integers (using int32 as the datatype).
 
-    Note that Shapes are intended to used in many cases like Python lists, hence `+` acts as concatenation
+    Note that Shapes are intended to be used in many cases like Python lists; hence `+` acts as concatenation
     on Shapes rather than elementwise addition and `*` acts as tiling rather than elementwise multiplication;
     the methods `add` and `multiply` can be used for elementwise addition and multiplication, respectively.
     Additionally, `len` can be used to get the length of a shape.

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -180,10 +180,10 @@ class Shape(Tensor):
     # multiplication for shapes is tiling, not elementwise multiplication
 
     def __mul__(self, other):
+        from tripy.frontend.trace.ops.binary_elementwise import maximum
         from tripy.frontend.trace.ops.expand import expand
         from tripy.frontend.trace.ops.reshape import flatten
         from tripy.frontend.trace.ops.unsqueeze import unsqueeze
-        from tripy.frontend.trace.ops.where import where
 
         # We unsqueeze self into shape [1, len(self)], so giving [other, len(self)] as
         # the argument to expand will result in a shape of [other, len(self)] by
@@ -198,7 +198,7 @@ class Shape(Tensor):
             )
         # note: in Python, if a list is multiplied by a negative number, this is the same as multiplying by 0,
         # so we should clamp the argument
-        other = where(other >= 0, other, Tensor(0))
+        other = maximum(other, 0)
 
         unsqueezed = unsqueeze(self, 0)
         tiled = expand(unsqueezed, [other, len(self)])


### PR DESCRIPTION
Since we are treating `tp.Shape` more like a `Sequence` than a `Tensor`, we can treat `*` similarly to `+` and have a separate `multiply` to do elementwise multiplication while treating `*` as tiling.

This PR also improves the doc comment for `Shape`, so that the generated doc page clearly explains how `+` and `*` work differently compared to `Tensor`.