### PR TITLE
[Tripy] Separate converting shape args from converting tensor args

### DIFF
--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -200,10 +200,10 @@ import tripy.frontend.utils as frontend_utils
 # If we needed to provide any special autodoc options, we could use the `autodoc_options` parameter.
 @export.public_api(document_under="tensor_operations")
 
-# The `convert_inputs_to_tensors` decorator converts function arguments to Tensors.
-# This is what makes it possible for the user to use Python numbers in Tripy functions (e.g. `tensor + 1`)
-# In this case, we want `shape` to turn into a `tripy.Shape` instead of a regular `Tensor`.
-@frontend_utils.convert_inputs_to_tensors(shape_argument=["shape"], exclude=["dim", "dtype"])
+# The `convert_shape_inputs` decorator converts the specified function arguments into `tripy.Shape`s rather than Tensors,
+# which would allow for using Python numbers and sequences. The `convert_inputs_to_tensors` decorator more generally converts
+# function arguments into Tripy tensors and is also commonly used in the codebase.
+@frontend_utils.convert_shape_inputs(["shape"])
 def theta(shape: Tuple[int], dim: int = 0, dtype: datatype.dtype = datatype.float32) -> "tripy.Tensor":
     # For any public facing interfaces, we have documentation requirements which you can read
     # about in the 'Docs README' (linked below). The docstring we've implemented here

--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -200,7 +200,7 @@ import tripy.frontend.utils as frontend_utils
 # If we needed to provide any special autodoc options, we could use the `autodoc_options` parameter.
 @export.public_api(document_under="tensor_operations")
 
-# The `convert_shape_inputs` decorator converts the specified function arguments into `tripy.Shape`s rather than Tensors,
+# The `convert_shape_inputs` decorator converts the specified function arguments into `tripy.Shape`s,
 # which would allow for using Python numbers and sequences. The `convert_inputs_to_tensors` decorator more generally converts
 # function arguments into Tripy tensors and is also commonly used in the codebase.
 @frontend_utils.convert_shape_inputs(["shape"])

--- a/tripy/tests/frontend/test_utils.py
+++ b/tripy/tests/frontend/test_utils.py
@@ -22,59 +22,62 @@ import tripy as tp
 from tripy.frontend.utils import convert_inputs_to_tensors, convert_shape_inputs
 from tests import helper
 
+# Putting underscores at the beginning and end of the names to get around the check
+# for magic methods. We would not want to see this outside of tests.
+
 
 @convert_inputs_to_tensors()
-def func(a):
+def __func_test_basic__(a):
     return a
 
 
 @convert_inputs_to_tensors()
-def multi_input(a, b, c):
+def __func_test_multi_input__(a, b, c):
     return a, b, c
 
 
 @convert_inputs_to_tensors(sync_arg_types=[("a", "b", "c")])
-def sync_arg_types(a, b, c):
+def __func_test_sync_arg_types__(a, b, c):
     return a, b, c
 
 
 @convert_inputs_to_tensors()
-def variadic_positional_args(*args):
+def __func_test_variadic_positional_args__(*args):
     return args
 
 
 @convert_inputs_to_tensors()
-def arg_before_variadic_positional_args(x, *args):
+def __func_test_arg_before_variadic_positional_args__(x, *args):
     return (x,) + args
 
 
 @convert_inputs_to_tensors()
-def kwarg_after_variadic_positional_args(*args, y):
+def __func_test_kwarg_after_variadic_positional_args__(*args, y):
     return args + (y,)
 
 
 @convert_inputs_to_tensors(unpack_argument=["xs"])
-def convert_list_input(xs):
+def __func_test_convert_list_input__(xs):
     return xs
 
 
 @convert_inputs_to_tensors(sync_arg_types=[("xs",)], unpack_argument=["xs"])
-def sync_within_list(xs):
+def __func_test_sync_within_list__(xs):
     return xs
 
 
 @convert_inputs_to_tensors(sync_arg_types=[("x", "ys")], unpack_argument=["ys"])
-def sync_single_type_to_list(x, ys):
+def __func_test_sync_single_type_to_list__(x, ys):
     return x, ys
 
 
 @convert_inputs_to_tensors(sync_arg_types=[("xs", "y")], unpack_argument=["xs"])
-def sync_list_type_to_single(xs, y):
+def __func_test_sync_list_type_to_single__(xs, y):
     return xs, y
 
 
 @convert_inputs_to_tensors(sync_arg_types=[("xs", "ys")], unpack_argument=["xs", "ys"])
-def sync_list_types(xs, ys):
+def __func_test_sync_list_types__(xs, ys):
     return xs, ys
 
 
@@ -90,45 +93,45 @@ def ignore_not_named(s, t):
 
 class TestConvertInputsToTensors:
     def test_args(self):
-        assert isinstance(func(0), tp.Tensor)
+        assert isinstance(__func_test_basic__(0), tp.Tensor)
 
     def test_kwargs(self):
-        assert isinstance(func(a=0), tp.Tensor)
+        assert isinstance(__func_test_basic__(a=0), tp.Tensor)
 
     def test_convert_list_into_tensor(self):
-        t1 = func([1, 2, 3])
+        t1 = __func_test_basic__([1, 2, 3])
         assert isinstance(t1, tp.Tensor)
         assert t1.shape == [3]
 
-        t2 = func([[1, 2], [3, 4]])
+        t2 = __func_test_basic__([[1, 2], [3, 4]])
         assert t2.shape == [2, 2]
 
     def test_convert_list_input(self):
-        xs = convert_list_input([1.0, 2.0, 3.0, 4.0])
+        xs = __func_test_convert_list_input__([1.0, 2.0, 3.0, 4.0])
         assert len(xs) == 4
         for x in xs:
             assert isinstance(x, tp.Tensor)
-        assert not convert_list_input([])
+        assert not __func_test_convert_list_input__([])
 
     def test_convert_tuple_input(self):
-        xs = convert_list_input((1.0, 2.0))
+        xs = __func_test_convert_list_input__((1.0, 2.0))
         assert isinstance(xs, tuple)
         assert len(xs) == 2
         assert isinstance(xs[0], tp.Tensor)
         assert isinstance(xs[1], tp.Tensor)
 
     def test_variadic_positional_args(self):
-        x, y = variadic_positional_args(1.0, 2.0)
+        x, y = __func_test_variadic_positional_args__(1.0, 2.0)
         assert isinstance(x, tp.Tensor)
         assert isinstance(y, tp.Tensor)
 
     def test_arg_before_variadic_positional_args(self):
-        x, y = arg_before_variadic_positional_args(1.0, 2.0)
+        x, y = __func_test_arg_before_variadic_positional_args__(1.0, 2.0)
         assert isinstance(x, tp.Tensor)
         assert isinstance(y, tp.Tensor)
 
     def test_kwarg_after_variadic_positional_args(self):
-        x, y = kwarg_after_variadic_positional_args(1.0, y=2.0)
+        x, y = __func_test_kwarg_after_variadic_positional_args__(1.0, y=2.0)
         assert isinstance(x, tp.Tensor)
         assert isinstance(y, tp.Tensor)
 
@@ -185,26 +188,26 @@ class TestConvertInputsToTensors:
     # When we convert arguments to tensors, we should preserve the column range
     # of the original non-Tensor argument.
     def test_includes_column_range_for_non_tensors(self):
-        tensor = func(3.0)
+        tensor = __func_test_basic__(3.0)
 
         # Column offset of the `3.0` above.
-        assert tensor.stack_info[tensor.stack_info.get_first_user_frame_index()].column_range == (22, 25)
+        assert tensor.stack_info[tensor.stack_info.get_first_user_frame_index()].column_range == (37, 40)
 
     def test_includes_column_range_for_non_tensors_multiple_inputs(self):
-        a, b, c = multi_input(1, 2.0, 3)
+        a, b, c = __func_test_multi_input__(1, 2.0, 3)
 
         # Column offsets of the arguments above.
-        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (30, 31)
-        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (33, 36)
-        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (38, 39)
+        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (44, 45)
+        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (47, 50)
+        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (52, 53)
 
     def test_includes_column_range_for_non_tensors_multiple_inputs_with_kwargs(self):
-        a, b, c = multi_input(1, b=2.0, c=3)
+        a, b, c = __func_test_multi_input__(1, b=2.0, c=3)
 
         # Column offsets of the arguments above.
-        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (30, 31)
-        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (33, 38)
-        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (40, 43)
+        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (44, 45)
+        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (47, 52)
+        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (54, 57)
 
     def test_includes_column_range_for_non_tensors_for_magic_methods(self):
         c = tp.ones((2, 3)) + 3
@@ -223,33 +226,33 @@ class TestConvertInputsToTensors:
         assert stack_info[stack_info.get_first_user_frame_index()].column_range == (36, 43)
 
     def test_includes_column_range_for_list_elements(self):
-        xs = convert_list_input([1.0, 2.0])
-        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (33, 36)
-        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (38, 41)
+        xs = __func_test_convert_list_input__([1.0, 2.0])
+        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (47, 50)
+        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (52, 55)
 
     def test_includes_column_range_for_tuple_elements(self):
-        xs = convert_list_input((1.0, 2.0))
-        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (33, 36)
-        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (38, 41)
+        xs = __func_test_convert_list_input__((1.0, 2.0))
+        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (47, 50)
+        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (52, 55)
 
     def test_sync_arg_type_includes_non_tensor_column_range(self):
-        x, y, z = sync_arg_types(tp.Tensor(3.0, dtype=tp.float16), 3, 4.0)
+        x, y, z = __func_test_sync_arg_types__(tp.Tensor(3.0, dtype=tp.float16), 3, 4.0)
 
         assert y.dtype == tp.float16
         assert z.dtype == tp.float16
-        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (67, 68)
-        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (70, 73)
+        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (81, 82)
+        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (84, 87)
 
     def test_sync_arg_type_includes_non_tensor_column_range_with_kwargs(self):
-        x, y, z = sync_arg_types(tp.Tensor(3.0, dtype=tp.float16), b=3, c=4.0)
+        x, y, z = __func_test_sync_arg_types__(tp.Tensor(3.0, dtype=tp.float16), b=3, c=4.0)
 
         assert y.dtype == tp.float16
         assert z.dtype == tp.float16
-        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (67, 70)
-        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (72, 77)
+        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (81, 84)
+        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (86, 91)
 
     def test_sync_arg_type_not_applied_to_tensors(self):
-        x, y, z = sync_arg_types(
+        x, y, z = __func_test_sync_arg_types__(
             tp.Tensor(3.0),
             tp.Tensor(3, dtype=tp.int32),
             tp.Tensor(4, dtype=tp.float16),
@@ -260,28 +263,28 @@ class TestConvertInputsToTensors:
         assert z.dtype == tp.float16
 
     def test_sync_arg_type_within_list(self):
-        xs = sync_within_list([1.0, tp.Tensor(3, dtype=tp.float16), 5])
+        xs = __func_test_sync_within_list__([1.0, tp.Tensor(3, dtype=tp.float16), 5])
 
         assert xs[0].dtype == tp.float16
         assert xs[1].dtype == tp.float16
         assert xs[2].dtype == tp.float16
 
     def test_sync_single_arg_type_to_list(self):
-        _, ys = sync_single_type_to_list(tp.Tensor(5, dtype=tp.int32), [2.0, 3.0, 4.0])
+        _, ys = __func_test_sync_single_type_to_list__(tp.Tensor(5, dtype=tp.int32), [2.0, 3.0, 4.0])
 
         assert ys[0].dtype == tp.int32
         assert ys[1].dtype == tp.int32
         assert ys[2].dtype == tp.int32
 
     def test_sync_list_arg_type_to_single_arg(self):
-        xs, y = sync_list_type_to_single([1.0, tp.Tensor(5, dtype=tp.int32), 4.0], 1.0)
+        xs, y = __func_test_sync_list_type_to_single__([1.0, tp.Tensor(5, dtype=tp.int32), 4.0], 1.0)
 
         assert xs[0].dtype == tp.int32
         assert xs[2].dtype == tp.int32
         assert y.dtype == tp.int32
 
     def test_sync_list_arg_types(self):
-        xs, ys = sync_list_types([1.0, 2.0, 3.0], [3, 4, tp.Tensor(6, dtype=tp.int32)])
+        xs, ys = __func_test_sync_list_types__([1.0, 2.0, 3.0], [3, 4, tp.Tensor(6, dtype=tp.int32)])
 
         for x in xs:
             assert x.dtype == tp.int32
@@ -289,7 +292,7 @@ class TestConvertInputsToTensors:
             assert y.dtype == tp.int32
 
     def test_sync_arg_type_list_not_applied_to_tensors(self):
-        xs = sync_within_list(
+        xs = __func_test_sync_within_list__(
             [tp.Tensor(1.0, dtype=tp.int32), tp.Tensor(3, dtype=tp.float16), tp.Tensor(5, dtype=tp.float32)]
         )
 
@@ -302,30 +305,30 @@ class TestConvertInputsToTensors:
             tp.TripyException,
             match=r"At least one of the arguments: \('a', 'b', 'c'\) must be a \`tripy.Tensor\`.",
         ):
-            x, y, z = sync_arg_types(3.0, 3, 4)
+            x, y, z = __func_test_sync_arg_types__(3.0, 3, 4)
 
     def test_seq_arg_invalid(self):
         with helper.raises(
             tp.TripyException,
             match=r"Encountered non-number of type str in sequence: hello",
         ):
-            _ = func([1, 2, "hello"])
+            _ = __func_test_basic__([1, 2, "hello"])
 
     def test_nested_seq_inconsistent_len(self):
         with helper.raises(
             tp.TripyException,
             match=r"Expected a sequence of length 3 but got length 4: \[7, 8, 9, 10\]",
         ):
-            _ = func([[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]])
+            _ = __func_test_basic__([[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]])
 
     def test_nested_seq_inconsistent_types(self):
         with helper.raises(
             tp.TripyException,
             match=r"Expected a sequence but got str: hi",
         ):
-            _ = func([[1, 2, 3], [4, 5, 6], "hi"])
+            _ = __func_test_basic__([[1, 2, 3], [4, 5, 6], "hi"])
 
     def test_invalid_argument_type_not_converted(self):
         a = np.array([1, 2, 3])
-        b = func(np.array([1, 2, 3]))
+        b = __func_test_basic__(np.array([1, 2, 3]))
         assert (a == b).all()

--- a/tripy/tests/frontend/test_utils.py
+++ b/tripy/tests/frontend/test_utils.py
@@ -179,7 +179,7 @@ class TestConvertInputsToTensors:
         assert isinstance(s, tp.Shape)
         assert cp.from_dlpack(s).get().tolist() == [1, 2]
 
-    def test_convert_only_named_argument_to_shape(self):
+    def test_convert_only_specified_argument_to_shape(self):
         t1 = tp.Tensor([1, 2, 3], dtype=tp.int32)
         s, t2 = ignore_not_named(t1, [4, 5, 6])
         assert isinstance(s, tp.Shape)

--- a/tripy/tests/frontend/test_utils.py
+++ b/tripy/tests/frontend/test_utils.py
@@ -19,7 +19,7 @@ import cupy as cp
 import numpy as np
 
 import tripy as tp
-from tripy.frontend.utils import convert_inputs_to_tensors
+from tripy.frontend.utils import convert_inputs_to_tensors, convert_shape_inputs
 from tests import helper
 
 
@@ -78,9 +78,14 @@ def sync_list_types(xs, ys):
     return xs, ys
 
 
-@convert_inputs_to_tensors(shape_argument=["s"])
+@convert_shape_inputs(["s"])
 def convert_shape(s):
     return s
+
+
+@convert_shape_inputs(["s"])
+def ignore_not_named(s, t):
+    return (s, t)
 
 
 class TestConvertInputsToTensors:
@@ -170,6 +175,12 @@ class TestConvertInputsToTensors:
         s = convert_shape([t1, t2])
         assert isinstance(s, tp.Shape)
         assert cp.from_dlpack(s).get().tolist() == [1, 2]
+
+    def test_convert_only_named_argument_to_shape(self):
+        t1 = tp.Tensor([1, 2, 3], dtype=tp.int32)
+        s, t2 = ignore_not_named(t1, [4, 5, 6])
+        assert isinstance(s, tp.Shape)
+        assert t2 == [4, 5, 6]
 
     # When we convert arguments to tensors, we should preserve the column range
     # of the original non-Tensor argument.

--- a/tripy/tests/frontend/trace/ops/test_binary_elementwise.py
+++ b/tripy/tests/frontend/trace/ops/test_binary_elementwise.py
@@ -41,6 +41,9 @@ _COMPARISON_OPS = [
     (Comparison.Kind.GREATER, lambda a, b: a > b),
 ]
 
+# Ops that do not automatically convert data types
+_NON_CONVERTING_OPS = {BinaryElementwise.Kind.MAXIMUM, BinaryElementwise.Kind.MINIMUM}
+
 # Ops that are flipped instead of calling a right-side version.
 _FLIP_OPS = {}
 for key, val in {
@@ -68,6 +71,12 @@ class TestBinaryElementwise:
     )
     @pytest.mark.parametrize("kind, func", _BINARY_OPS + _COMPARISON_OPS)
     def test_op_funcs(self, kind, func, lhs, rhs, left_side_is_non_tensor):
+        if kind in _NON_CONVERTING_OPS:
+            if not isinstance(lhs, tp.Tensor):
+                lhs = tp.Tensor(lhs)
+            if not isinstance(rhs, tp.Tensor):
+                rhs = tp.Tensor(rhs)
+
         out = func(lhs, rhs)
         assert isinstance(out, tp.Tensor)
         assert isinstance(out.trace_tensor.producer, BinaryElementwise)

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -105,9 +105,9 @@ def str_from_source_info(source_info, enable_color=True, is_first_frame=True, ca
 
 
 def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
-    from tripy.frontend.utils import convert_inputs_to_tensors
+    from tripy.frontend.utils import convert_inputs_to_tensors, convert_shape_inputs
 
-    EXCLUDE_FUNCTIONS = [convert_inputs_to_tensors]
+    EXCLUDE_FUNCTIONS = [convert_inputs_to_tensors, convert_shape_inputs]
 
     def should_exclude(frame):
         for func in EXCLUDE_FUNCTIONS:

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -28,7 +28,7 @@ from tripy.frontend import utils as frontend_utils
 
 
 @export.public_api(document_under="operations/initializers")
-@frontend_utils.convert_inputs_to_tensors(shape_argument=["shape"], exclude=["dtype"])
+@frontend_utils.convert_shape_inputs(["shape"])
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["int32"],
@@ -64,7 +64,7 @@ def ones(
 
 
 @export.public_api(document_under="operations/initializers")
-@frontend_utils.convert_inputs_to_tensors(shape_argument=["shape"], exclude=["dtype"])
+@frontend_utils.convert_shape_inputs(["shape"])
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["int32"],

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -280,7 +280,7 @@ class Shape(Tensor):
         # so we should clamp the argument
         if other.rank == 0:
             other = reshape(other, (1,))
-        other = Shape(maximum(other, 0)) + [len(self)]
+        other = Shape(maximum(other, Tensor(0, int32))) + [len(self)]
 
         unsqueezed = unsqueeze(self, 0)
         tiled = expand(unsqueezed, other)

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -291,7 +291,7 @@ class Shape(Tensor):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    @frontend_utils.convert_inputs_to_tensors(shape_argument=["other"])
+    @frontend_utils.convert_shape_inputs(["other"])
     def __eq__(self, other):
         from tripy.frontend.trace.ops.reduce import all
 

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -627,12 +627,11 @@ def __rmod__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]
 
 
 @export.public_api(document_under="operations/functions")
-@frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("lhs", "rhs")])
 @constraints.dtype_info(
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"lhs": "T1", "rhs": "T1", constraints.RETURN_VALUE: "T1"},
 )
-def maximum(lhs: "tripy.types.TensorLike", rhs: "tripy.types.TensorLike") -> "tripy.Tensor":
+def maximum(lhs: "tripy.Tensor", rhs: "tripy.Tensor") -> "tripy.Tensor":
     """
     Performs an elementwise maximum.
 
@@ -658,12 +657,11 @@ def maximum(lhs: "tripy.types.TensorLike", rhs: "tripy.types.TensorLike") -> "tr
 
 
 @export.public_api(document_under="operations/functions")
-@frontend_utils.convert_inputs_to_tensors(sync_arg_types=[("lhs", "rhs")])
 @constraints.dtype_info(
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
     dtype_constraints={"lhs": "T1", "rhs": "T1", constraints.RETURN_VALUE: "T1"},
 )
-def minimum(lhs: "tripy.types.TensorLike", rhs: "tripy.types.TensorLike") -> "tripy.Tensor":
+def minimum(lhs: "tripy.Tensor", rhs: "tripy.Tensor") -> "tripy.Tensor":
     """
     Performs an elementwise minimum.
 

--- a/tripy/tripy/frontend/trace/ops/dequantize.py
+++ b/tripy/tripy/frontend/trace/ops/dequantize.py
@@ -108,7 +108,6 @@ class Dequantize(BaseTraceOp):
 
 
 @export.public_api(document_under="operations/quantization")
-@frontend_utils.convert_inputs_to_tensors(exclude=["dtype", "dim"])
 @constraints.dtype_info(
     dtype_variables={"T1": ["int4", "int8", "float8"], "T2": ["float32", "float16", "bfloat16"]},
     dtype_constraints={"input": "T1", "scale": "T2", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
@@ -186,6 +185,11 @@ def dequantize(
 
     .. seealso:: :func:`quantize`
     """
+    from tripy.frontend import Tensor
+
+    if not isinstance(scale, Tensor):
+        scale = Tensor(scale)
+
     op_utils.check_qdq_args(input, scale, dtype, dim, False)
 
     return Dequantize.build([input, scale], dtype, dim)

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -69,7 +69,7 @@ class Expand(BaseTraceOp):
         )
 
 
-@frontend_utils.convert_inputs_to_tensors(exclude=["input", "output_rank", "output_len"], shape_argument=["shape"])
+@frontend_utils.convert_shape_inputs(["shape"])
 def expand_impl(input: "tripy.Tensor", shape: Sequence, output_rank: int, output_len: Optional[int] = None):
     return Expand.build([input, shape], output_rank, output_len)
 

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -92,7 +92,7 @@ class Fill(BaseTraceOp):
         )
 
 
-@frontend_utils.convert_inputs_to_tensors(exclude=["value", "dtype", "output_rank"], shape_argument=["shape"])
+@frontend_utils.convert_shape_inputs(["shape"])
 def full_impl(
     shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
     value: Union[numbers.Number, "tripy.Tensor"],

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -68,7 +68,7 @@ class Iota(BaseTraceOp):
         DynamicIotaOp.build(inputs, outputs, dim=self.dim)
 
 
-@frontend_utils.convert_inputs_to_tensors(exclude=["dim", "dtype", "output_rank"], shape_argument=["shape"])
+@frontend_utils.convert_shape_inputs(["shape"])
 def iota_impl(
     shape: Union["tripy.Shape", Sequence[int]], dim: int, dtype: datatype.dtype, output_rank: int
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/quantize.py
+++ b/tripy/tripy/frontend/trace/ops/quantize.py
@@ -128,7 +128,6 @@ class Quantize(BaseTraceOp):
 
 
 @export.public_api(document_under="operations/quantization")
-@frontend_utils.convert_inputs_to_tensors(exclude=["dtype", "dim"])
 @constraints.dtype_info(
     dtype_variables={"T1": ["float32", "float16", "bfloat16"], "T2": ["int4", "int8", "float8"]},
     dtype_constraints={"input": "T1", "scale": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
@@ -211,6 +210,11 @@ def quantize(
 
     .. seealso:: :func:`dequantize`
     """
+    from tripy.frontend import Tensor
+
+    if not isinstance(scale, Tensor):
+        scale = Tensor(scale)
+
     op_utils.check_qdq_args(input, scale, dtype, dim, True)
 
     return Quantize.build([input, scale], dtype, dim)

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -406,11 +406,14 @@ def var(
         torch_input = torch.arange(6, dtype=torch.float32).reshape((2, 3)) # doc: omit
         assert np.array_equal(cp.from_dlpack(output).get(), np.from_dlpack(torch_input.var(dim=1, keepdim=True)))
     """
+    from tripy.frontend import Tensor
     from tripy.frontend.trace.ops.binary_elementwise import maximum
 
     mean_val = mean(input, dim=dim, keepdim=dim is not None)
     sub = (input - mean_val) ** 2.0
-    return mean_impl(sub, dim=dim, keepdim=keepdim, apply_to_divisor=lambda x: maximum(x - correction, 0))
+    return mean_impl(
+        sub, dim=dim, keepdim=keepdim, apply_to_divisor=lambda x: maximum(x - Tensor(correction), Tensor(0))
+    )
 
 
 def _arg_min_max_impl(tensor: "tripy.Tensor", kind: ArgMinMax.Kind, dim: Optional[int], keepdim: bool):

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -65,7 +65,7 @@ class Reshape(BaseTraceOp):
         DynamicReshapeOp.build(inputs, outputs)
 
 
-@frontend_utils.convert_inputs_to_tensors(exclude=["input", "output_rank", "output_len"], shape_argument=["shape"])
+@frontend_utils.convert_shape_inputs(["shape"])
 def reshape_impl(
     input: "tripy.Tensor", shape: Sequence, output_rank: int, output_len: Optional[int] = None
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -26,18 +26,139 @@ from tripy.flat_ir.ops import BaseFlatIROp
 from tripy.frontend.trace.ops import BaseTraceOp
 
 
+# Try to include correct column offsets for non-tensor arguments.
+def _add_column_info_for_non_tensor(
+    arg, arg_index, is_kwarg, dtype, num_args, func_name, skip_num_stack_entries, list_index=None
+):
+    from tripy.frontend.tensor import Tensor
+
+    assert not isinstance(arg, Tensor)
+    arg = Tensor(arg, dtype=dtype)
+    arg.stack_info.fetch_source_code()
+
+    # This is the stack depth in arg.stack_info where we find the decorated function.
+    for idx, source_info in enumerate(arg.stack_info):
+        if source_info.function == "wrapper" and source_info.module == __name__:
+            WRAPPER_STACK_DEPTH = idx + 1
+            break
+    else:
+        assert (
+            False
+        ), "`wrapper` function was not found in the call stack. Please update the check above if the name of the wrapper function has changed."
+
+    # Find the first caller of this function that is NOT the function registry.
+    # Also save the last dispatch target we see.
+    dispatch_target = None
+    for idx, source_info in enumerate(arg.stack_info[WRAPPER_STACK_DEPTH + skip_num_stack_entries :]):
+        import tripy.function_registry
+
+        dispatch_target = source_info._dispatch_target or dispatch_target
+        if source_info.module not in utils.get_module_names_to_exclude_from_stack_info():
+            frame_index = idx + WRAPPER_STACK_DEPTH + skip_num_stack_entries
+            break
+    else:
+        # Fallback path is just to look at the user code
+        frame_index = arg.stack_info.get_first_user_frame_index()
+        dispatch_target = arg.stack_info[frame_index - 1]._dispatch_target
+
+    source_info = arg.stack_info[frame_index]
+
+    # The reverse binary ops need special handling since they will be swapped out for the non-reverse
+    # variants and the order of operands will be inverted.
+    REVERSE_BIN_OPS = {
+        "__radd__",
+        "__rmul__",
+        "__rsub__",
+        "__rpow__",
+        "__rtruediv__",
+    }
+
+    if dispatch_target in REVERSE_BIN_OPS:
+        assert arg_index in [0, 1]
+        arg_index = 0 if arg_index == 1 else 1
+        dispatch_target = dispatch_target.replace("__r", "__")
+
+    # Special case for __getitem__: It is variadic. Argument 0 is the tensor,
+    # and all subsequent arguments are slice parameters (in start, stop, step order).
+    # Hence, we subtract two to get the index of the slice parameters
+    if dispatch_target == "__getitem__":
+        arg_index -= 1
+
+    candidates = utils.get_arg_candidate_column_offsets(
+        source_info.code,
+        arg_index,
+        num_args,
+        dispatch_target if dispatch_target else func_name,
+        is_kwarg,
+        list_index=list_index,
+    )
+
+    # Only set column range if there is exactly one candidate, otherwise we can't reliably determine
+    # what we should be pointing at.
+    if len(candidates) == 1:
+        source_info.column_range = candidates[0]
+
+    return arg
+
+
+def _convert_nontensor_arg(
+    arg, arg_idx, is_kwarg, num_args, func_name, skip_num_stack_entries, cast_dtype=None, list_index=None
+):
+    from tripy.utils import Result
+
+    def is_valid_sequence(seq_arg: Sequence) -> Result:
+        if len(seq_arg) == 0:
+            return Result.ok()
+        # If one is a sequence, all must be sequences of the same length. Do not accept strings.
+        if isinstance(seq_arg[0], Sequence) and not isinstance(seq_arg[0], str):
+            target_len = len(seq_arg[0])
+            for inner_arg in seq_arg[1:]:
+                if not isinstance(inner_arg, Sequence) or isinstance(inner_arg, str):
+                    return Result.err([f"Expected a sequence but got {type(inner_arg).__qualname__}: {inner_arg}"])
+                if len(inner_arg) != target_len:
+                    return Result.err(
+                        [f"Expected a sequence of length {target_len} but got length {len(inner_arg)}: {inner_arg}"]
+                    )
+                valid_inner = is_valid_sequence(inner_arg)
+                if not valid_inner:
+                    return valid_inner
+            return Result.ok()
+        # Otherwise check for numbers.
+        for inner_arg in seq_arg:
+            if not isinstance(inner_arg, numbers.Number):
+                return Result.err(
+                    [f"Encountered non-number of type {type(inner_arg).__qualname__} in sequence: {inner_arg}"]
+                )
+        return Result.ok()
+
+    if isinstance(arg, Sequence):
+        valid_sequence = is_valid_sequence(arg)
+        if not valid_sequence:
+            raise_error(f"Encountered invalid sequence argument: {arg}", details=valid_sequence.error_details)
+
+    return _add_column_info_for_non_tensor(
+        arg,
+        arg_idx,
+        is_kwarg=is_kwarg,
+        dtype=cast_dtype,
+        num_args=num_args,
+        func_name=func_name,
+        skip_num_stack_entries=skip_num_stack_entries,
+        list_index=list_index,
+    )
+
+
 # Decorator to preprocess inputs of a function and convert Python numbers to tripy tensors.
 def convert_inputs_to_tensors(
     sync_arg_types: Optional[List[Tuple[str]]] = None,
     exclude: Optional[List[str]] = None,
     unpack_argument: Optional[List[str]] = None,
-    shape_argument: Optional[List[str]] = None,
     skip_num_stack_entries: int = 0,
 ):
     """
-    Decorator that converts all arguments to `Tensor`s or `Shape`s before passing them along
+    Decorator that converts all arguments to `Tensor`s before passing them along
     to the decorated function. Converts only Python numbers or lists of Python numbers;
-    inputs like `numpy` arrays should be handled manually.
+    inputs like `numpy` arrays will be left unchanged and should be handled manually.
 
     Args:
         sync_arg_types: A list of tuples of strings indicating the parameter indices for parameters
@@ -53,10 +174,6 @@ def convert_inputs_to_tensors(
           the members of the list will each be individually converted into `Tensor`s,
           rather than having the whole list converted into a `Tensor`.
 
-        shape_argument: If an argument is included, it will be converted into a `Shape` rather than
-          an ordinary `Tensor`. If the named argument is a list, the individual members of the argument
-          will be converted to `Shape`s and then concatenated together into a single `Shape`.
-
         skip_num_stack_entries: If the decorator is used on a function that is *called by*
             a function that the user invokes, it will be necessary to skip stack entries
             in order to get the column info from the user code. The number of entries skipped
@@ -68,85 +185,12 @@ def convert_inputs_to_tensors(
     sync_arg_types = utils.default(sync_arg_types, [])
     exclude = utils.default(exclude, [])
     unpack_argument = utils.default(unpack_argument, [])
-    shape_argument = utils.default(shape_argument, [])
 
     def impl(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             from tripy.common.exception import raise_error
-            from tripy.frontend.shape import Shape
             from tripy.frontend.tensor import Tensor
-
-            # Try to include correct column offsets for non-tensor arguments.
-            def add_column_info_for_non_tensor(arg, arg_index, is_kwarg, dtype, list_index=None):
-                assert not isinstance(arg, Tensor)
-                arg = Tensor(arg, dtype=dtype)
-                arg.stack_info.fetch_source_code()
-
-                # This is the stack depth in arg.stack_info where we find the function
-                # that's decorated with `convert_inputs_to_tensors()`.
-                for idx, source_info in enumerate(arg.stack_info):
-                    if source_info.function == "wrapper" and source_info.module == __name__:
-                        WRAPPER_STACK_DEPTH = idx + 1
-                        break
-                else:
-                    assert (
-                        False
-                    ), "`wrapper` function was not found in the call stack. Please update the check above if the name of the wrapper function has changed."
-
-                # Find the first caller of this function that is NOT the function registry.
-                # Also save the last dispatch target we see.
-                dispatch_target = None
-                for idx, source_info in enumerate(arg.stack_info[WRAPPER_STACK_DEPTH + skip_num_stack_entries :]):
-                    import tripy.function_registry
-
-                    dispatch_target = source_info._dispatch_target or dispatch_target
-                    if source_info.module not in utils.get_module_names_to_exclude_from_stack_info():
-                        frame_index = idx + WRAPPER_STACK_DEPTH + skip_num_stack_entries
-                        break
-                else:
-                    # Fallback path is just to look at the user code
-                    frame_index = arg.stack_info.get_first_user_frame_index()
-                    dispatch_target = arg.stack_info[frame_index - 1]._dispatch_target
-
-                source_info = arg.stack_info[frame_index]
-
-                # The reverse binary ops need special handling since they will be swapped out for the non-reverse
-                # variants and the order of operands will be inverted.
-                REVERSE_BIN_OPS = {
-                    "__radd__",
-                    "__rmul__",
-                    "__rsub__",
-                    "__rpow__",
-                    "__rtruediv__",
-                }
-
-                if dispatch_target in REVERSE_BIN_OPS:
-                    assert arg_index in [0, 1]
-                    arg_index = 0 if arg_index == 1 else 1
-                    dispatch_target = dispatch_target.replace("__r", "__")
-
-                # Special case for __getitem__: It is variadic. Argument 0 is the tensor,
-                # and all subsequent arguments are slice parameters (in start, stop, step order).
-                # Hence, we subtract two to get the index of the slice parameters
-                if dispatch_target == "__getitem__":
-                    arg_index -= 1
-
-                candidates = utils.get_arg_candidate_column_offsets(
-                    source_info.code,
-                    arg_index,
-                    len(args),
-                    dispatch_target if dispatch_target else func.__name__,
-                    is_kwarg,
-                    list_index=list_index,
-                )
-
-                # Only set column range if there is exactly one candidate, otherwise we can't reliably determine
-                # what we should be pointing at.
-                if len(candidates) == 1:
-                    source_info.column_range = candidates[0]
-
-                return arg
 
             all_args = utils.merge_function_arguments(func, *args, **kwargs)
 
@@ -195,97 +239,21 @@ def convert_inputs_to_tensors(
                     return None
 
                 def convert_nontensor_arg(arg, list_index=None):
-                    from tripy.utils import Result
-
-                    def is_valid_sequence(seq_arg: Sequence) -> Result:
-                        if len(seq_arg) == 0:
-                            return Result.ok()
-                        # If one is a sequence, all must be sequences of the same length. Do not accept strings.
-                        if isinstance(seq_arg[0], Sequence) and not isinstance(seq_arg[0], str):
-                            target_len = len(seq_arg[0])
-                            for inner_arg in seq_arg[1:]:
-                                if not isinstance(inner_arg, Sequence) or isinstance(inner_arg, str):
-                                    return Result.err(
-                                        [f"Expected a sequence but got {type(inner_arg).__qualname__}: {inner_arg}"]
-                                    )
-                                if len(inner_arg) != target_len:
-                                    return Result.err(
-                                        [
-                                            f"Expected a sequence of length {target_len} but got length {len(inner_arg)}: {inner_arg}"
-                                        ]
-                                    )
-                                valid_inner = is_valid_sequence(inner_arg)
-                                if not valid_inner:
-                                    return valid_inner
-                            return Result.ok()
-                        # Otherwise check for numbers.
-                        for inner_arg in seq_arg:
-                            if not isinstance(inner_arg, numbers.Number):
-                                return Result.err(
-                                    [
-                                        f"Encountered non-number of type {type(inner_arg).__qualname__} in sequence: {inner_arg}"
-                                    ]
-                                )
-                        return Result.ok()
-
                     # simply do not convert in these cases and let the registry give an error instead
                     if not isinstance(arg, numbers.Number) and not isinstance(arg, Sequence):
                         return arg
 
-                    if isinstance(arg, Sequence):
-                        valid_sequence = is_valid_sequence(arg)
-                        if not valid_sequence:
-                            raise_error(
-                                f"Encountered invalid sequence argument: {arg}", details=valid_sequence.error_details
-                            )
-
-                    cast_dtype = find_sync_target_dtype(name)
-                    return add_column_info_for_non_tensor(
-                        arg, index, is_kwarg=name in kwargs, dtype=cast_dtype, list_index=list_index
+                    return _convert_nontensor_arg(
+                        arg,
+                        index,
+                        name in kwargs,
+                        len(args),
+                        func.__name__,
+                        skip_num_stack_entries,
+                        find_sync_target_dtype(name),
+                        list_index=list_index,
                     )
 
-                if name in shape_argument:
-                    from tripy.frontend.trace.ops.concatenate import concatenate
-                    from tripy.frontend.trace.ops.unsqueeze import unsqueeze
-
-                    if isinstance(arg, Shape):
-                        add_arg(arg)
-                        continue
-                    if isinstance(arg, Tensor):
-                        add_arg(Shape(arg))
-                        continue
-                    # if it's not a tensor and not a sequence, we treat as a singleton shape
-                    if not isinstance(arg, Sequence):
-                        add_arg(Shape(convert_nontensor_arg([arg])))
-                        continue
-                    # otherwise, for a sequence we convert all at once if no member is a tensor
-                    # and concatenate together with tensors if there is
-                    if len(arg) == 0:
-                        add_arg(Shape([]))
-                        continue
-
-                    if not any(map(lambda member: isinstance(member, Tensor), arg)):
-                        add_arg(Shape(convert_nontensor_arg(arg)))
-                        continue
-
-                    shape_components = []
-                    # accumulate non-tensors together to be converted into shapes
-                    acc = []
-                    for member in arg:
-                        if not isinstance(member, Tensor):
-                            acc.append(member)
-                            continue
-                        if len(acc) > 0:
-                            shape_components.append(Shape(convert_nontensor_arg(acc)))
-                            acc = []
-                        if member.rank != 0:
-                            raise_error("Tensor in a shape argument must be a scalar.", [f"Got {member}"])
-                        member = Shape(unsqueeze(member, 0))
-                        shape_components.append(member)
-                    if len(acc) > 0:
-                        shape_components.append(Shape(convert_nontensor_arg(acc)))
-                    add_arg(concatenate(shape_components, 0))
-                    continue
                 if name in exclude or isinstance(arg, Tensor):
                     add_arg(arg)
                     continue
@@ -299,6 +267,116 @@ def convert_inputs_to_tensors(
                     add_arg(new_list)
                     continue
                 add_arg(convert_nontensor_arg(arg))
+
+            return func(*new_args, **new_kwargs)
+
+        return wrapper
+
+    return impl
+
+
+def convert_shape_inputs(targets: Sequence[str], skip_num_stack_entries: int = 0):
+    """
+    Decorator that converts the specified arguments to `Shape`s before passing them along
+    to the decorated function. Converts only Tripy Tensors, Python numbers, or lists of Python numbers;
+    other input formats like `numpy` arrays will not be accepted.
+
+    If a targeted argument is a list, the individual members will be converted to `Shape`s
+    and then concatenated together into a single `Shape`.
+
+    Args:
+        targets: List of args to the decorated function to convert.
+
+        skip_num_stack_entries: If the decorator is used on a function that is *called by*
+            a function that the user invokes, it will be necessary to skip stack entries
+            in order to get the column info from the user code. The number of entries skipped
+            should be equal to the nesting depth from a function called by user code
+            (if the decorated function is called by the user the depth is 0;
+            if the decorated function is called from a user function, the depth is 1; etc.)
+    """
+
+    def impl(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            from tripy.common.exception import raise_error
+            from tripy.frontend.shape import Shape
+            from tripy.frontend.tensor import Tensor
+
+            all_args = utils.merge_function_arguments(func, *args, **kwargs)
+
+            new_args = []
+            new_kwargs = {}
+            for index, (name, arg) in enumerate(all_args):
+
+                def add_arg(arg):
+                    if name not in kwargs:
+                        new_args.append(arg)
+                    else:
+                        new_kwargs[name] = arg
+
+                def convert_nontensor_arg(arg, list_index=None):
+                    if not isinstance(arg, numbers.Number) and not isinstance(arg, Sequence):
+                        raise_error(
+                            f"Unsupported input format {type(arg)} in argument {arg}. "
+                            "Expected a Tripy Tensor or sequence of Python numbers."
+                        )
+
+                    return _convert_nontensor_arg(
+                        arg,
+                        index,
+                        name in kwargs,
+                        len(args),
+                        func.__name__,
+                        skip_num_stack_entries,
+                        cast_dtype=None,
+                        list_index=list_index,
+                    )
+
+                if name not in targets:
+                    add_arg(arg)
+                    continue
+
+                from tripy.frontend.trace.ops.concatenate import concatenate
+                from tripy.frontend.trace.ops.unsqueeze import unsqueeze
+
+                if isinstance(arg, Shape):
+                    add_arg(arg)
+                    continue
+                if isinstance(arg, Tensor):
+                    add_arg(Shape(arg))
+                    continue
+                # if it's not a tensor and not a sequence, we treat as a singleton shape
+                if not isinstance(arg, Sequence):
+                    add_arg(Shape(convert_nontensor_arg([arg])))
+                    continue
+
+                # otherwise, for a sequence we convert all at once if no member is a tensor
+                # and concatenate together with tensors if there is
+                if len(arg) == 0:
+                    add_arg(Shape([]))
+                    continue
+
+                if not any(map(lambda member: isinstance(member, Tensor), arg)):
+                    add_arg(Shape(convert_nontensor_arg(arg)))
+                    continue
+
+                shape_components = []
+                # accumulate non-tensors together to be converted into shapes
+                acc = []
+                for member in arg:
+                    if not isinstance(member, Tensor):
+                        acc.append(member)
+                        continue
+                    if len(acc) > 0:
+                        shape_components.append(Shape(convert_nontensor_arg(acc)))
+                        acc = []
+                    if member.rank != 0:
+                        raise_error("Tensor in a shape argument must be a scalar.", [f"Got {member}"])
+                    member = Shape(unsqueeze(member, 0))
+                    shape_components.append(member)
+                if len(acc) > 0:
+                    shape_components.append(Shape(convert_nontensor_arg(acc)))
+                add_arg(concatenate(shape_components, 0))
 
             return func(*new_args, **new_kwargs)
 


### PR DESCRIPTION
Addresses issue #214 and separates shape argument conversion from the `convert_inputs_to_tensors` decorator. Since most uses of the shape argument conversion would only convert one argument (usually named shape), this decorator takes a list of arguments to convert rather than converting all arguments by default. It also does not accept arguments that aren't sequences of Python numbers or Tripy Tensors, since it would make less sense to allow external data formats to silently pass through in cases that aren't operator overloads.