### PR TITLE
Adds `repeat` API, various other fixes

### DIFF
--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -27,7 +27,8 @@ from textwrap import indent
 from tests import helper
 
 import tripy as tp
-from tripy.constraints import TYPE_VERIFICATION, FUNC_W_DOC_VERIF
+from tripy.common.datatype import DATA_TYPES
+from tripy.constraints import FUNC_W_DOC_VERIF, TYPE_VERIFICATION
 
 PARAM_PAT = re.compile(":param .*?:")
 
@@ -206,7 +207,17 @@ def process_docstring(app, what, name, obj, options, lines):
                 for type_name, dt in type_dict.items():
                     blocks.insert(
                         index,
-                        f"    - **{type_name}**: :class:`" + "`, :class:`".join(set(dt)) + "`",
+                        f"    - **{type_name}**: :class:`"
+                        + "`, :class:`".join(
+                            sorted(
+                                set(dt),
+                                key=lambda dtype: (
+                                    tuple(typ.__name__ for typ in DATA_TYPES[dtype].__bases__),
+                                    DATA_TYPES[dtype].itemsize,
+                                ),
+                            )
+                        )
+                        + "`",
                     )
                     index += 1
                 blocks.insert(index, "\n")

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -231,7 +231,7 @@ def process_docstring(app, what, name, obj, options, lines):
                     blocks[index] = (
                         f"{block[0:add_text_index]}[dtype=\ **{TYPE_VERIFICATION[unqual_name].dtype_constraints[param_name]}**\ ] {block[add_text_index:]}"
                     )
-            if re.search(r":returns:", block):
+            if TYPE_VERIFICATION[unqual_name].return_dtype is not None and re.search(r":returns:", block):
                 add_text_index = re.search(r":returns:", block).span()[1] + 1
                 # Add dtype constraint to start of returns description.
                 blocks[index] = (

--- a/tripy/tests/frontend/ops/test_repeat.py
+++ b/tripy/tests/frontend/ops/test_repeat.py
@@ -1,0 +1,14 @@
+from tests import helper
+import tripy as tp
+
+
+class TestRepeat:
+    def test_invalid_dim_fails(self):
+        a = tp.ones((2, 2))
+        with helper.raises(tp.TripyException, "Dimension argument is out of bounds."):
+            tp.repeat(a, 2, dim=4)
+
+    def test_negative_repeats_fails(self):
+        a = tp.ones((2, 2))
+        with helper.raises(tp.TripyException, "`repeats` value must be non-negative."):
+            tp.repeat(a, -1, dim=0)

--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -102,7 +102,7 @@ class TestShape:
         assert isinstance(new_shape.trace_tensor.producer, Concatenate)
         assert cp.from_dlpack(new_shape).get().tolist() == values + appended
 
-    @pytest.mark.parametrize("constructor", [lambda x: x, tp.Tensor, np.array])
+    @pytest.mark.parametrize("constructor", [lambda x: x, tp.Tensor])
     @pytest.mark.parametrize("factor", [-1, 0, 1, 2])
     def test_mul_override(self, values, constructor, factor):
         s = tp.Shape(values)
@@ -113,7 +113,7 @@ class TestShape:
         assert cp.from_dlpack(new_shape).get().tolist() == expected
         assert cp.from_dlpack(rmul).get().tolist() == expected
 
-    @pytest.mark.parametrize("constructor", [lambda x: x, tp.Tensor, np.array])
+    @pytest.mark.parametrize("constructor", [lambda x: x, tp.Tensor])
     @pytest.mark.parametrize("factor", [-1, 0, 1, 2])
     def test_mul_empty_shape(self, constructor, factor):
         s = tp.Shape([])

--- a/tripy/tests/integration/test_repeat.py
+++ b/tripy/tests/integration/test_repeat.py
@@ -1,0 +1,24 @@
+import tripy as tp
+
+import pytest
+import numpy as np
+
+
+class TestRepeat:
+    @pytest.mark.parametrize(
+        "repeats,dim",
+        [
+            (1, 0),
+            (2, 0),
+            (2, -1),
+            (2, 1),
+            (0, 1),
+        ],
+    )
+    def test_repeat(self, repeats, dim):
+        inp = np.arange(4, dtype=np.int32).reshape((2, 2))
+
+        out = tp.repeat(tp.Tensor(inp), repeats, dim)
+        expected = np.repeat(inp, repeats, dim)
+
+        assert np.array_equal(np.from_dlpack(tp.copy(out, device=tp.device("cpu"))), expected)

--- a/tripy/tests/integration/test_unsqueeze.py
+++ b/tripy/tests/integration/test_unsqueeze.py
@@ -23,16 +23,15 @@ import tripy as tp
 
 
 class TestUnsqueezeOp:
-    @pytest.mark.parametrize("axis", [0, 2, 3])
+    @pytest.mark.parametrize("axis", [-1, 0, 2])
     def test_unsqueeze_dynamic_op(self, axis):
         def func(a):
             return tp.unsqueeze(a, dim=axis)
 
-        # TODO: DS blocked on mlir-tensorrt #635
-        # compiler = tp.Compiler(func)
-        # compiler.compile(tp.InputInfo(([2, 4, 6], 2, 2, 3), dtype=tp.float32))
-
         inp = np.ones((4, 2, 2, 3), dtype=np.float32)
 
         out = func(tp.Tensor(inp))
-        assert tp.allclose(out, tp.Tensor(np.expand_dims(inp, axis=axis)))
+        ref_out = np.expand_dims(inp, axis=axis)
+        assert tp.allclose(out, tp.Tensor(ref_out))
+
+        assert out.shape == ref_out.shape

--- a/tripy/tests/spec_verification/object_builders.py
+++ b/tripy/tests/spec_verification/object_builders.py
@@ -110,6 +110,7 @@ default_constraints_all = {
     "ones": {"shape": tp.Tensor([3, 2])},
     "zeros": {"shape": tp.Tensor([3, 2])},
     "arange": {"start": 0, "stop": 5},
+    "repeat": {"repeats": 2, "dim": 0},
 }
 
 

--- a/tripy/tests/spec_verification/test_dtype_constraints.py
+++ b/tripy/tests/spec_verification/test_dtype_constraints.py
@@ -17,14 +17,16 @@
 
 
 import inspect
-from typing import List
-from tripy.common.datatype import DATA_TYPES
 import itertools
+from typing import List
+
 import pytest
+from tests import helper
 from tests.spec_verification.object_builders import create_obj
-from tripy.constraints import TYPE_VERIFICATION, RETURN_VALUE
+
 import tripy as tp
-from contextlib import ExitStack
+from tripy.common.datatype import DATA_TYPES
+from tripy.constraints import RETURN_VALUE, TYPE_VERIFICATION
 
 
 def _method_handler(func_name, kwargs, func_obj, api_call_locals):
@@ -59,9 +61,8 @@ def _method_handler(func_name, kwargs, func_obj, api_call_locals):
     print("API call: ", func_name, ", with parameters: ", kwargs)
 
 
-# Create list of all test that will be run.
-pos_func_list = []
-neg_func_list = []
+DTYPE_CONSTRAINT_CASES = []
+
 for func_name, (
     func_obj,
     inputs,
@@ -93,6 +94,7 @@ for func_name, (
         # Get all dtypes for negative test case.
         total_dtypes = set(map(str, DATA_TYPES.values()))
         negative_test_dtypes[name] = list(total_dtypes - pos_dtypes)
+
     for positive_case in [True, False]:
         if positive_case:
             dtype_lists_list = [positive_test_dtypes]
@@ -106,6 +108,7 @@ for func_name, (
                     if name_temp != name_not_equal:
                         temp_dict[name_not_equal] = total_dtypes
                 dtype_lists_list.append(temp_dict)
+
         for dtype_lists in dtype_lists_list:
             for combination in itertools.product(*(dtype_lists.values())):
                 # Create a tuple with keys and corresponding elements.
@@ -116,34 +119,24 @@ for func_name, (
                         exception = True
                         positive_case = False
                 ids = [f"{dtype_name}={dtype}" for dtype_name, dtype in namespace.items()]
-                if positive_case:
-                    pos_func_list.append(
-                        (
-                            func_name,
-                            func_obj,
-                            inputs,
-                            return_dtype,
-                            namespace,
-                            func_name + "_valid: " + ", ".join(ids),
-                        )
+                DTYPE_CONSTRAINT_CASES.append(
+                    (
+                        func_name,
+                        func_obj,
+                        inputs,
+                        return_dtype,
+                        namespace,
+                        positive_case,
+                        func_name + ("-valid" if positive_case else "-invalid") + ":" + ",".join(ids),
                     )
-                else:
-                    neg_func_list.append(
-                        (
-                            func_name,
-                            func_obj,
-                            inputs,
-                            return_dtype,
-                            namespace,
-                            func_name + "_invalid: " + ", ".join(ids),
-                        )
-                    )
+                )
+
                 if exception:
                     positive_case = True
 
 
 def _run_dtype_constraints_subtest(test_data):
-    func_name, func_obj, inputs, _, namespace, _ = test_data
+    func_name, func_obj, inputs, _, namespace, _, _ = test_data
     kwargs = {}
     # Create all input objects using object_builders.create_obj.
     for param_name, param_type in inputs.items():
@@ -164,20 +157,13 @@ def _run_dtype_constraints_subtest(test_data):
 
 # Positive dtype testing is run during L1 testing.
 @pytest.mark.l1
-@pytest.mark.parametrize("test_data", pos_func_list, ids=lambda val: val[5])
-def test_pos_dtype_constraints(test_data):
-    _, _, _, return_dtype, _, _ = test_data
-    api_call_locals, namespace = _run_dtype_constraints_subtest(test_data)
-    if isinstance(api_call_locals[RETURN_VALUE], tp.Tensor):
-        assert api_call_locals[RETURN_VALUE].dtype == namespace[return_dtype]
-
-
-# Run xfail test cases only during L1 testing.
-@pytest.mark.l1
-@pytest.mark.parametrize("test_data", neg_func_list, ids=lambda val: val[5])
-def test_neg_dtype_constraints(test_data):
-    _, _, _, return_dtype, _, _ = test_data
-    with pytest.raises(Exception):
+@pytest.mark.parametrize("test_data", DTYPE_CONSTRAINT_CASES, ids=lambda val: val[-1])
+def test_dtype_constraints(test_data):
+    _, _, _, return_dtype, _, positive_case, _ = test_data
+    if positive_case:
         api_call_locals, namespace = _run_dtype_constraints_subtest(test_data)
         if isinstance(api_call_locals[RETURN_VALUE], tp.Tensor):
             assert api_call_locals[RETURN_VALUE].dtype == namespace[return_dtype]
+    else:
+        with helper.raises(Exception):
+            api_call_locals, namespace = _run_dtype_constraints_subtest(test_data)

--- a/tripy/tripy/common/datatype.py
+++ b/tripy/tripy/common/datatype.py
@@ -53,23 +53,28 @@ class BaseDtype(metaclass=dtype):
     The base class for all data types supported by tripy.
     """
 
-    pass
+    name = "BaseDtype"
+    itemsize = -1
 
 
+@export.public_api(document_under="datatype.rst", autodoc_options=[":no-show-inheritance:"])
 class integer(BaseDtype):
     """
     The base class for all integer data types.
     """
 
-    pass
+    name = "integer"
+    itemsize = -1
 
 
+@export.public_api(document_under="datatype.rst", autodoc_options=[":no-show-inheritance:"])
 class floating(BaseDtype):
     """
     The base class for all floating-point data types.
     """
 
-    pass
+    name = "floating"
+    itemsize = -1
 
 
 # We use `__all__` to control what is exported from this file. `import *` will only pull in objects that are in `__all__`.

--- a/tripy/tripy/constraints.py
+++ b/tripy/tripy/constraints.py
@@ -45,7 +45,7 @@ def dtype_info(
     """
 
     def decorator(func_obj):
-        return_dtype = dtype_constraints.get(RETURN_VALUE, -1)
+        return_dtype = dtype_constraints.get(RETURN_VALUE, None)
         func_name = func_obj.__qualname__ if not function_name else function_name
         VerifInfo = namedtuple(
             "VerifInfo", ["obj", "inputs", "dtype_exceptions", "return_dtype", "dtypes", "dtype_constraints"]

--- a/tripy/tripy/flat_ir/ops/add.py
+++ b/tripy/tripy/flat_ir/ops/add.py
@@ -25,5 +25,4 @@ from tripy.flat_ir.ops.base import BaseFlatIROp
 @dataclass(repr=False)
 class AddOp(BaseFlatIROp):
     def to_mlir(self, operands):
-        add_out = stablehlo.AddOp(*operands)
-        return [add_out]
+        return [stablehlo.AddOp(*operands)]

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -16,12 +16,12 @@
 #
 
 from dataclasses import dataclass
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 from tripy import export, utils
 from tripy.common import datatype
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import Parameter, DefaultParameter
+from tripy.frontend.module.parameter import DefaultParameter, Parameter
 
 
 @export.public_api(document_under="operations/modules")
@@ -36,7 +36,7 @@ class LayerNorm(Module):
     where :math:`\bar{x}` is the mean and :math:`\sigma^2` is the variance.
 
     The mean and standard deviation are calculated over the last :math:`D`
-    dimensions, where :math:`D` is the dimension of `normalized_shape`.
+    dimensions, where :math:`D` is the dimension of :math:`\text{normalized_shape}`.
     """
 
     dtype: datatype.dtype
@@ -46,20 +46,23 @@ class LayerNorm(Module):
     r"""Defines the shape of the input tensor that is to be normalized over."""
 
     weight: Parameter
-    r"""The :math:`\gamma` parameter of shape :math:`[\text{normalized_shape}]`."""
+    r"""The :math:`\gamma` parameter of shape :math:`\text{normalized_shape}`."""
 
     bias: Parameter
-    r"""The :math:`\beta` parameter of shape :math:`[\text{normalized_shape}]`."""
+    r"""The :math:`\beta` parameter of shape :math:`\text{normalized_shape}`."""
 
     eps: float
     """A value added to the denominator to prevent division by zero."""
 
-    def __init__(self, normalized_shape: Union[int, Tuple[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5) -> None:
-        """
+    def __init__(
+        self, normalized_shape: Union[int, Tuple[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5
+    ) -> None:
+        r"""
         Args:
             normalized_shape: The size of the feature dimension of the input over which normalization is performed.
+                If a single integer is provided, it will be unsqueezed to a 1 dimensional shape.
             dtype: The data type to use for the weight and bias parameters.
-            eps: :math:\epsilon value to prevent division by zero.
+            eps: :math:`\epsilon` value to prevent division by zero.
 
         .. code-block:: python
             :linenos:

--- a/tripy/tripy/frontend/ops/relu.py
+++ b/tripy/tripy/frontend/ops/relu.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import tripy as tp
 from tripy import export, constraints
 
 
@@ -50,5 +49,8 @@ def relu(input: "tripy.Tensor") -> "tripy.Tensor":
         assert tp.allclose(output, tp.Tensor(torch.nn.functional.relu(t)))
 
     """
-    zeros = tp.zeros((1,), dtype=input.dtype)
-    return tp.maximum(zeros, input)
+    from tripy.frontend.ops import zeros
+    from tripy.frontend.trace.ops.binary_elementwise import maximum
+
+    mask = zeros((1,), dtype=input.dtype)
+    return maximum(mask, input)

--- a/tripy/tripy/frontend/ops/repeat.py
+++ b/tripy/tripy/frontend/ops/repeat.py
@@ -1,0 +1,78 @@
+from tripy import constraints, export
+from tripy.common.exception import raise_error
+from tripy.frontend import utils as frontend_utils
+
+
+@export.public_api(document_under="operations/functions")
+@constraints.dtype_info(
+    dtype_variables={
+        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+    },
+    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
+)
+@frontend_utils.process_dim
+def repeat(input: "tripy.Tensor", repeats: int, dim: int) -> "tripy.Tensor":
+    """
+    Repeats each element of a tensor after itself along the specified dimension.
+
+    Args:
+        input: The input tensor.
+        repeats: The number of times to repeat each element.
+        dim: The dimension along which to repeat values.
+
+    Returns:
+        The new tensor.
+
+    .. code-block:: python
+        :linenos:
+        :caption: 1D tensor
+
+        inp = tp.arange(4, dtype=tp.int32)
+        out0 = tp.repeat(inp, 2, dim=0)
+
+        np_inp = np.from_dlpack(tp.copy(inp, device=tp.device("cpu"))) # doc: omit
+        ref_out0 = np.repeat(np_inp, 2, 0) # doc: omit
+        assert np.array_equal(ref_out0, np.from_dlpack(tp.copy(out0, device=tp.device("cpu"))))
+
+
+    .. code-block:: python
+        :linenos:
+        :caption: 2D tensor
+
+        inp = tp.reshape(tp.arange(4, dtype=tp.int32), (2, 2))
+        out0 = tp.repeat(inp, 2, dim=0)
+        out1 = tp.repeat(inp, 2, dim=1)
+
+        np_inp = np.from_dlpack(tp.copy(inp, device=tp.device("cpu"))) # doc: omit
+        ref_out0 = np.repeat(np_inp, 2, 0) # doc: omit
+        assert np.array_equal(ref_out0, np.from_dlpack(tp.copy(out0, device=tp.device("cpu"))))
+
+        ref_out1 = np.repeat(np_inp, 2, 1) # doc: omit
+        assert np.array_equal(ref_out1, np.from_dlpack(tp.copy(out1, device=tp.device("cpu"))))
+    """
+    from tripy.frontend.trace.ops.expand import expand
+    from tripy.frontend.trace.ops.reshape import reshape
+    from tripy.frontend.trace.ops.unsqueeze import unsqueeze
+
+    if repeats < 0:
+        raise_error("`repeats` value must be non-negative.", [f"Got: repeats={repeats}."])
+
+    # By constraining repeats to be a single integer, we can use a very
+    # simple implementation for repeat.
+    # Imagine we have:
+    #   a = [1, 2]
+    #   out = tp.repeat(a, 2, dim=0)
+    #
+    # We achieve this by:
+    #
+    # [1, 2] -> [[1],  -> [[1, 1],  -> [1, 1, 2, 2]
+    #            [2],]     [2, 2],]
+    #
+    out = unsqueeze(input, dim + 1)
+    out = expand(out, input.shape[: dim + 1] + [repeats] + input.shape[dim + 1 :])
+
+    repeat_mask = [1] * input.rank
+    repeat_mask[dim] = repeats
+    new_shape = input.shape.multiply(repeat_mask)
+    out = reshape(out, new_shape)
+    return out

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -26,7 +26,6 @@ from tripy.frontend.trace.ops.fill import full, full_like
 from tripy.frontend.trace.ops.iota import iota, iota_like
 from tripy.frontend.trace.ops.where import where
 from tripy.frontend import utils as frontend_utils
-from tripy.common.datatype import DATA_TYPES
 
 
 @export.public_api(document_under="operations/initializers")

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -202,7 +202,8 @@ def all(
         :caption: Example
 
         input = tp.Tensor([True, True], dtype=tp.bool)
-        assert tp.all(input) == tp.Tensor([True], dtype=tp.bool)
+        out = tp.all(input)
+        assert bool(out)
     """
     return _reduce_impl(input, Reduce.Kind.AND, dim, keepdim)
 
@@ -235,7 +236,8 @@ def any(
         :caption: Example
 
         input = tp.Tensor([True, False], dtype=tp.bool)
-        assert tp.any(input) == tp.Tensor([True], dtype=tp.bool)
+        out = tp.any(input)
+        assert bool(out)
     """
     return _reduce_impl(input, Reduce.Kind.OR, dim, keepdim)
 
@@ -427,7 +429,7 @@ def var(
     return mean_impl(sub, dim=dim, keepdim=keepdim, apply_to_divisor=lambda x: maximum(x - correction, 0))
 
 
-def _arg_min_max_impl(tensor: "tripy.Tensor", kind: ArgMinMax.Kind, dim: int, keepdim: bool):
+def _arg_min_max_impl(tensor: "tripy.Tensor", kind: ArgMinMax.Kind, dim: Optional[int], keepdim: bool):
     from tripy.frontend.trace.ops.iota import iota_like
     from tripy.frontend.trace.ops.reshape import reshape
     from tripy.frontend.trace.ops.unsqueeze import unsqueeze

--- a/tripy/tripy/frontend/trace/ops/unsqueeze.py
+++ b/tripy/tripy/frontend/trace/ops/unsqueeze.py
@@ -65,11 +65,12 @@ def unsqueeze_two_operand(input, result_shape, dim):
 def unsqueeze(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":
     """
     Returns a new tensor with the contents of the input tensor with a
-    singleton dimension inserted at the specified position.
+    singleton dimension inserted before the specified axis.
 
     Args:
         input: The input tensor.
-        dim: index to insert the singleton dimension.
+        dim: index before which to insert the singleton dimension.
+            A negative dimension will be converted to ``dim = dim + input.rank + 1``.
 
     Returns:
         A new tensor.
@@ -85,7 +86,7 @@ def unsqueeze(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":
     """
     from tripy.frontend.trace.ops.concatenate import concatenate
 
-    from tripy.frontend import Shape, Tensor
+    from tripy.frontend import Shape
 
     if dim < 0:
         dim = dim + input.rank + 1

--- a/tripy/tripy/utils/utils.py
+++ b/tripy/tripy/utils/utils.py
@@ -468,3 +468,33 @@ def merge_function_arguments(func, *args, **kwargs):
     all_args = get_positional_arg_names(func, *args)
     all_args.extend(kwargs.items())
     return all_args
+
+
+def get_arg_by_name(name, func, *args, **kwargs):
+    if name in kwargs:
+        return kwargs[name]
+
+    args = dict(get_positional_arg_names(func, *args))
+    if name in args:
+        return args[name]
+
+    assert False, f"No such argument: {name}"
+
+
+def modify_arg(name, modify_func, func, *args, **kwargs):
+    """
+    Modifies an argument corresponding to the provided name.
+    `modify_func` should be a function that accepts the argument and returns the modified argument.
+    """
+    if name in kwargs:
+        kwargs[name] = modify_func(kwargs[name])
+        return args, kwargs
+
+    all_args = get_positional_arg_names(func, *args)
+    args = list(args)
+    for index, (arg_name, _) in enumerate(all_args):
+        if name == arg_name:
+            args[index] = modify_func(args[index])
+            return args, kwargs
+
+    assert False, f"No such argument: {name}"


### PR DESCRIPTION
- Updates unsqueeze test to check that shape is correct

- Updates docstrings in some functions to print outputs, disables `bool` in allclose

- Miscellaneous bug fixes in various operations
    
- Adds a `tp.repeat` API. The API is currently constrained to accepting only a single integer value for
     `repeats` since this greatly simplifies the implementation.
    
- Introduces a `process_dim` decorator which handles negative dimensions in API functions.
    
- Various minor fixes to dtype constraint checking. Also merges the positive/negative
     dtype constraints test into one so it's easier to run all the tests for a given op.