### PR TITLE
Various bug fixes to fix L1 tests

### DIFF
--- a/tripy/docs/post0_developer_guides/design-decisions.md
+++ b/tripy/docs/post0_developer_guides/design-decisions.md
@@ -100,7 +100,7 @@ to MLIR if needed or return the newly created ones.
 
 ## Why Not Build On [JAX](https://github.com/google/jax)?
 
-Tripy’s architecture looks very similar to JAX's, where python code is staged out and
+Tripy's architecture looks very similar to JAX's, where python code is staged out and
 lowered into a custom IR and eventually to MLIR.
 
 Then why not build on top of JAX? There are a couple reasons:

--- a/tripy/docs/pre0_user_guides/02-compiler.md
+++ b/tripy/docs/pre0_user_guides/02-compiler.md
@@ -58,7 +58,7 @@ fast_geglu(inp).eval()
 ### Optimization Profiles
 
 In the example above, we assumed `inp` has a static shape of `(1, 2)`.
-Now, let’s assume that the shape of `inp` can vary from `(1, 2)` to `(16, 2)`, with `(8, 2)`
+Now, let's assume that the shape of `inp` can vary from `(1, 2)` to `(16, 2)`, with `(8, 2)`
 being the shape we'd like to optimize for. To express this constraint to the compiler,
 we can provide the range of shapes to `InputInfo` using `shape=((1, 8, 16), 2)`.
 This indicates to the compiler that the first dimension can vary from 1 to 16,

--- a/tripy/tests/flat_ir/ops/test_gather.py
+++ b/tripy/tests/flat_ir/ops/test_gather.py
@@ -20,6 +20,7 @@ import tripy as tp
 
 from tripy.flat_ir.ops import DynamicGatherOp
 from tripy.frontend.trace import Trace
+import re
 
 
 class TestGatherOp:
@@ -38,9 +39,9 @@ class TestGatherOp:
         reshape = flat_ir.ops[-2]
         print(str(reshape))
         assert isinstance(gather, DynamicGatherOp)
-        assert (
-            str(gather)
-            == f"out: [rank=(3), dtype=(float32), loc=(gpu:0)] = DynamicGatherOp(data, indices, t_inter4, axis={axis})"
+        assert re.match(
+            rf"out: \[rank=\(3\), dtype=\(float32\), loc=\(gpu:0\)\] = DynamicGatherOp\(data, indices, t_inter[0-9]+, axis={axis}\)",
+            str(gather),
         )
 
     @pytest.mark.parametrize("axis", [0, 1])

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -43,17 +43,24 @@ TAB_SIZE = 4
 
 ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 
-MARKDOWN_FILES = [
-    path
-    for path in glob.glob(os.path.join(ROOT_DIR, "**", "*.md"), recursive=True)
-    if not path.startswith(
-        (
-            os.path.join(ROOT_DIR, "build"),
-            os.path.join(ROOT_DIR, "mlir-tensorrt"),
-            os.path.join(ROOT_DIR, "stablehlo"),
+
+def get_files_with_extension(ext):
+    return [
+        path
+        for path in glob.glob(os.path.join(ROOT_DIR, "**", f"*{ext}"), recursive=True)
+        if not path.startswith(
+            (
+                os.path.join(ROOT_DIR, "build"),
+                os.path.join(ROOT_DIR, "mlir-tensorrt"),
+                os.path.join(ROOT_DIR, "stablehlo"),
+            )
         )
-    )
-]
+    ]
+
+
+MARKDOWN_FILES = get_files_with_extension(".md")
+
+PYTHON_FILES = get_files_with_extension(".py")
 
 
 @contextlib.contextmanager

--- a/tripy/tests/spec_verification/object_builders.py
+++ b/tripy/tests/spec_verification/object_builders.py
@@ -60,6 +60,7 @@ def default_builder(init, dtype, namespace):
 
 find_func = {
     "tripy.Tensor": tensor_builder,
+    "tripy.types.TensorLike": tensor_builder,
     "tripy.Shape": tensor_builder,
     "tripy.dtype": dtype_builder,
     datatype.dtype: dtype_builder,
@@ -83,6 +84,12 @@ All other types do not have defaults and must be passed to the verifier using de
 default_constraints_all = {
     "__getitem__": {"index": 2},
     "__matmul__": {"self": tp.ones((2, 3))},
+    # Force broadcasting for binary ops so the entire broadcasting code path is triggered.
+    "__add__": {"other": 1},
+    "__mul__": {"other": 1},
+    "__pow__": {"other": 1},
+    "__sub__": {"other": 1},
+    "__truediv__": {"other": 1},
     "__radd__": {"self": 1},
     "__rmul__": {"self": 1},
     "__rpow__": {"self": 1},
@@ -105,21 +112,23 @@ default_constraints_all = {
     },
     "cumsum": {"dim": 0},
     "dequantize": {"scale": tp.Tensor([1, 1, 1]), "dim": 0},
-    "expand": {"sizes": tp.Tensor([3, 4]), "input": tp.ones((3, 1))},
+    "expand": {"sizes": [3, 4], "input": tp.ones((3, 1))},
     "flip": {"dim": 1},
     "full_like": {"value": 1},
-    "full": {"shape": tp.Tensor([3]), "value": 1},
+    "full": {"shape": [3], "value": 1},
     "gather": {"dim": 0, "index": tp.Tensor([1])},
-    "iota": {"shape": tp.Tensor([4])},
+    "iota": {"shape": [4]},
     "masked_fill": {"value": 1},
+    "maxpool": {"input": tp.ones((1, 3, 5, 5)), "kernel_dims": (3, 3)},
     "max": {"dim": 0},
     "mean": {"dim": 0},
-    "ones": {"shape": tp.Tensor([3, 2])},
+    "ones": {"shape": [3, 2]},
+    "outer": {"vec1": tp.Tensor([2, 3, 4, 5]), "vec2": tp.Tensor([1, 2, 3, 4])},
     "permute": {"perm": [1, 0]},
     "prod": {"dim": 0},
     "quantize": {"scale": tp.Tensor([1, 1, 1]), "dim": 0},
     "repeat": {"repeats": 2, "dim": 0},
-    "reshape": {"shape": tp.Tensor([6])},
+    "reshape": {"shape": [6]},
     "softmax": {"dim": 1},
     "split": {"indices_or_sections": 2},
     "squeeze": {"input": tp.ones((3, 1)), "dims": (1)},
@@ -127,7 +136,7 @@ default_constraints_all = {
     "transpose": {"dim0": 0, "dim1": 1},
     "unsqueeze": {"dim": 1},
     "var": {"dim": 0},
-    "zeros": {"shape": tp.Tensor([3, 2])},
+    "zeros": {"shape": [3, 2]},
 }
 
 

--- a/tripy/tests/spec_verification/test_dtype_constraints.py
+++ b/tripy/tests/spec_verification/test_dtype_constraints.py
@@ -172,8 +172,6 @@ def _run_dtype_constraints_subtest(test_data):
     return ret_val, namespace
 
 
-# Positive dtype testing is run during L1 testing.
-@pytest.mark.l1
 @pytest.mark.parametrize("test_data", DTYPE_CONSTRAINT_CASES, ids=lambda val: val[-1])
 def test_dtype_constraints(test_data):
     # If data type checking is enabled, negative tests will trivially pass (we will throw an

--- a/tripy/tests/test_files.py
+++ b/tripy/tests/test_files.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from tests import helper
+
+
+# Checks all Python and markdown files to ensure there are no non-ASCII characters
+@pytest.mark.parametrize("file", helper.MARKDOWN_FILES + helper.PYTHON_FILES)
+def test_no_non_ascii_characters(file):
+    with open(file, "rb") as f:
+        contents = f.read()
+
+    try:
+        contents.decode("ascii")
+    except UnicodeDecodeError as err:
+        str_contents = contents.decode("utf-8")
+
+        non_ascii = str_contents[err.start : err.end]
+
+        line_num = [line_num for line_num, line in enumerate(str_contents.splitlines()) if non_ascii in line][0] + 1
+
+        assert False, f"Detected non-ASCII character(s) on line {line_num}: {non_ascii}"

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -97,9 +97,6 @@ def str_from_source_info(source_info, enable_color=True, is_first_frame=True, ca
         frame_info += " " * start + apply_color("^" * (size), Fore.red)
         if not is_first_frame:
             frame_info += " --- required from here"
-    else:
-        if not is_first_frame:
-            frame_info = "Required from:\n" + frame_info
     frame_info += "\n\n"
     return frame_info
 

--- a/tripy/tripy/export.py
+++ b/tripy/tripy/export.py
@@ -19,7 +19,7 @@ import inspect
 from dataclasses import dataclass
 from typing import List, Optional, Any
 from types import ModuleType
-
+from textwrap import dedent
 from tripy.function_registry import FunctionRegistry
 
 
@@ -40,7 +40,11 @@ PUBLIC_API_FUNCTION_REGISTRY = FunctionRegistry()
 
 
 def public_api(
-    document_under: str = "", autodoc_options: Optional[List[str]] = None, module: ModuleType = None, symbol: str = None
+    document_under: str = "",
+    autodoc_options: Optional[List[str]] = None,
+    module: ModuleType = None,
+    symbol: str = None,
+    doc: str = None,
 ):
     """
     Decorator that exports a function/class to the public API under the top-level module and
@@ -71,6 +75,9 @@ def public_api(
         module: The module under which to export this public API. Defaults to the top-level Tripy module.
 
         symbol: The name of the symbol, if different from ``__name__``.
+
+        doc: Optional docstring. This is useful in cases where the docstring cannot be provided as normal.
+            For example, global variables sometimes don't register docstrings correctly.
     """
     assert not autodoc_options or (
         ":no-members:" not in autodoc_options or ":no-special-members:" in autodoc_options
@@ -79,6 +86,9 @@ def public_api(
     def export_impl(obj):
         nonlocal module, symbol
         import tripy
+
+        if doc is not None:
+            obj.__doc__ = dedent(doc)
 
         module = module or tripy
 

--- a/tripy/tripy/frontend/module/parameter.py
+++ b/tripy/tripy/frontend/module/parameter.py
@@ -17,7 +17,6 @@
 
 from typing import Any, Sequence
 
-import tripy.frontend.utils as frontend_utils
 from tripy import export, utils
 from tripy.frontend.tensor import Tensor
 from tripy.utils import Result
@@ -30,7 +29,6 @@ class Parameter(Tensor):
     constant, enabling additional optimization opportunities.
     """
 
-    @frontend_utils.convert_inputs_to_tensors()
     def __init__(self, tensor: Any) -> None:
         """
         Args:

--- a/tripy/tripy/frontend/ops/allclose.py
+++ b/tripy/tripy/frontend/ops/allclose.py
@@ -21,7 +21,7 @@ from tripy.common.exception import raise_error
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int32", "int8"]},
     dtype_constraints={"a": "T1", "b": "T1"},
 )
 def allclose(a: "tripy.Tensor", b: "tripy.Tensor", rtol: float = 1e-05, atol: float = 1e-08) -> bool:

--- a/tripy/tripy/frontend/ops/cumsum.py
+++ b/tripy/tripy/frontend/ops/cumsum.py
@@ -20,7 +20,7 @@ from tripy.frontend import utils as frontend_utils
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8", "int32"],
+        "T1": ["float32", "float16", "bfloat16", "int32"],
     },
     dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/ops/outer.py
+++ b/tripy/tripy/frontend/ops/outer.py
@@ -21,7 +21,7 @@ import tripy.frontend.utils as frontend_utils
 
 @export.public_api(document_under="operations/functions")
 @constraints.dtype_info(
-    dtype_variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"]},
+    dtype_variables={"T1": ["float32", "float16", "bfloat16", "int32"]},
     dtype_constraints={"vec1": "T1", "vec2": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def outer(vec1: "tripy.Tensor", vec2: "tripy.Tensor") -> "tripy.Tensor":

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -31,13 +31,12 @@ from tripy.frontend import utils as frontend_utils
 @frontend_utils.convert_shape_inputs(["shape"])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
     },
-    dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
+    dtype_constraints={"dtype": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def ones(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
+    shape: "tripy.types.ShapeLike",
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":
     """
@@ -67,13 +66,12 @@ def ones(
 @frontend_utils.convert_shape_inputs(["shape"])
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int4", "int32", "int64", "bool"],
     },
-    dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
+    dtype_constraints={"dtype": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def zeros(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
+    shape: "tripy.types.ShapeLike",
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":
     """

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -125,11 +125,7 @@ class Shape(Tensor):
             # share the underlying data
             self.trace_tensor = data.trace_tensor
             self.stack_info = data.stack_info
-        elif (
-            isinstance(data, Sequence)
-            and len(data) > 0
-            and all(map(lambda e: isinstance(e, int) or isinstance(e, ShapeScalar), data))
-        ):
+        elif isinstance(data, Sequence) and len(data) > 0 and any(map(lambda e: isinstance(e, ShapeScalar), data)):
             # Handle the case where data is a list of mixed int and ShapeScalar elements
             # Example: [1, a.shape[0]]
             # We convert this to a tensor to avoid expensive evaluation of ShapeScalar elements (like a.shape[0])

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -27,13 +27,16 @@ class Cast(BaseTraceOp):
 
     def infer_shape_output_idxs(self, inputs):
         from tripy.common.datatype import int32
-        from tripy.frontend.shape import Shape
+        from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
 
-        if isinstance(inputs[0], Shape):
-            # Only still a valid shape if it remains int32
-            if self.dtype == int32:
+        # Only still a valid shape if it remains int32
+        if self.dtype == int32:
+            if isinstance(inputs[0], Shape):
                 return Result.ok({"shape": [0]})
+            elif isinstance(inputs[0], ShapeScalar):
+                return Result.ok({"scalar": [0]})
+
         return Result.ok({})
 
     infer_len = InferLenPolicies.infer_same_as_first_input
@@ -107,8 +110,10 @@ class Cast(BaseTraceOp):
     },
     dtype_constraints={"input": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
     dtype_exceptions=[
+        {"T1": "float8", "T2": "int4"},
         {"T1": "float8", "T2": "int8"},
         {"T1": "float8", "T2": "int64"},
+        {"T1": "int4", "T2": "float8"},
         {"T1": "int4", "T2": "int8"},
         {"T1": "int4", "T2": "int64"},
     ],

--- a/tripy/tripy/frontend/trace/ops/convolution.py
+++ b/tripy/tripy/frontend/trace/ops/convolution.py
@@ -85,7 +85,7 @@ class Convolution(BaseTraceOp):
 
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16", "float8"],
+        "T1": ["float32", "float16", "bfloat16"],
     },
     dtype_constraints={"input": "T1", "weight": "T1", constraints.RETURN_VALUE: "T1"},
 )

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -78,13 +78,10 @@ def expand_impl(input: "tripy.Tensor", shape: Sequence, output_rank: int, output
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"],
-        "T2": ["int8", "int32", "int64"],
     },
-    dtype_constraints={"input": "T1", "sizes": "T2", constraints.RETURN_VALUE: "T1"},
+    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )
-def expand(
-    input: "tripy.Tensor", sizes: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]]
-) -> "tripy.Tensor":
+def expand(input: "tripy.Tensor", sizes: "tripy.types.ShapeLike") -> "tripy.Tensor":
     """
     Returns a new tensor based on the input tensor with singleton dimensions expanded to a larger size.
 

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -94,7 +94,7 @@ class Fill(BaseTraceOp):
 
 @frontend_utils.convert_shape_inputs(["shape"])
 def full_impl(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
+    shape: "tripy.types.ShapeLike",
     value: Union[numbers.Number, "tripy.Tensor"],
     dtype: "tripy.dtype",
     output_rank: int,
@@ -110,13 +110,12 @@ def full_impl(
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
     },
-    dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
+    dtype_constraints={"dtype": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def full(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
+    shape: "tripy.types.ShapeLike",
     value: Union[numbers.Number, "tripy.Tensor"],
     dtype: "tripy.dtype" = datatype.float32,
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -85,13 +85,12 @@ def iota_impl(
 @export.public_api(document_under="operations/initializers")
 @constraints.dtype_info(
     dtype_variables={
-        "T1": ["int32"],
-        "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "bool"],
+        "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "bool"],
     },
-    dtype_constraints={"shape": "T1", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
+    dtype_constraints={"dtype": "T1", constraints.RETURN_VALUE: "T1"},
 )
 def iota(
-    shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]],
+    shape: "tripy.types.ShapeLike",
     dim: int = 0,
     dtype: datatype.dtype = datatype.float32,
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/pooling.py
+++ b/tripy/tripy/frontend/trace/ops/pooling.py
@@ -17,9 +17,9 @@
 
 import enum
 from dataclasses import dataclass
-from typing import Sequence, Tuple
+from typing import Optional, Sequence, Tuple
 
-from tripy import export, constraints, utils
+from tripy import constraints, export, utils
 from tripy.common.exception import raise_error
 from tripy.frontend.trace.ops import utils as op_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
@@ -90,8 +90,8 @@ class Pooling(BaseTraceOp):
 def maxpool(
     input: "tripy.Tensor",
     kernel_dims: Sequence[int],
-    stride: Sequence[int] = None,
-    padding: Sequence[Tuple[int]] = None,
+    stride: Optional[Sequence[int]] = None,
+    padding: Optional[Sequence[Tuple[int]]] = None,
 ) -> "tripy.Tensor":
     r"""
     Applies a max pooling over the input tensor.

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -22,7 +22,6 @@ from tripy.common.exception import raise_error
 from tripy.frontend import utils as frontend_utils
 from tripy.frontend.trace.ops import utils as op_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
-from tripy.common.datatype import DATA_TYPES
 
 
 @dataclass(repr=False)
@@ -76,13 +75,10 @@ def reshape_impl(
 @constraints.dtype_info(
     dtype_variables={
         "T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64", "bool"],
-        "T2": ["int8", "int32", "int64"],
     },
-    dtype_constraints={"input": "T1", "shape": "T2", constraints.RETURN_VALUE: "T1"},
+    dtype_constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
 )
-def reshape(
-    input: "tripy.Tensor", shape: Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]]
-) -> "tripy.Tensor":
+def reshape(input: "tripy.Tensor", shape: "tripy.types.ShapeLike") -> "tripy.Tensor":
     """
     Returns a new tensor with the contents of the input tensor in the specified shape.
 

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -16,7 +16,7 @@
 #
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Optional, Sequence, Union
 
 from tripy import constraints, utils
 from tripy.common.exception import raise_error
@@ -182,7 +182,9 @@ class Slice(BaseTraceOp):
     },
     dtype_constraints={"self": "self_dtype", constraints.RETURN_VALUE: "self_dtype"},
 )
-def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "tripy.Tensor"]) -> "tripy.Tensor":
+def __getitem__(
+    self: "tripy.Tensor", index: Union[slice, int, "tripy.Tensor", Sequence[Union[slice, int, "tripy.Tensor"]]]
+) -> "tripy.Tensor":
     """
     Returns a tensor containing a slice of this tensor.
 
@@ -214,7 +216,7 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
     from tripy.frontend.tensor import Tensor
     from tripy.frontend.trace.ops.flip import flip
     from tripy.frontend.trace.ops.gather import gather
-    from tripy.frontend.trace.ops.reshape import reshape, squeeze
+    from tripy.frontend.trace.ops.reshape import squeeze
     from tripy.frontend.trace.ops.where import where
 
     # If a tensor is indexed by another tensor, this operation is equivalent to a gather operation.
@@ -305,6 +307,6 @@ def __getitem__(self: "tripy.Tensor", index: Union[slice, int, Tuple[int], "trip
 # Conveniently converts the inputs to tensors. The decorator also fills in column info for the converted tensors.
 # Because the helper is called inside another function, we need to skip one entry in the call stack to find
 # the original call to user code.
-@frontend_utils.convert_inputs_to_tensors(exclude=["shape_slice"], skip_num_stack_entries=1)
+@frontend_utils.convert_inputs_to_tensors(exclude=["tensor", "shape_slice"], skip_num_stack_entries=1)
 def slice_helper(tensor, *slice_params, shape_slice: Optional[slice] = None):
     return Slice.build(inputs=[tensor, *slice_params], shape_slice=shape_slice)

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -16,8 +16,8 @@
 #
 
 import functools
-from collections import deque
 import numbers
+from collections import deque
 from typing import List, Optional, Sequence, Tuple, Union
 
 from tripy import utils
@@ -28,12 +28,33 @@ from tripy.frontend.trace.ops import BaseTraceOp
 
 # Try to include correct column offsets for non-tensor arguments.
 def _add_column_info_for_non_tensor(
-    arg, arg_index, is_kwarg, dtype, num_args, func_name, skip_num_stack_entries, list_index=None
+    arg,
+    arg_index,
+    is_kwarg,
+    dtype,
+    num_args,
+    func_name,
+    skip_num_stack_entries,
+    list_index=None,
+    TensorType=None,
 ):
     from tripy.frontend.tensor import Tensor
+    from tripy.frontend.shape import Shape
+    from tripy.frontend.trace.ops.cast import cast
 
-    assert not isinstance(arg, Tensor)
-    arg = Tensor(arg, dtype=dtype)
+    TensorType = utils.default(TensorType, Tensor)
+
+    assert not isinstance(
+        arg, Tensor
+    ), f"This function should not be called for objects that are already Tensor instances"
+
+    if isinstance(arg, numbers.Number) and TensorType == Shape:
+        # Shapes require 1D values.
+        arg = [arg]
+
+    arg = TensorType(arg)
+    if dtype is not None:
+        arg = cast(arg, dtype=dtype)
     arg.stack_info.fetch_source_code()
 
     # This is the stack depth in arg.stack_info where we find the decorated function.
@@ -50,8 +71,6 @@ def _add_column_info_for_non_tensor(
     # Also save the last dispatch target we see.
     dispatch_target = None
     for idx, source_info in enumerate(arg.stack_info[WRAPPER_STACK_DEPTH + skip_num_stack_entries :]):
-        import tripy.function_registry
-
         dispatch_target = source_info._dispatch_target or dispatch_target
         if source_info.module not in utils.get_module_names_to_exclude_from_stack_info():
             frame_index = idx + WRAPPER_STACK_DEPTH + skip_num_stack_entries
@@ -102,7 +121,15 @@ def _add_column_info_for_non_tensor(
 
 
 def _convert_nontensor_arg(
-    arg, arg_idx, is_kwarg, num_args, func_name, skip_num_stack_entries, cast_dtype=None, list_index=None
+    arg,
+    arg_idx,
+    is_kwarg,
+    num_args,
+    func_name,
+    skip_num_stack_entries,
+    cast_dtype=None,
+    list_index=None,
+    TensorType=None,
 ):
     from tripy.utils import Result
 
@@ -145,6 +172,7 @@ def _convert_nontensor_arg(
         func_name=func_name,
         skip_num_stack_entries=skip_num_stack_entries,
         list_index=list_index,
+        TensorType=TensorType,
     )
 
 
@@ -212,8 +240,30 @@ def convert_inputs_to_tensors(
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             from tripy.frontend.tensor import Tensor
+            from tripy.frontend.shape import Shape, ShapeScalar
 
             all_args = utils.merge_function_arguments(func, *args, **kwargs)
+
+            # TODO (#233): Disallow mixing Tensor/Shape. The workaround below works
+            # because ShapeScalars will typically be broadcasted in order to operate
+            # with Tensors/Shapes. Otherwise, Shape and ShapeScalar would have been
+            # at the same level of hierarchy.
+            #
+            # When a function has multiple arguments, the order of precedence is:
+            #
+            # 1. Tensor
+            # 2. Shape
+            # 3. ShapeScalar
+            #
+            # That is, if we have an operation with a mixture of types, all arguments are
+            # converted to the type with the highest precedence, e.g. Tensor + Shape -> Tensor.
+            TensorType = None
+            MaxType = max(
+                (type(arg) for arg_name, arg in all_args if arg_name not in exclude),
+                key=lambda typ: {Tensor: 2, Shape: 1, ShapeScalar: 0}.get(typ, -1),
+            )
+            if issubclass(MaxType, Tensor):
+                TensorType = MaxType
 
             def get_arg(name: str):
                 for arg_name, arg in all_args:
@@ -273,6 +323,7 @@ def convert_inputs_to_tensors(
                         skip_num_stack_entries,
                         find_sync_target_dtype(name),
                         list_index=list_index,
+                        TensorType=TensorType,
                     )
 
                 if name in exclude or isinstance(arg, Tensor):
@@ -351,6 +402,7 @@ def convert_shape_inputs(targets: Sequence[str], skip_num_stack_entries: int = 0
                         skip_num_stack_entries,
                         cast_dtype=None,
                         list_index=list_index,
+                        TensorType=Shape,
                     )
 
                 if name not in targets:
@@ -368,7 +420,7 @@ def convert_shape_inputs(targets: Sequence[str], skip_num_stack_entries: int = 0
                     continue
                 # if it's not a tensor and not a sequence, we treat as a singleton shape
                 if not isinstance(arg, Sequence):
-                    add_arg(Shape(convert_nontensor_arg([arg])))
+                    add_arg(convert_nontensor_arg([arg]))
                     continue
 
                 # otherwise, for a sequence we convert all at once if no member is a tensor
@@ -378,7 +430,7 @@ def convert_shape_inputs(targets: Sequence[str], skip_num_stack_entries: int = 0
                     continue
 
                 if not any(map(lambda member: isinstance(member, Tensor), arg)):
-                    add_arg(Shape(convert_nontensor_arg(arg)))
+                    add_arg(convert_nontensor_arg(arg))
                     continue
 
                 shape_components = []
@@ -389,14 +441,14 @@ def convert_shape_inputs(targets: Sequence[str], skip_num_stack_entries: int = 0
                         acc.append(member)
                         continue
                     if len(acc) > 0:
-                        shape_components.append(Shape(convert_nontensor_arg(acc)))
+                        shape_components.append(convert_nontensor_arg(acc))
                         acc = []
                     if member.rank != 0:
                         raise_error("Tensor in a shape argument must be a scalar.", [f"Got {member}"])
                     member = Shape(unsqueeze(member, 0))
                     shape_components.append(member)
                 if len(acc) > 0:
-                    shape_components.append(Shape(convert_nontensor_arg(acc)))
+                    shape_components.append(convert_nontensor_arg(acc))
                 add_arg(concatenate(shape_components, 0))
 
             return func(*new_args, **new_kwargs)

--- a/tripy/tripy/function_registry.py
+++ b/tripy/tripy/function_registry.py
@@ -120,7 +120,7 @@ class FuncOverload:
 
         def matches_type(name: str, annotation: type, arg: Any) -> bool:
             from collections.abc import Sequence as ABCSequence
-            from typing import ForwardRef, get_args, get_origin, Sequence, Union
+            from typing import ForwardRef, get_args, get_origin, Sequence, Union, Optional
 
             # In cases where a type is not available at the time of function definition, the type
             # annotation may be provided as a string. Since we need the actual type, we just
@@ -148,6 +148,9 @@ class FuncOverload:
                     assert len(seq_arg) == 1
                     return all(map(lambda member: matches_type(name, seq_arg[0], member), arg))
                 return True
+
+            if get_origin(annotation) is Optional:
+                return arg is None or matches_type(arg, get_args(annotation)[0])
 
             # Forward references can be used for recursive type definitions. Warning: Has the potential for infinite looping if there is no base case!
             if isinstance(annotation, ForwardRef):

--- a/tripy/tripy/types.py
+++ b/tripy/tripy/types.py
@@ -25,27 +25,36 @@ from typing import Union, Sequence
 
 from tripy import export
 
-export.public_api()(sys.modules[__name__])
+export.public_api(autodoc_options=[":no-members:", ":no-special-members:"])(sys.modules[__name__])
 
 NestedNumberSequence = export.public_api(
     document_under="types.rst",
     autodoc_options=[":no-index:"],
     module=sys.modules[__name__],
     symbol="NestedNumberSequence",
+    doc="""
+        Denotes the recursive type annotation for sequences of Python numbers, possibly nested to an arbitrary depth.
+        Tripy often automatically converts these sequences to `tp.Tensor`.
+        """,
 )(Union[numbers.Number, Sequence["tripy.types.NestedNumberSequence"]])
-
-NestedNumberSequence.__doc__ = """
-Denotes the recursive type annotation for sequences of Python numbers, possibly nested to an arbitrary depth.
-Tripy often automatically converts these sequences to `tp.Tensor`.
-"""
 
 TensorLike = export.public_api(
     document_under="types.rst",
     autodoc_options=[":no-index:"],
     module=sys.modules[__name__],
     symbol="TensorLike",
+    doc="""
+        Type annotation for a parameter that is either a Tripy `Tensor` or a Python sequence that can be automatically converted into one.
+        """,
 )(Union["tripy.Tensor", "tripy.types.NestedNumberSequence"])
 
-TensorLike.__doc__ = """
-Type annotation for a parameter that is either a Tripy `Tensor` or a Python sequence that can be automatically converted into one.
-"""
+
+ShapeLike = export.public_api(
+    document_under="types.rst",
+    autodoc_options=[":no-index:"],
+    module=sys.modules[__name__],
+    symbol="ShapeLike",
+    doc="""
+        Type annotation for a parameter that is either a Tripy `Shape` or Python sequence that can be automatically converted into one.
+        """,
+)(Union["tripy.Shape", Sequence[Union[int, "tripy.ShapeScalar"]]])


### PR DESCRIPTION
- Adds tests to ensure we only use ASCII characters in our code and markdown files. Some non-ASCII characters that look like ASCII characters were breaking tests that make assumptions about the encoding.

- Updates dtype constraint tests to properly construct inputs for various APIs.

- Moves dtype constraint tests to L0 since they only add about 20 seconds and were breaking very often otherwise.

- Updates binary elementwise ops to only return `ShapeScalar`s if *all* inputs are also `ShapeScalar`s.

- Corrects dtype constraints for several APIs.

- Simplifies `mean` implementation.

- Corrects type annotations for some APIs and introduces a `ShapeLike` type.

- Adds support for `Optional` during type checking.

- Updates `convert_inputs_to_tensors` to now potentially convert tensors to `Tensor` subclasses. See the note in the code for details on the logic.