### PR TITLE
Add scalar shape class to Tripy

### DIFF
--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -40,6 +40,30 @@ def other_values(request):
     return request.param
 
 
+class TestShapeScalar:
+    @pytest.mark.parametrize("value", [1, tp.Tensor(1), np.array(2)])
+    def test_scalar_shape(self, value):
+        s = tp.ShapeScalar(values)
+
+        assert isinstance(s, tp.ShapeScalar)
+        assert s.trace_tensor.producer.inputs == []
+
+    def test_scalar_slice(self):
+        a = tp.iota((3, 3))
+        assert isinstance(a.shape[0], tp.ShapeScalar)
+
+        s = a.shape[0] * a.shape[1]
+        b = tp.reshape(a, tp.reshape(s, (1,)))
+        assert tp.allclose(tp.flatten(a), b)
+
+    def test_scalar_scalar_op(self):
+        a = tp.iota((3, 4))
+        s1 = a.shape[0]
+        s2 = a.shape[1]
+        s = s1 + s2
+        assert isinstance(s, tp.ShapeScalar)
+
+
 class TestShape:
     def test_shape(self, values):
         s = tp.Shape(values)

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -48,7 +48,7 @@ class BinaryElementwise(BaseTraceOp):
 
     def infer_shape_output_idxs(self, inputs):
         # permit one input to be a shape but require the output to be a shape
-        from tripy.frontend.shape import Shape
+        from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
 
         if any(map(lambda t: isinstance(t, Shape), inputs)):
@@ -66,9 +66,12 @@ class BinaryElementwise(BaseTraceOp):
                         f"The following inputs have invalid ranks: {invalid_indices_message}",
                     ]
                 )
-            return Result.ok([0])
+            return Result.ok({"shape": [0]})
+        elif all(map(lambda t: isinstance(t, ShapeScalar), inputs)):
+            # Binary operation on ShapeScalar should yield another ShapeScalar.
+            return Result.ok({"scalar": [0]})
         else:
-            return Result.ok([])
+            return Result.ok({})
 
     def infer_len(self):
         # For the shape case, the result will be broadcast to the max of the input shapes

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -33,8 +33,8 @@ class Cast(BaseTraceOp):
         if isinstance(inputs[0], Shape):
             # Only still a valid shape if it remains int32
             if self.dtype == int32:
-                return Result.ok([0])
-        return Result.ok([])
+                return Result.ok({"shape": [0]})
+        return Result.ok({})
 
     infer_len = InferLenPolicies.infer_same_as_first_input
 

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -39,8 +39,8 @@ class Expand(BaseTraceOp):
 
         # wrap if the first input is a shape and the output is rank-1
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok([0])
-        return Result.ok([])
+            return Result.ok({"shape": [0]})
+        return Result.ok({})
 
     def infer_len(self):
         if self.output_len is not None:

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -38,7 +38,7 @@ class MatrixMultiplication(BaseTraceOp):
         if (isinstance(inputs[0], Shape) and isinstance(inputs[1], Shape)) or (
             not isinstance(inputs[0], Shape) and not isinstance(inputs[1], Shape)
         ):
-            return Result.ok([])
+            return Result.ok({})
         return Result.err(None)
 
     def infer_rank(self):

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -47,8 +47,8 @@ class Reshape(BaseTraceOp):
 
         # Only wrap the reshaped output if the result is rank 1, otherwise don't wrap
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok([0])
-        return Result.ok([])
+            return Result.ok({"shape": [0]})
+        return Result.ok({})
 
     def infer_rank(self):
         if self.output_rank is None:

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -28,7 +28,7 @@ class Shape(BaseTraceOp):
 
     # always return a shape
     def infer_shape_output_idxs(self, inputs) -> Result:
-        return Result.ok([0])
+        return Result.ok({"shape": [0]})
 
     def infer_len(self):
         return [self.inputs[0].rank]

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -208,7 +208,7 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
         assert np.array_equal(cp.from_dlpack(output).get(), np.arange(10)[8:2:-1])
 
     """
-    from tripy.frontend.shape import Shape
+    from tripy.frontend.shape import ShapeScalar, Shape
     from tripy.frontend.tensor import Tensor
     from tripy.frontend.trace.ops.flip import flip
     from tripy.frontend.trace.ops.reshape import reshape, squeeze
@@ -297,7 +297,7 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
     if squeeze_dims:
         out = squeeze(out, make_tuple(squeeze_dims))
 
-    return out
+    return ShapeScalar(out) if isinstance(self, Shape) and out.rank == 0 else out
 
 
 # Conveniently converts the inputs to tensors. The decorator also fills in column info for the converted tensors.

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -61,14 +61,14 @@ class ShapeOutputIdxPolicies:
         from tripy.frontend.shape import Shape
 
         if isinstance(inputs[0], Shape):
-            return Result.ok(list(range(len(self.outputs))))
-        return Result.ok([])
+            return Result.ok({"shape": list(range(len(self.outputs)))})
+        return Result.ok({})
 
     def never_return_shape(self, inputs):
         """
         Accepts shapes but the result is always no shape indices
         """
-        return Result.ok([])
+        return Result.ok({})
 
 
 ##

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -40,9 +40,9 @@ class Where(BaseTraceOp):
                         f" the Boolean input must be rank 1, but given rank {inputs[0].rank}",
                     ]
                 )
-            return Result.ok([0])
+            return Result.ok({"shape": [0]})
         elif not isinstance(inputs[1], Shape) and not isinstance(inputs[2], Shape):
-            return Result.ok([])
+            return Result.ok({})
         else:
             return Result.err(
                 [


### PR DESCRIPTION
This PR adds `ScalarShape` to Tripy which is encodes a value that is sliced out of a `Shape` tensor.