### PR TITLE
Enables data type checking in the API

### DIFF
--- a/.github/workflows/tripy-l0.yml
+++ b/.github/workflows/tripy-l0.yml
@@ -8,6 +8,7 @@ on:
     paths: ['tripy/**']
 
 env:
+  REGISTRY: ghcr.io
   DEFAULT_IMAGE: ghcr.io/nvidia/tensorrt-incubator/tripy:latest
   NEW_TEST_IMAGE: test-image:latest
 
@@ -23,22 +24,35 @@ jobs:
       id: filter
       with:
         filters: |
-          new_container:
+          local_container:
             - 'tripy/Dockerfile'
             - 'tripy/pyproject.toml'
 
-    - if: steps.filter.outputs.new_container == 'true'
+    - if: steps.filter.outputs.local_container == 'true'
       run: echo "l0_image=${{ env.NEW_TEST_IMAGE }}" >> "$GITHUB_ENV"
-    - if: steps.filter.outputs.new_container != 'true'
+    - if: steps.filter.outputs.local_container != 'true'
       run: echo "l0_image=${{ env.DEFAULT_IMAGE }}" >> "$GITHUB_ENV"
 
+    # Login against a Docker registry
+    # https://github.com/docker/login-action
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: build-new-container
-      if: steps.filter.outputs.new_container == 'true'
+      if: steps.filter.outputs.local_container == 'true'
       uses: docker/build-push-action@v6
       with:
         context: tripy/
         tags: ${{ env.NEW_TEST_IMAGE }}
         push: false
+
+    - name: pull-latest-container
+      if: steps.filter.outputs.local_container != 'true'
+      run: docker pull ${{ env.l0_image }}
 
     - name: build-docs
       uses: addnab/docker-run-action@v3

--- a/tripy/tests/flat_ir/test_flat_ir.py
+++ b/tripy/tests/flat_ir/test_flat_ir.py
@@ -24,7 +24,7 @@ class TestFlatIR:
         # When we build up a FlatIR with multiple layers, the tensors/ops
         # should be connected to each other - i.e. the producer/inputs fields
         # should let you walk through the entire FlatIR.
-        inp = tp.Tensor([0])
+        inp = tp.Tensor([0], dtype=tp.float32)
 
         b = tp.tanh(inp)
         out = tp.tanh(b)

--- a/tripy/tests/frontend/module/test_embedding.py
+++ b/tripy/tests/frontend/module/test_embedding.py
@@ -33,7 +33,7 @@ class TestEmbedding:
 
         with helper.raises(
             tp.TripyException,
-            match="Index tensor for gather operation should be of int32 type.",
+            match="Unsupported data type for 'gather'.",
             has_stack_info_for=[a],
         ):
             out = linear(a)

--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -459,14 +459,6 @@ class TestShape:
         ):
             tp.Shape(values).multiply(tp.Tensor([values, values]))
 
-    def test_unary_elementwise_fails_at_run_time(self, values):
-        v = tp.exp(tp.Shape(values))
-        with raises(
-            tp.TripyException,
-            match=("'stablehlo.exponential' op operand #0 must be ranked tensor of"),
-        ):
-            v.eval()
-
     def test_shape_equality(self, other_values):
         a = tp.Shape([4, 5])
         if isinstance(other_values, np.ndarray):

--- a/tripy/tests/frontend/trace/ops/test_binary_elementwise.py
+++ b/tripy/tests/frontend/trace/ops/test_binary_elementwise.py
@@ -104,7 +104,7 @@ class TestBinaryElementwise:
         with helper.raises(
             tp.TripyException,
             # Keep the entire error message here so we'll know if the display becomes horribly corrupted.
-            match=r"For operation: '\+', data types for all inputs must match, but got: \[float32, float16\].",
+            match=r"Mismatched data types for '__add__'.",
             has_stack_info_for=[a, b],
         ):
             c = a + b

--- a/tripy/tests/frontend/trace/ops/test_convolution.py
+++ b/tripy/tests/frontend/trace/ops/test_convolution.py
@@ -38,7 +38,7 @@ class TestConvolution:
 
         with helper.raises(
             tp.TripyException,
-            match=r"For operation: 'convolution', data types for all inputs must match, but got: \[float32, float16\].",
+            match=r"Mismatched data types for 'convolution'.",
             has_stack_info_for=[input],
         ):
             output = conv_layer(input)

--- a/tripy/tests/frontend/trace/ops/test_dequantize.py
+++ b/tripy/tests/frontend/trace/ops/test_dequantize.py
@@ -39,7 +39,7 @@ class TestDequantize:
         a = tp.Tensor([1.0, 2.0])
         with helper.raises(
             tp.TripyException,
-            match="Input does not have a valid dtype in dequantize op",
+            match="Unsupported data type for 'dequantize'.",
         ):
             a = tp.dequantize(a, 0.9, tp.float32)
 
@@ -47,7 +47,7 @@ class TestDequantize:
         a = tp.Tensor([2, 4], dtype=tp.int8)
         with helper.raises(
             tp.TripyException,
-            match="Unsupported dtype in dequantize op.",
+            match="Unsupported data type for 'dequantize'.",
         ):
             a = tp.dequantize(a, 0.9, tp.int32)
 

--- a/tripy/tests/frontend/trace/ops/test_gather.py
+++ b/tripy/tests/frontend/trace/ops/test_gather.py
@@ -32,16 +32,15 @@ class TestGather:
         assert isinstance(out, tp.Tensor)
         assert isinstance(out.trace_tensor.producer, Gather)
 
-    @pytest.mark.parametrize("axis", [0, 1, 2])
-    def test_incorrect_dtype(self, axis):
+    def test_incorrect_dtype(self):
         a = tp.Tensor([[[1, 2, 3, 4], [1, 2, 3, 4]], [[1, 2, 3, 4], [1, 2, 3, 4]]])
         index = tp.Tensor(np.zeros(1, dtype=np.float32))
         with helper.raises(
             tp.TripyException,
-            match="Index tensor for gather operation should be of int32 type.",
-            has_stack_info_for=[a, index],
+            match="Unsupported data type for 'gather'.",
+            has_stack_info_for=[index],
         ):
-            b = tp.gather(a, axis, index)
+            b = tp.gather(a, 0, index)
 
     @pytest.mark.parametrize("index_shape", [(1,), (2, 2)])
     @pytest.mark.parametrize("axis", [0, 1, 2])

--- a/tripy/tests/frontend/trace/ops/test_matmul.py
+++ b/tripy/tests/frontend/trace/ops/test_matmul.py
@@ -46,7 +46,9 @@ class TestMatMul:
         a = tp.ones((2, 3), dtype=tp.float32)
         b = tp.ones((3, 2), dtype=tp.float16)
 
-        with helper.raises(tp.TripyException, match="Incompatible input data types.", has_stack_info_for=[a, b]):
+        with helper.raises(
+            tp.TripyException, match="Mismatched data types for '__matmul__'.", has_stack_info_for=[a, b]
+        ):
             c = a @ b
 
     def test_incompatible_1d_shapes_fails(self):

--- a/tripy/tests/frontend/trace/ops/test_quantize.py
+++ b/tripy/tests/frontend/trace/ops/test_quantize.py
@@ -37,7 +37,7 @@ class TestQuantize:
         a = tp.Tensor([1, 2], dtype=tp.int32)
         with helper.raises(
             tp.TripyException,
-            match="Input does not have a valid dtype in quantize op.",
+            match="Unsupported data type for 'quantize'.",
         ):
             a = tp.quantize(a, 0.9, tp.int8)
 
@@ -45,7 +45,7 @@ class TestQuantize:
         a = tp.Tensor([1.0, 2.0])
         with helper.raises(
             tp.TripyException,
-            match="Unsupported dtype in quantize op.",
+            match="Unsupported data type for 'quantize'.",
         ):
             a = tp.quantize(a, 0.9, tp.float16)
 

--- a/tripy/tests/frontend/trace/ops/test_reduce.py
+++ b/tripy/tests/frontend/trace/ops/test_reduce.py
@@ -35,13 +35,13 @@ class TestReduce:
         assert isinstance(a.trace_tensor.producer, Reduce)
 
     def test_all(self):
-        a = tp.ones((2, 3))
+        a = tp.ones((2, 3), dtype=tp.bool)
         a = tp.all(a)
         assert isinstance(a, tp.Tensor)
         assert isinstance(a.trace_tensor.producer, Reduce)
 
     def test_any(self):
-        a = tp.ones((2, 3))
+        a = tp.ones((2, 3), dtype=tp.bool)
         a = tp.any(a)
         assert isinstance(a, tp.Tensor)
         assert isinstance(a.trace_tensor.producer, Reduce)

--- a/tripy/tests/frontend/trace/ops/test_where.py
+++ b/tripy/tests/frontend/trace/ops/test_where.py
@@ -56,7 +56,7 @@ class TestWhere:
         a = tp.ones((2,), dtype=tp.float32)
         b = tp.ones((2,), dtype=tp.float16)
 
-        with helper.raises(tp.TripyException, match="Incompatible input data types.", has_stack_info_for=[a, b, cond]):
+        with helper.raises(tp.TripyException, match="Mismatched data types for 'where'.", has_stack_info_for=[a, b]):
             c = tp.where(cond, a, b)
 
     def test_condition_is_not_bool(self):
@@ -64,9 +64,7 @@ class TestWhere:
         a = tp.ones((2,), dtype=tp.float32)
         b = tp.ones((2,), dtype=tp.float32)
 
-        with helper.raises(
-            tp.TripyException, match="Condition input must have boolean type.", has_stack_info_for=[a, b, cond]
-        ):
+        with helper.raises(tp.TripyException, match="Unsupported data type for 'where'.", has_stack_info_for=[cond]):
             c = tp.where(cond, a, b)
 
     def test_infer_rank(self):
@@ -91,7 +89,7 @@ class TestMaskedFill:
         mask = tp.Tensor([1.0, 2.0, 3.0, 4.0])
 
         with helper.raises(
-            tp.TripyException, match="Condition input must have boolean type.", has_stack_info_for=[a, mask]
+            tp.TripyException, match="Unsupported data type for 'masked_fill'.", has_stack_info_for=[mask]
         ):
             b = tp.masked_fill(a, mask, -1)
 

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -72,6 +72,19 @@ def raises(ExcType: type, match: Optional[str] = None, has_stack_info_for: Seque
         assert expected_stack_info in error_msg, f"Missing stack information for tensor:\n{expected_stack_info}"
 
 
+@contextlib.contextmanager
+def config(name: str, value: Any):
+    """
+    Temporarily changes a configuration option.
+    """
+    old_value = getattr(tp.config, name)
+    try:
+        setattr(tp.config, name, value)
+        yield
+    finally:
+        setattr(tp.config, name, old_value)
+
+
 def check_mlir(mlir, expected):
     # Checks a given MLIR module against a string of the expected program.
     # MLIR indents with 2 spaces; we'll replace it with 4 spaces so that it's

--- a/tripy/tests/spec_verification/object_builders.py
+++ b/tripy/tests/spec_verification/object_builders.py
@@ -24,11 +24,14 @@ import inspect
 
 def tensor_builder(init, dtype, namespace):
     if init is None:
-        return tp.ones(dtype=namespace[dtype], shape=(3, 2))
+        out = tp.ones(dtype=namespace[dtype], shape=(3, 2))
+        out.eval()
+        return out
     elif not isinstance(init, tp.Tensor):
-        assert dtype == None
         return init
-    return tp.cast(init, dtype=namespace[dtype])
+    out = tp.cast(init, dtype=namespace[dtype])
+    out.eval()
+    return out
 
 
 def dtype_builder(init, dtype, namespace):
@@ -37,9 +40,12 @@ def dtype_builder(init, dtype, namespace):
 
 def tensor_list_builder(init, dtype, namespace):
     if init is None:
-        return [tp.ones(shape=(3, 2), dtype=namespace[dtype]) for _ in range(2)]
+        out = [tp.ones(shape=(3, 2), dtype=namespace[dtype]) for _ in range(2)]
     else:
-        return [tp.cast(tens, dtype=namespace[dtype]) for tens in init]
+        out = [tp.cast(tens, dtype=namespace[dtype]) for tens in init]
+    for t in out:
+        t.eval()
+    return out
 
 
 def device_builder(init, dtype, namespace):
@@ -87,11 +93,12 @@ default_constraints_all = {
     "full_like": {"value": 1},
     "flip": {"dim": 1},
     "gather": {"dim": 0, "index": tp.Tensor([1])},
-    "iota": {"shape": tp.Tensor([3])},
+    "iota": {"shape": tp.Tensor([4])},
     "__matmul__": {"self": tp.ones((2, 3))},
     "transpose": {"dim0": 0, "dim1": 1},
     "permute": {"perm": [1, 0]},
     "quantize": {"scale": tp.Tensor([1, 1, 1]), "dim": 0},
+    "dequantize": {"scale": tp.Tensor([1, 1, 1]), "dim": 0},
     "sum": {"dim": 0},
     "all": {"dim": 0},
     "any": {"dim": 0},
@@ -111,6 +118,15 @@ default_constraints_all = {
     "zeros": {"shape": tp.Tensor([3, 2])},
     "arange": {"start": 0, "stop": 5},
     "repeat": {"repeats": 2, "dim": 0},
+    "convolution": {
+        "input": tp.ones((1, 3, 5, 5)),
+        "weight": tp.ones((1, 3, 3, 3)),
+        "padding": ((0, 0), (0, 0)),
+        "stride": [1, 1],
+        "groups": 1,
+        "lhs_dilation": [1, 1],
+        "rhs_dilation": [1, 1],
+    },
 }
 
 

--- a/tripy/tripy/backend/mlir/utils.py
+++ b/tripy/tripy/backend/mlir/utils.py
@@ -256,6 +256,7 @@ def redirect_stderr() -> BinaryIO:
 
 
 TRIPY_DTYPE_TO_MLIR_TRT = {
+    datatype.int4: runtime.ScalarTypeCode.i4,
     datatype.int8: runtime.ScalarTypeCode.i8,
     datatype.int32: runtime.ScalarTypeCode.i32,
     datatype.int64: runtime.ScalarTypeCode.i64,

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -105,7 +105,6 @@ def str_from_source_info(source_info, enable_color=True, is_first_frame=True, ca
 
 
 def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
-    import tripy.function_registry
     from tripy.frontend.utils import convert_inputs_to_tensors
 
     EXCLUDE_FUNCTIONS = [convert_inputs_to_tensors]
@@ -130,7 +129,8 @@ def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool =
         if source_info.code is None:
             continue
 
-        if source_info.module == tripy.function_registry.__name__:
+        # Exclude frames from some modules that are not very useful to users:
+        if source_info.module in utils.get_module_names_to_exclude_from_stack_info():
             continue
 
         if should_exclude(source_info):

--- a/tripy/tripy/config.py
+++ b/tripy/tripy/config.py
@@ -27,22 +27,28 @@ from tripy import export
 
 export.public_api(autodoc_options=[":no-members:", ":no-special-members:"])(sys.modules[__name__])
 
-# MLIR Debug options
+# MLIR-TRT Debug options
 enable_mlir_debug = os.environ.get("TRIPY_MLIR_DEBUG_ENABLED", "0") == "1"
 mlir_debug_types = os.environ.get("TRIPY_MLIR_DEBUG_TYPES", "-mlir-print-ir-after-all,-translate-to-tensorrt").split(
     ","
 )
 mlir_debug_tree_path = os.environ.get("TRIPY_MLIR_DEBUG_PATH", os.path.join("/", "tripy", "mlir-dumps"))
 
-# Tensorrt debug options
+# TensorRT debug options
 enable_tensorrt_debug = os.environ.get("TRIPY_TRT_DEBUG_ENABLED", "0") == "1"
 tensorrt_debug_path = os.environ.get("TRIPY_TRT_DEBUG_PATH", os.path.join("/", "tripy", "tensorrt-dumps"))
 
-# Variables that are exposed to the user are kept lowercase.
 timing_cache_file_path: str = export.public_api(
     document_under="config.rst",
     autodoc_options=[":no-value:"],
     module=sys.modules[__name__],
     symbol="timing_cache_file_path",
 )(os.path.join(tempfile.gettempdir(), "tripy-cache"))
-"""Path to a timing cache file that can be used to speed up compilation time"""
+"""Path to a timing cache file that can be used to speed up compilation time."""
+
+enable_dtype_checking: bool = export.public_api(
+    document_under="config.rst",
+    module=sys.modules[__name__],
+    symbol="enable_dtype_checking",
+)(True)
+"""Whether to enable data type checking in API functions."""

--- a/tripy/tripy/constraints.py
+++ b/tripy/tripy/constraints.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 
-from typing import Optional
+from typing import List, Dict, Tuple, Any
 from collections import namedtuple
+import functools
+from tripy import utils
+from tripy.common.exception import raise_error
+from tripy import config
 
 TYPE_VERIFICATION = {}
-FUNC_W_DOC_VERIF = []
 RETURN_VALUE = "RETURN_VALUE"
 
 
@@ -27,11 +30,14 @@ def dtype_info(
     dtype_variables: dict = {},
     dtype_constraints: dict = {},
     dtype_exceptions: dict = [],
-    function_name: Optional[str] = "",
+    aliases: List[str] = [],
 ):
     """
     This function is a decorator that populates TYPE_VERIFICATION global dictionary which will be used by
     test_dtype_constraints.py to verify the dtypes of all operations.
+
+    **IMPORTANT: This should be applied before the `convert_inputs_to_tensors` decorator (i.e. must follow it in the code)**
+        **to make type checking work reliably. This ensures that the inputs coming in to the wrapped functions are Tensors**
 
     Args:
         dtype_variables: This input must be a dictionary with the names of groups of variables as the keys and lists of datatypes as the values.
@@ -41,19 +47,88 @@ def dtype_info(
             It must be a dictionary with parameter names as keys and variable group names as values.
             For assigning the return value, the key must be constraints.RETURN_VALUE.
             Example: dtype_constraints={"input": "T", "index": "T1", constraints.RETURN_VALUE: "T"}.
-        function_name: This parameter is only needed if a function is being mapped to multiple APIs. Takes a string with the function name as input.
+        aliases: A list of function name aliases. For methods that are exposed as multiple APIs (e.g. __add__ and __radd__), this
+            will enable type information to be added to the documentation for the aliases as well.
     """
 
-    def decorator(func_obj):
+    def decorator(func):
         return_dtype = dtype_constraints.get(RETURN_VALUE, None)
-        func_name = func_obj.__qualname__ if not function_name else function_name
         VerifInfo = namedtuple(
             "VerifInfo", ["obj", "inputs", "dtype_exceptions", "return_dtype", "dtypes", "dtype_constraints"]
         )
-        TYPE_VERIFICATION[func_name] = VerifInfo(
-            func_obj, {}, dtype_exceptions, return_dtype, dtype_variables, dtype_constraints
-        )
-        FUNC_W_DOC_VERIF.append(func_obj.__qualname__)
-        return func_obj
+        verif_info = VerifInfo(func, {}, dtype_exceptions, return_dtype, dtype_variables, dtype_constraints)
+
+        for key in [func.__qualname__] + aliases:
+            TYPE_VERIFICATION[key] = verif_info
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if config.enable_dtype_checking:
+                from tripy.frontend.tensor import Tensor
+                from tripy.common.datatype import dtype
+
+                merged_args = utils.merge_function_arguments(func, *args, **kwargs)
+
+                # The first arguments seen for each type variable. Other arguments with the same variable
+                # must use the same data types.
+                type_var_first_args: Dict[str, Tuple[str, dtype, Any]] = {}
+
+                for name, arg in merged_args:
+                    if name in dtype_constraints:
+                        type_var = dtype_constraints[name]
+
+                        if isinstance(arg, Tensor):
+                            arg_dtype = arg.dtype
+                        elif isinstance(arg, dtype):
+                            arg_dtype = arg
+                        else:
+                            continue
+
+                        # Check if the type is supported at all
+                        supported_dtypes = dtype_variables[type_var]
+                        if arg_dtype.name not in supported_dtypes:
+                            raise_error(
+                                f"Unsupported data type for '{func.__qualname__}'.",
+                                [
+                                    f"For parameter: '{name}', got unsupported data type: '{arg_dtype}'.\n"
+                                    f"Supported data types are: {supported_dtypes}.\n"
+                                ]
+                                + (
+                                    [
+                                        f"Note: '{name}' was: ",
+                                        arg,
+                                    ]
+                                    if isinstance(arg, Tensor)
+                                    else []
+                                ),
+                            )
+
+                        # Check if the type matches that of other inputs with the same type_var.
+                        if type_var in type_var_first_args:
+                            other_name, other_arg_dtype, other_arg = type_var_first_args[type_var]
+                            if other_arg_dtype != arg_dtype:
+                                raise_error(
+                                    f"Mismatched data types for '{func.__qualname__}'.",
+                                    [
+                                        f"Parameters: '{other_name}' and '{name}' must have matching data types, but got: "
+                                        f"'{other_arg_dtype.name}' and '{arg_dtype.name}' respectively.\n"
+                                    ]
+                                    + (
+                                        [
+                                            f"Note: '{other_name}' was: ",
+                                            other_arg,
+                                            f"While '{name}' was: ",
+                                            arg,
+                                        ]
+                                        if isinstance(arg, Tensor)
+                                        else []
+                                    ),
+                                )
+
+                        type_var_first_args[type_var] = (name, arg_dtype, arg)
+
+            return func(*args, **kwargs)
+
+        return wrapper
 
     return decorator

--- a/tripy/tripy/frontend/module/conv_transpose.py
+++ b/tripy/tripy/frontend/module/conv_transpose.py
@@ -15,16 +15,14 @@
 # limitations under the License.
 #
 
-from dataclasses import dataclass
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Optional
 
-from tripy import export, utils
+from tripy import export
 from tripy.common import datatype
 from tripy.frontend.module.convolution import ConvBase
-from tripy.frontend.module.parameter import Parameter, DefaultParameter
-
-from tripy.common.exception import raise_error
+from tripy.frontend.module.parameter import DefaultParameter, Parameter
 
 
 @export.public_api(document_under="operations/modules")
@@ -213,10 +211,10 @@ class ConvTranspose(ConvBase):
             :math:`(N, \text{out_channels}, D_{0_{\text{out}}},\ldots,D_{n_{\text{out}}})`
             where :math:`D_{k_{\text{out}}} = (D_{k_{\text{in}}} - 1) \times \text{stride}_k - \text{padding}_{k_0} - \text{padding}_{k_1} + \text{dilation}_k \times (\text{kernel_dims}_k - 1) + 1`
         """
-        from tripy.frontend.trace.ops.convolution import Convolution
-        from tripy.frontend.trace.ops.reshape import reshape
-        from tripy.frontend.trace.ops.permute import transpose
+        from tripy.frontend.trace.ops.convolution import convolution
         from tripy.frontend.trace.ops.flip import flip
+        from tripy.frontend.trace.ops.permute import transpose
+        from tripy.frontend.trace.ops.reshape import reshape
 
         # SHLO expects kernel shape in (out_channels, in_channels / feature_groups, ...) format
         # whereas typically transpose conv uses (in_channels, out_channels / feature_groups, ...) e.g. in Torch.
@@ -231,8 +229,9 @@ class ConvTranspose(ConvBase):
             weight = transpose(weight, 1, 2)
             weight = reshape(weight, self._kernel_hlo_final_shape)
 
-        x = Convolution.build(
-            [input, weight],
+        x = convolution(
+            input,
+            weight,
             self._transpose_padding,
             self._dummy_stride,
             self.groups,

--- a/tripy/tripy/frontend/module/convolution.py
+++ b/tripy/tripy/frontend/module/convolution.py
@@ -280,11 +280,12 @@ class Conv(ConvBase):
             :math:`(N, \text{out_channels}, D_{0_{\text{out}}},\ldots,D_{n_{\text{out}}})`
             where :math:`D_{k_{\text{out}}} = \large \left\lfloor \frac{D_{k_{\text{in}}} + \text{padding}_{k_0} + \text{padding}_{k_1} - \text{dilation}_k \times (\text{kernel_dims}_k - 1) - 1}{\text{stride}_k} \right\rfloor + \normalsize 1`
         """
-        from tripy.frontend.trace.ops.convolution import Convolution
+        from tripy.frontend.trace.ops.convolution import convolution
         from tripy.frontend.trace.ops.reshape import reshape
 
-        x = Convolution.build(
-            [input, self.weight],
+        x = convolution(
+            input,
+            self.weight,
             self.padding,
             self.stride,
             self.groups,

--- a/tripy/tripy/frontend/ops/relu.py
+++ b/tripy/tripy/frontend/ops/relu.py
@@ -21,7 +21,7 @@ from tripy import export, constraints
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "int32", "int64", "bool", "int8"],
+        "T1": ["float32", "float16", "bfloat16", "int4", "int32", "int64", "bool", "int8"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/ops/repeat.py
+++ b/tripy/tripy/frontend/ops/repeat.py
@@ -21,7 +21,7 @@ from tripy.frontend import utils as frontend_utils
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "int4", "float8", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/ops/stack.py
+++ b/tripy/tripy/frontend/ops/stack.py
@@ -21,7 +21,7 @@ from tripy.common.exception import raise_error
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"tensors": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -33,7 +33,7 @@ from tripy.frontend import utils as frontend_utils
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
     },
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
@@ -69,7 +69,7 @@ def ones(
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
     },
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
@@ -103,8 +103,8 @@ def zeros(
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
@@ -136,8 +136,8 @@ def ones_like(input: "tripy.Tensor", dtype: Optional[datatype.dtype] = None) -> 
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -21,7 +21,7 @@ from tripy import export, utils
 from tripy.common.datatype import int32
 from tripy.common.exception import raise_error
 from tripy.frontend.tensor import Tensor
-from tripy.frontend.utils import convert_inputs_to_tensors
+import tripy.frontend.utils as frontend_utils
 
 
 @export.public_api()
@@ -209,7 +209,7 @@ class Shape(Tensor):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    @convert_inputs_to_tensors(shape_argument=["other"])
+    @frontend_utils.convert_inputs_to_tensors(shape_argument=["other"])
     def __eq__(self, other):
         from tripy.frontend.trace.ops.reduce import all
 

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -80,7 +80,6 @@ class BinaryElementwise(BaseTraceOp):
         return [max(input_lengths)]
 
     def infer_dtypes(self):
-        op_utils.check_input_dtypes_match(self, self.kind.strip())
         self.outputs[0].dtype = self.inputs[0].dtype
 
     def broadcast_inputs(self, inputs, outputs):
@@ -161,7 +160,6 @@ class Comparison(BinaryElementwise):
     infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
 
     def infer_dtypes(self):
-        op_utils.check_input_dtypes_match(self, self.kind.strip())
         self.outputs[0].dtype = datatype.bool
 
     def to_flat_ir(self, inputs, outputs):
@@ -175,13 +173,9 @@ class Comparison(BinaryElementwise):
 @TENSOR_METHOD_REGISTRY("__radd__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
-)
-@constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
-    dtype_constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
-    function_name="__radd__",
+    aliases=["__radd__"],
 )
 def __add__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
     """
@@ -211,7 +205,7 @@ def __add__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
 @TENSOR_METHOD_REGISTRY("__sub__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64"]},
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def __sub__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -242,7 +236,7 @@ def __sub__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
 @TENSOR_METHOD_REGISTRY("__rsub__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "float8", "int32", "int64"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int4", "float8", "int32", "int64"]},
     dtype_constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def __rsub__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -336,14 +330,9 @@ def __rpow__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.
 @TENSOR_METHOD_REGISTRY("__rmul__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
-    function_name="__mul__",
-)
-@constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
-    dtype_constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
-    function_name="__rmul__",
+    aliases=["__rmul__"],
 )
 def __mul__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
     """
@@ -373,7 +362,7 @@ def __mul__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
 @TENSOR_METHOD_REGISTRY("__truediv__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int4", "int8", "int32", "int64"]},
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def __truediv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -404,7 +393,7 @@ def __truediv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", A
 @TENSOR_METHOD_REGISTRY("__rtruediv__")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int4", "int8", "int32", "int64"]},
     dtype_constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def __rtruediv__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -435,7 +424,7 @@ def __rtruediv__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tr
 @export.public_api(document_under="operations/functions")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("lhs", "rhs")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"lhs": "T1", "rhs": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def maximum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -466,7 +455,7 @@ def maximum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) ->
 @export.public_api(document_under="operations/functions")
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("lhs", "rhs")])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"lhs": "T1", "rhs": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def minimum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
@@ -498,7 +487,7 @@ def minimum(lhs: Union["tripy.Tensor", Any], rhs: Union["tripy.Tensor", Any]) ->
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
@@ -532,7 +521,7 @@ def __lt__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) 
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
@@ -566,7 +555,7 @@ def __le__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) 
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
@@ -600,7 +589,7 @@ def __eq__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) 
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
@@ -634,7 +623,7 @@ def __ne__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) 
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
@@ -668,7 +657,7 @@ def __ge__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) 
 @frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("self", "other")])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["bool"],
     },
     dtype_constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -102,11 +102,16 @@ class Cast(BaseTraceOp):
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
-    dtype_exceptions=[{"T1": "float8", "T2": "int8"}, {"T1": "float8", "T2": "int64"}],
+    dtype_exceptions=[
+        {"T1": "float8", "T2": "int8"},
+        {"T1": "float8", "T2": "int64"},
+        {"T1": "int4", "T2": "int8"},
+        {"T1": "int4", "T2": "int64"},
+    ],
 )
 def cast(input: "tripy.Tensor", dtype: "tripy.dtype") -> "tripy.Tensor":
     r"""

--- a/tripy/tripy/frontend/trace/ops/concatenate.py
+++ b/tripy/tripy/frontend/trace/ops/concatenate.py
@@ -46,7 +46,7 @@ class Concatenate(BaseTraceOp):
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"tensors": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/trace/ops/convolution.py
+++ b/tripy/tripy/frontend/trace/ops/convolution.py
@@ -17,6 +17,7 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from tripy import constraints
 
 import tripy.frontend.trace.ops.utils as op_utils
 from tripy import utils
@@ -66,7 +67,6 @@ class Convolution(BaseTraceOp):
         self.outputs[0].rank = self.inputs[0].rank
 
     def infer_dtypes(self):
-        op_utils.check_input_dtypes_match(self, "convolution")
         self.outputs[0].dtype = self.inputs[0].dtype
 
     def to_flat_ir(self, inputs, outputs):
@@ -81,3 +81,21 @@ class Convolution(BaseTraceOp):
             lhs_dilation=self.lhs_dilation,
             rhs_dilation=self.rhs_dilation,
         )
+
+
+@constraints.dtype_info(
+    dtype_variables={
+        "T1": ["float32", "float16", "bfloat16", "float8"],
+    },
+    dtype_constraints={"input": "T1", "weight": "T1", constraints.RETURN_VALUE: "T1"},
+)
+def convolution(
+    input: "tripy.Tensor",
+    weight: "tripy.Tensor",
+    padding: Sequence[Sequence[int]],
+    stride: Sequence[int],
+    groups: int,
+    lhs_dilation: Sequence[int],
+    rhs_dilation: Sequence[int],
+):
+    return Convolution.build([input, weight], padding, stride, groups, lhs_dilation, rhs_dilation)

--- a/tripy/tripy/frontend/trace/ops/copy.py
+++ b/tripy/tripy/frontend/trace/ops/copy.py
@@ -41,7 +41,7 @@ class Copy(BaseTraceOp):
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -89,7 +89,7 @@ def full_impl(
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
@@ -124,8 +124,8 @@ def full(
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -84,7 +84,10 @@ def iota_impl(
 
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["int32"], "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "bool"]},
+    dtype_variables={
+        "T1": ["int32"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "bool"],
+    },
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def iota(
@@ -123,8 +126,8 @@ def iota(
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "bool"],
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -61,7 +61,6 @@ class MatrixMultiplication(BaseTraceOp):
 
         if a_rank == 1 and b_rank == 1:
             # case 1: both operands are 1-D
-            op_utils.check_input_shapes_match(self, "@")
             self.batching_dim = {"lhs": [], "rhs": []}
             self.contracting_dim = {"lhs": [0], "rhs": [0]}
             self.outputs[0].rank = 0
@@ -107,10 +106,6 @@ class MatrixMultiplication(BaseTraceOp):
             }
 
             self.outputs[0].rank = output_rank
-
-    def infer_dtypes(self):
-        op_utils.check_input_dtypes_match(self, "@")
-        self.outputs[0].dtype = self.inputs[0].dtype
 
     def to_flat_ir(self, inputs, outputs):
         from tripy.common.datatype import int32

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -56,7 +56,7 @@ class Transpose(Permute):
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def transpose(input: "tripy.Tensor", dim0: int, dim1: int) -> "tripy.Tensor":
@@ -86,7 +86,7 @@ def transpose(input: "tripy.Tensor", dim0: int, dim1: int) -> "tripy.Tensor":
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def permute(input: "tripy.Tensor", perm: Sequence[int]) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/quantize.py
+++ b/tripy/tripy/frontend/trace/ops/quantize.py
@@ -130,7 +130,7 @@ class Quantize(BaseTraceOp):
 @export.public_api(document_under="operations/quantization")
 @frontend_utils.convert_inputs_to_tensors(exclude=["dtype", "dim"])
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16"], "T2": ["int8", "float8"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16"], "T2": ["int4", "int8", "float8"]},
     dtype_constraints={"input": "T1", "scale": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def quantize(

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -449,10 +449,8 @@ def _arg_min_max_impl(tensor: "tripy.Tensor", kind: ArgMinMax.Kind, dim: Optiona
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={
-        "T1": ["int32"],
-    },
-    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int32", "bool", "int8"], "T2": ["int32"]},
+    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T2"},
 )
 def argmax(input: "tripy.Tensor", dim: Optional[int] = None, keepdim: bool = False) -> "tripy.Tensor":
     """
@@ -483,10 +481,8 @@ def argmax(input: "tripy.Tensor", dim: Optional[int] = None, keepdim: bool = Fal
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={
-        "T1": ["int32"],
-    },
-    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int32", "bool", "int8"], "T2": ["int32"]},
+    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T2"},
 )
 def argmin(input: "tripy.Tensor", dim: Optional[int] = None, keepdim: bool = False) -> "tripy.Tensor":
     """

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -75,7 +75,7 @@ def reshape_impl(
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["int8", "int32", "int64"],
     },
     dtype_constraints={"input": "T1", "shape": "T2", constraints.RETURN_VALUE: "T1"},
@@ -265,7 +265,7 @@ def squeeze(input: "tripy.Tensor", dims: Union[Tuple, int] = None) -> "tripy.Ten
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -52,7 +52,7 @@ class Shape(BaseTraceOp):
 @property
 @constraints.dtype_info(
     dtype_variables={
-        "self_dtype": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "self_dtype": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
         "T2": ["int32"],
     },
     dtype_constraints={"self": "self_dtype", constraints.RETURN_VALUE: "T2"},

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -175,7 +175,9 @@ class Slice(BaseTraceOp):
 
 @TENSOR_METHOD_REGISTRY("__getitem__")
 @constraints.dtype_info(
-    dtype_variables={"self_dtype": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={
+        "self_dtype": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]
+    },
     dtype_constraints={"self": "self_dtype", constraints.RETURN_VALUE: "self_dtype"},
 )
 def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -197,7 +197,7 @@ class Split(BaseTraceOp):
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/trace/ops/unsqueeze.py
+++ b/tripy/tripy/frontend/trace/ops/unsqueeze.py
@@ -59,7 +59,7 @@ def unsqueeze_two_operand(input, result_shape, dim):
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def unsqueeze(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -22,39 +22,6 @@ from tripy.utils import Result
 import tripy.common.datatype as tp_dtype
 
 
-def _check_input_attr_matches(
-    op: "BaseTraceOp", op_details: str, attr: str, attr_name: str, start_index: int = None, stop_index: int = None
-):
-    assert len(op.inputs), "This function must not be called for operations without inputs!"
-
-    start = utils.default(start_index, 0)
-    stop = utils.default(stop_index, len(op.inputs))
-
-    inp_range_str = "all inputs"
-    if start_index is not None or stop_index is not None:
-        inp_range_str = f"inputs [{start}-{stop - 1}]"
-
-    assert start < len(op.inputs), "Start index cannot be larger than number of inputs!"
-
-    inputs = op.inputs[start:stop]
-
-    if any(getattr(inp, attr) != getattr(inputs[0], attr) for inp in inputs):
-        dtypes = []
-        for index, inp in enumerate(inputs):
-            dtypes.extend([", " if index > 0 else "", getattr(inp, attr)])
-
-        utils.raise_error_io_info(
-            op,
-            f"Incompatible input {attr_name}s.",
-            details=[
-                f"For operation: '{op_details}', " if op_details else "For this operation, ",
-                f"{attr_name}s for {inp_range_str}" " must match, but got: [",
-                *dtypes,
-                "]",
-            ],
-        )
-
-
 # Utility for error messages in wrap_shape_inputs
 def write_shape_input_indices_message(inputs: List["tripy.Tensor"]) -> str:
     from tripy.frontend.shape import Shape
@@ -65,15 +32,6 @@ def write_shape_input_indices_message(inputs: List["tripy.Tensor"]) -> str:
     if len(shape_indices) == 1:
         return f"input with index {shape_indices[0]} is tp.Shape"
     return f"inputs with indices {', '.join(shape_indices)} are tp.Shape"
-
-
-# Checks whether properties of the inputs match. Optional index parameters can be provided in case not all inputs should be considered.
-def check_input_dtypes_match(op: "BaseTraceOp", op_details: str = "", start_index: int = None, stop_index: int = None):
-    return _check_input_attr_matches(op, op_details, "dtype", "data type", start_index, stop_index)
-
-
-def check_input_shapes_match(op: "BaseTraceOp", op_details: str = "", start_index: int = None, stop_index: int = None):
-    return _check_input_attr_matches(op, op_details, "shape", "shape", start_index, stop_index)
 
 
 def get_broadcast_dim(dim1, dim2):
@@ -510,7 +468,7 @@ def check_qdq_args(input, scale, dtype, dim, is_quantize):
     quantizable_dtype, quantized_dtype = (input.dtype, dtype) if is_quantize else (dtype, input.dtype)
     if scale.dtype != quantizable_dtype:
         raise_error(
-            f"Scale dtype does not match input dtype in {op_str}.",
+            f"Scale dtype does not match expected dtype in {op_str}.",
             [f"scale should have dtype={quantizable_dtype}, got {scale.dtype}"],
         )
 

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -99,7 +99,7 @@ def convert_inputs_to_tensors(
                     import tripy.function_registry
 
                     dispatch_target = source_info._dispatch_target or dispatch_target
-                    if source_info.module != tripy.function_registry.__name__:
+                    if source_info.module not in utils.get_module_names_to_exclude_from_stack_info():
                         frame_index = idx + WRAPPER_STACK_DEPTH + skip_num_stack_entries
                         break
                 else:

--- a/tripy/tripy/utils/__init__.py
+++ b/tripy/tripy/utils/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from tripy.utils.stack_info import StackInfo, get_stack_info
+from tripy.utils.stack_info import StackInfo, get_stack_info, get_module_names_to_exclude_from_stack_info
 from tripy.utils.utils import *
 from tripy.utils.ast import *
 from tripy.utils.result import Result

--- a/tripy/tripy/utils/stack_info.py
+++ b/tripy/tripy/utils/stack_info.py
@@ -124,3 +124,14 @@ def get_stack_info(include_code_index: int = None) -> StackInfo:
         frame = frame.f_back
 
     return stack_info
+
+
+def get_module_names_to_exclude_from_stack_info():
+    """
+    Returns a set of module names to exclude from stack information when displaying exceptions
+    or trying to retrieve column information from code.
+    """
+    import tripy.function_registry
+    import tripy.constraints
+
+    return {mod.__name__ for mod in [tripy.function_registry, tripy.constraints]}


### PR DESCRIPTION
- We already document supported data types via our dtype constraints decorator. This change also adds data type checks in the frontend to preempt confusing error messages emitted from lower in the stack.

- This also adds a switch in the `config` so that data type checking can be disabled if desired (e.g. this is useful in our own data type constraint negative testing).

-  Fixes bugs in the `int4` implementation and corrects type constraints.
    
- Removes dtype checking from trace operations and associated helpers since it's now all done in the API.