### PR TITLE
Re-introduce tp.Stream

### DIFF
--- a/tripy/tests/backend/test_stream.py
+++ b/tripy/tests/backend/test_stream.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import gc, sys
+import tripy as tp
+import cupy as cp
+
+
+def test_default_stream_creation():
+    default_stream1 = tp.Stream.get_default_stream()
+    default_stream2 = tp.Stream.get_default_stream()
+    assert default_stream1 == default_stream2
+
+
+def test_new_streams():
+    stream1 = tp.Stream()
+    stream2 = tp.Stream()
+    assert stream1 != stream2
+    assert stream1 != tp.Stream().get_default_stream()
+
+
+def test_enqueue_work_on_stream():
+    linear = tp.Linear(25, 30)
+    compiler = tp.Compiler(linear)
+
+    compiled_linear = compiler.compile(tp.InputInfo((2, 25), dtype=tp.float32))
+
+    a = tp.ones((2, 25), dtype=tp.float32)
+
+    stream = tp.Stream()
+    compiled_linear.stream = stream
+    out = compiled_linear(a)
+    # stream sync below is not required since from_dlpack method will eval() the tensor which will call stream sync anyway.
+    compiled_linear.stream.synchronize()
+    assert cp.array_equal(cp.from_dlpack(out), cp.from_dlpack(linear(a)))

--- a/tripy/tests/backend/test_stream.py
+++ b/tripy/tests/backend/test_stream.py
@@ -12,20 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 import pytest
 import gc, sys
 import tripy as tp
@@ -33,8 +19,8 @@ import cupy as cp
 
 
 def test_default_stream_creation():
-    default_stream1 = tp.Stream.get_default_stream()
-    default_stream2 = tp.Stream.get_default_stream()
+    default_stream1 = tp.default_stream()
+    default_stream2 = tp.default_stream()
     assert default_stream1 == default_stream2
 
 
@@ -42,7 +28,7 @@ def test_new_streams():
     stream1 = tp.Stream()
     stream2 = tp.Stream()
     assert stream1 != stream2
-    assert stream1 != tp.Stream().get_default_stream()
+    assert stream1 != tp.default_stream()
 
 
 def test_enqueue_work_on_stream():
@@ -52,6 +38,10 @@ def test_enqueue_work_on_stream():
     compiled_linear = compiler.compile(tp.InputInfo((2, 25), dtype=tp.float32))
 
     a = tp.ones((2, 25), dtype=tp.float32)
+
+    out = compiled_linear(a)
+    tp.default_stream().synchronize()
+    assert cp.array_equal(cp.from_dlpack(out), cp.from_dlpack(linear(a)))
 
     stream = tp.Stream()
     compiled_linear.stream = stream

--- a/tripy/tripy/backend/mlir/executor.py
+++ b/tripy/tripy/backend/mlir/executor.py
@@ -30,15 +30,14 @@ from tripy.utils import log_time, make_tuple
 class Executor:
     def __init__(self, executable: runtime.Executable) -> None:
         from tripy.backend.mlir.utils import MLIRRuntimeClient
-        from tripy.backend.compiler_api import Stream
+        from tripy.backend.compiler_api import default_stream
 
         self.runtime_client = MLIRRuntimeClient()
-        self.stream = self.runtime_client.create_stream()
         session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
         self.session = runtime.RuntimeSession(session_options, executable)
         self.device = self.runtime_client.get_devices()[0]  # Assume a single device is available.
         self.signature = executable.get_signature("main")
-        self._stream = Stream.get_default_stream()
+        self.stream = default_stream()
 
     def _create_shape_memref(self, shape):
         from tripy.common.utils import convert_list_to_array
@@ -47,13 +46,13 @@ class Executor:
         if len(shape) == 0:
             # create an empty memref
             return self.runtime_client.create_memref(
-                shape=(0,),
-                dtype=runtime.runtime.ScalarTypeCode.i64,
+                shape=(0,), dtype=runtime.runtime.ScalarTypeCode.i64, stream=self.stream._active_cuda_stream
             )
         return self.runtime_client.create_memref(
             convert_list_to_array(shape, datatype.int64),
             shape=(len(shape),),
             dtype=runtime.ScalarTypeCode.i64,
+            stream=self.stream._active_cuda_stream,
         )
 
     def _get_inputs_runtime_shape(self, inputs):
@@ -174,7 +173,10 @@ class Executor:
 
         # Allocate output memory and store buffer pointers.
         outputs = [
-            create_empty_memref(shape=info.shape, dtype=info.dtype, device=info.device) for info in out_tensor_info
+            create_empty_memref(
+                shape=info.shape, dtype=info.dtype, device=info.device, stream=self.stream._active_cuda_stream
+            )
+            for info in out_tensor_info
         ]
 
         out_args = []
@@ -186,6 +188,7 @@ class Executor:
                 memref = self.runtime_client.copy_to_device(
                     host_memref=memref,
                     device=self.runtime_client.get_devices()[0],
+                    stream=self.stream._active_cuda_stream,
                 )
             if not memref:
                 raise_error("Could not allocate output memref", details=memref.error_details)
@@ -193,7 +196,7 @@ class Executor:
 
         # Execute and populate device pointers.
         self.session.execute_function(
-            "main", in_args=in_args, out_args=out_args, stream=self._stream._active_cuda_stream
+            "main", in_args=in_args, out_args=out_args, stream=self.stream._active_cuda_stream
         )
 
         # For outputs that were on the host, do the copy back
@@ -203,7 +206,7 @@ class Executor:
                 self.runtime_client.copy_to_host(
                     device_memref=out_args[idx],
                     existing_host_memref=outputs[idx],
-                    stream=None,
+                    stream=self.stream._active_cuda_stream,
                 )
 
         return outputs

--- a/tripy/tripy/backend/mlir/memref.py
+++ b/tripy/tripy/backend/mlir/memref.py
@@ -23,7 +23,7 @@ from tripy.common import utils as common_utils
 import mlir_tensorrt.runtime.api as runtime
 
 
-def create_empty_memref(shape, dtype, device=tp_device("gpu")):
+def create_empty_memref(shape, dtype, device=tp_device("gpu"), stream=None):
     """
     Creates an empty memref, used for allocating memory.
     """
@@ -33,6 +33,7 @@ def create_empty_memref(shape, dtype, device=tp_device("gpu")):
         shape=list(shape),
         dtype=mlir_dtype,
         device=mlirtrt_device,
+        stream=stream,
     )
 
 
@@ -51,9 +52,7 @@ def tolist(memref):
     """
     memref_value = memref
     if memref.address_space == runtime.PointerType.device:
-        memref_value = mlir_utils.MLIRRuntimeClient().copy_to_host(
-            device_memref=memref,
-        )
+        memref_value = mlir_utils.MLIRRuntimeClient().copy_to_host(device_memref=memref)
     try:
         return memoryview(memref_value).tolist()
     except NotImplementedError as e:

--- a/tripy/tripy/frontend/tensor.py
+++ b/tripy/tripy/frontend/tensor.py
@@ -30,6 +30,7 @@ from tripy.frontend.trace.ops import Storage
 
 import mlir_tensorrt.runtime.api as runtime
 
+
 class TensorMeta(type):
     def __new__(cls, name, bases, dct):
         new = type.__new__(cls, name, bases, dct)
@@ -188,6 +189,7 @@ class Tensor(metaclass=TensorMeta):
         # Upon computing the value of this tensor, we switch it to have a `Storage`
         # parameter so that it does not need to be computed again.
         data = executor.execute([out.device for out in flat_ir.outputs])
+        executor._stream.synchronize()
         assert len(data) == 1, "Expects only one output from mlir_tensorrt.compiler executor"
         data = data[0]
         # Data is present now. Assign the underlying device type.


### PR DESCRIPTION
Changes in this MR:

1. Adds `tp.Stream` interface. (supports streams with priority 0 as of now). Allows getting default stream.
2. Tripy execution will be async by default and user is expected to call `stream.synchronize()`.
3. In case the user does not set stream for execution, Tripy will use default stream. The user is still expected to call synchronize and can call synchronize on the class which invokes sync on default stream. (ie. `tp.synchronize()`.