### PR TITLE
Fix reshape annotation to allow tensor input

### DIFF
--- a/tripy/tests/integration/test_arange.py
+++ b/tripy/tests/integration/test_arange.py
@@ -48,9 +48,7 @@ class TestArange:
         ):
             tp.arange(0, 5, 0)
 
-    def test_tensor_inputs(self):
-        start = tp.Tensor(1.0)
-        stop = tp.Tensor(5.0)
-        step = tp.Tensor(0.5)
-        out = tp.arange(start, stop, step)
-        assert np.allclose(cp.from_dlpack(out).get(), np.arange(1.0, 5.0, 0.5, dtype=np.float32))
+    def test_shapescalar_inputs(self):
+        a = tp.ones((1, 5, 1))
+        out = tp.arange(a.shape[0], a.shape[1] + 1, a.shape[2])
+        assert np.allclose(cp.from_dlpack(out).get(), np.arange(1.0, 6.0, 1.0, dtype=np.float32))

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -37,7 +37,7 @@ from tripy.frontend import utils as frontend_utils
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def ones(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]],
+    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":
     """
@@ -73,7 +73,7 @@ def ones(
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def zeros(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]],
+    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":
     """
@@ -290,9 +290,9 @@ def triu(tensor: "tripy.Tensor", diagonal: int = 0) -> "tripy.Tensor":
     dtype_constraints={"dtype": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def arange(
-    start: Union[numbers.Number, "tripy.Tensor"],
-    stop: Union[numbers.Number, "tripy.Tensor"],
-    step: Union[numbers.Number, "tripy.Tensor"] = 1,
+    start: Union[numbers.Number, "tripy.ShapeScalar"],
+    stop: Union[numbers.Number, "tripy.ShapeScalar"],
+    step: Union[numbers.Number, "tripy.ShapeScalar"] = 1,
     dtype: "tripy.dtype" = datatype.float32,
 ) -> "tripy.Tensor":
     r"""
@@ -326,6 +326,7 @@ def arange(
     """
     from tripy.frontend import Tensor
     from tripy.common.datatype import int32
+    from tripy.frontend.shape import ShapeScalar
 
     if isinstance(step, numbers.Number) and step == 0:
         raise_error("Step in arange cannot be 0.", [])
@@ -340,14 +341,11 @@ def arange(
             ],
         )
 
-    if isinstance(size, Tensor):
-        from tripy.frontend.trace.ops.cast import cast
-
-        size = cast(size, int32)
-    else:
+    if not isinstance(size, ShapeScalar):
         size = int(size)
+    size = (size,)
 
-    output = iota((size,), 0, dtype) * full((size,), step, dtype) + full((size,), start, dtype)
+    output = iota(size, 0, dtype) * full(size, step, dtype) + full(size, start, dtype)
     return output
 
 

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -49,6 +49,7 @@ class BinaryElementwise(BaseTraceOp):
 
     def infer_shape_output_idxs(self, inputs):
         # permit one input to be a shape but require the output to be a shape
+        from tripy.frontend.tensor import Tensor
         from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
 
@@ -68,7 +69,9 @@ class BinaryElementwise(BaseTraceOp):
                     ]
                 )
             return Result.ok({"shape": [0]})
-        elif all(map(lambda t: isinstance(t, ShapeScalar), inputs)):
+        elif any(
+            map(lambda t: isinstance(t, ShapeScalar) or (isinstance(t, int) and not isinstance(t, Tensor)), inputs)
+        ):
             # Binary operation on ShapeScalar should yield another ShapeScalar.
             return Result.ok({"scalar": [0]})
         else:

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -82,7 +82,9 @@ def expand_impl(input: "tripy.Tensor", shape: Sequence, output_rank: int, output
     },
     dtype_constraints={"input": "T1", "sizes": "T2", constraints.RETURN_VALUE: "T1"},
 )
-def expand(input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]]) -> "tripy.Tensor":
+def expand(
+    input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]]
+) -> "tripy.Tensor":
     """
     Returns a new tensor based on the input tensor with singleton dimensions expanded to a larger size.
 

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -94,7 +94,7 @@ class Fill(BaseTraceOp):
 
 @frontend_utils.convert_inputs_to_tensors(exclude=["value", "dtype", "output_rank"], shape_argument=["shape"])
 def full_impl(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]],
+    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     value: Union[numbers.Number, "tripy.Tensor"],
     dtype: "tripy.dtype",
     output_rank: int,
@@ -116,7 +116,7 @@ def full_impl(
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def full(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]],
+    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     value: Union[numbers.Number, "tripy.Tensor"],
     dtype: "tripy.dtype" = datatype.float32,
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -91,7 +91,7 @@ def iota_impl(
     dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
 )
 def iota(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]],
+    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     dim: int = 0,
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -80,7 +80,9 @@ def reshape_impl(
     },
     dtype_constraints={"input": "T1", "shape": "T2", constraints.RETURN_VALUE: "T1"},
 )
-def reshape(input: "tripy.Tensor", shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]]) -> "tripy.Tensor":
+def reshape(
+    input: "tripy.Tensor", shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]]
+) -> "tripy.Tensor":
     """
     Returns a new tensor with the contents of the input tensor in the specified shape.
 

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -242,7 +242,7 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
             if isinstance(index, int):
                 return index if index >= 0 else index + t_shape[i]
             else:
-                return where(index >= 0, index, reshape(t_shape[i], (1,)) + index)
+                return where(index >= 0, index, t_shape[i] + index)
 
         # when dealing with a slice (not a single index), we clamp the start and end bounds to [0, t_shape[i]]
         # because out of bounds indices for a *slice* mean that the dim should be empty, not an error


### PR DESCRIPTION
Fixes below bug: 
```
--> /tripy/examples/nanogpt/model.py:92 in <lambda>()
      |
   92 |         multi_heads = lambda x: tp.transpose(tp.reshape(x, multi_head_output_shape), 1, 2)
      | 

Could not find an implementation for function: 'reshape'.
    Candidate overloads were:

    --> /tripy/tripy/constraints.py:75 in reshape()
          |
       75 | def reshape(input: "tripy.Tensor", shape: Union["tripy.Shape", Sequence[Union[int, "tripy.Tensor"]]]) -> "tripy.Tensor":
       76 |     ...
          | 

    Not a valid overload because: For parameter: 'shape', expected an instance of type: 'typing.Union[ForwardRef('tripy.Shape'), typing.Sequence[typing.Union[int, ForwardRef('tripy.Tensor')]]]' but got argument of type: 'Tensor'.
```