### PR TITLE
Fix dtype constraints and copyright hook

### DIFF
--- a/tripy/.pre-commit-config.yaml
+++ b/tripy/.pre-commit-config.yaml
@@ -22,3 +22,5 @@ repos:
         language: python
         stages: [pre-commit]
         files: \.py$
+        verbose: true
+        require_serial: true

--- a/tripy/Dockerfile
+++ b/tripy/Dockerfile
@@ -27,7 +27,8 @@ COPY pyproject.toml /tripy/pyproject.toml
 
 RUN pip install build .[docs,dev,test] \
     -f https://nvidia.github.io/TensorRT-Incubator/packages.html \
-    --extra-index-url https://download.pytorch.org/whl
+    --extra-index-url https://download.pytorch.org/whl \
+    --extra-index-url https://pypi.nvidia.com
 
 # Installl lldb for debugging purposes in Tripy container.
 # The LLVM version should correspond on LLVM_VERSION specified in https://github.com/NVIDIA/TensorRT-Incubator/blob/main/mlir-tensorrt/build_tools/docker/Dockerfile#L30.

--- a/tripy/docs/pre0_user_guides/01-quantization.md
+++ b/tripy/docs/pre0_user_guides/01-quantization.md
@@ -62,7 +62,7 @@ We need to perform another step called calibration to compute the correct scales
 There are many ways to do calibration, one of which is using the `nvidia-modelopt` toolkit. To install it, run:
 
 ```sh
-python3 -m pip install --extra-index-url https://pypi.nvidia.com nvidia-modelopt==0.11.0 transformers datasets
+python3 -m pip install --extra-index-url https://pypi.nvidia.com nvidia-modelopt==0.11.0 transformers==4.44.2 datasets==2.21.0
 ```
 
 First, let's get the pre-trained GPT model from hugging face:

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -44,6 +44,10 @@ docs = [
   "myst-parser==2.0.0",
   "sphinxcontrib-mermaid==0.9.2",
   "tripy[doc_test_common]",
+  # Needed for guides:
+  "nvidia-modelopt==0.11.0",
+  "transformers==4.44.2",
+  "datasets==2.21.0",
 ]
 test = [
   "pytest==7.1.3",

--- a/tripy/tests/frontend/ops/test_repeat.py
+++ b/tripy/tests/frontend/ops/test_repeat.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from tests import helper
 import tripy as tp
 

--- a/tripy/tests/integration/test_repeat.py
+++ b/tripy/tests/integration/test_repeat.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import tripy as tp
 
 import pytest

--- a/tripy/tools/add_copyright.py
+++ b/tripy/tools/add_copyright.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tripy/tools/add_copyright.py
+++ b/tripy/tools/add_copyright.py
@@ -1,6 +1,5 @@
-
 #
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,31 +15,34 @@
 # limitations under the License.
 #
 
+import argparse
 import os
 import re
 import subprocess
-import sys
 from datetime import datetime
 
 current_year = str(datetime.now().year)
 
+
 def get_license_header():
-    for license_path in ['LICENSE', 'tripy/LICENSE']:
+    for license_path in ["LICENSE", "tripy/LICENSE"]:
         if os.path.exists(license_path):
-            with open(license_path, 'r', encoding='utf-8') as license_file:
+            with open(license_path, "r", encoding="utf-8") as license_file:
                 return license_file.read().strip()
-    raise FileNotFoundError('LICENSE file not found in the current directory or tripy folder')
+    raise FileNotFoundError("LICENSE file not found in the current directory or tripy folder")
+
 
 license_text = get_license_header()
 
+
 def update_file(file_path):
-    with open(file_path, 'r+', encoding='utf-8') as file:
+    with open(file_path, "r+", encoding="utf-8") as file:
         content = file.read()
-        copyright_pattern = r"Copyright \(c\) 1993-\d{4}"
+        copyright_pattern = r"Copyright \(c\) \d{4}"
         if re.search(copyright_pattern, content):
-            updated_content = re.sub(copyright_pattern, f'Copyright (c) 1993-{current_year}', content)
+            updated_content = re.sub(copyright_pattern, f"Copyright (c) {current_year}", content)
         else:
-            updated_content = license_text + '\n' + content
+            updated_content = license_text + "\n" + content
 
         if content != updated_content:
             file.seek(0)
@@ -49,27 +51,29 @@ def update_file(file_path):
             return True
     return False
 
-def get_files(mode):
-    if mode == 'new':
-        command = ['git', 'diff', '--cached', '--name-only', '--diff-filter=A']
-    elif mode == 'all':
-        command = ['git', 'ls-files']
+
+def get_files(args):
+    if args.files:
+        result = args.files
     else:
-        raise ValueError("Invalid mode. Use 'new' or 'all'.")
-    
-    result = subprocess.run(command, capture_output=True, text=True)
-    return [f for f in result.stdout.splitlines() if f.endswith('.py') and f.startswith('tripy/')]
+        command = ["git", "ls-files"]
+        result = subprocess.run(command, capture_output=True, text=True).stdout.splitlines()
+    return [f for f in result if f.endswith(".py") and f.startswith("tripy/")]
 
-def main(mode):
-    files = get_files(mode)
+
+def main():
+    parser = argparse.ArgumentParser(description="Adds copyright headers to source files")
+    parser.add_argument("files", nargs="*")
+
+    args, _ = parser.parse_known_args()
+    files = get_files(args)
     updated_files = [f for f in files if update_file(f)]
-    
-    if mode == 'new' and updated_files:
-        subprocess.run(['git', 'add'] + updated_files)
-    
-    print(f"Updated {len(updated_files)} out of {len(files)} Python files in '{mode}' mode.")
 
-if __name__ == '__main__':
-    import sys
-    mode = 'all' if len(sys.argv) > 1 and sys.argv[1] == 'all' else 'new'
-    main(mode)
+    if updated_files:
+        subprocess.run(["git", "add"] + updated_files)
+
+    print(f"Updated {len(updated_files)} out of {len(files)} Python files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tripy/tripy/frontend/ops/repeat.py
+++ b/tripy/tripy/frontend/ops/repeat.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from tripy import constraints, export
 from tripy.common.exception import raise_error
 from tripy.frontend import utils as frontend_utils


### PR DESCRIPTION
- Updates copyright hook to update existing files    
    - Updates the copyright hook to accept file arguments directly from `pre-commit`.  
    - Updates copyright hook to also update existing files when required.
- Fixes an error in negative dtype constraint tests where output types were not checked
- Adds license to repeat files
