### PR TITLE
Add output_shape argument to resize ops

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -3510,6 +3510,7 @@ def TensorRT_ResizeNearestOp : TensorRT_Op<"resize_nearest", [Pure,
 
   let arguments = (ins
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$input,
+    Optional<TensorRT_ShapeTensor>:$output_shape,
     OptionalAttr<DenseF32ArrayAttr>:$scales,
     TensorRT_ResizeCoordinateTransformationAttr:$coordinateTransformation,
     TensorRT_ResizeRoundModeAttr:$nearestRounding,
@@ -3517,11 +3518,13 @@ def TensorRT_ResizeNearestOp : TensorRT_Op<"resize_nearest", [Pure,
   );
   let results = (outs
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
-  let assemblyFormat = "attr-dict $input `:` type($input) `to` type($result)";
+  let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
   let trtLayerAdd = [{
     nvinfer1::IResizeLayer *layer = network->addResize(*$input);
-    if ($op.getScales().has_value())
+    if ($op.getOutputShape())
+      layer->setInput(1, *$output_shape);
+    else if ($op.getScales().has_value())
       layer->setScales($scales.value().begin(), $scales.value().size());
     else
       layer->setOutputDimensions(getNvInferDims($op.getType().getShape()));
@@ -3576,17 +3579,20 @@ def TensorRT_ResizeLinearOp : TensorRT_Op<"resize_linear", [Pure,
 
   let arguments = (ins
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$input,
+    Optional<TensorRT_ShapeTensor>:$output_shape,
     OptionalAttr<DenseF32ArrayAttr>:$scales,
     TensorRT_ResizeCoordinateTransformationAttr:$coordinateTransformation,
     TensorRT_ResizeSelectorAttr:$selectorForSinglePixel
   );
   let results = (outs
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
-  let assemblyFormat = "attr-dict $input `:` type($input) `to` type($result)";
+  let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
   let trtLayerAdd = [{
     nvinfer1::IResizeLayer *layer = network->addResize(*$input);
-    if ($op.getScales().has_value())
+    if ($op.getOutputShape())
+      layer->setInput(1, *$output_shape);
+    else if ($op.getScales().has_value())
       layer->setScales($scales.value().begin(), $scales.value().size());
     else
       layer->setOutputDimensions(getNvInferDims($op.getType().getShape()));
@@ -3642,6 +3648,7 @@ def TensorRT_ResizeCubicOp : TensorRT_Op<"resize_cubic", [Pure,
 
   let arguments = (ins
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$input,
+    Optional<TensorRT_ShapeTensor>:$output_shape,
     OptionalAttr<DenseF32ArrayAttr>:$scales,
     TensorRT_ResizeCoordinateTransformationAttr:$coordinateTransformation,
     TensorRT_ResizeSelectorAttr:$selectorForSinglePixel,
@@ -3649,11 +3656,13 @@ def TensorRT_ResizeCubicOp : TensorRT_Op<"resize_cubic", [Pure,
   );
   let results = (outs
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
-  let assemblyFormat = "attr-dict $input `:` type($input) `to` type($result)";
+  let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
   let trtLayerAdd = [{
     nvinfer1::IResizeLayer *layer = network->addResize(*$input);
-    if ($op.getScales().has_value())
+    if ($op.getOutputShape())
+      layer->setInput(1, *$output_shape);
+    else if ($op.getScales().has_value())
       layer->setScales($scales.value().begin(), $scales.value().size());
     else
       layer->setOutputDimensions(getNvInferDims($op.getType().getShape()));

--- a/mlir-tensorrt/tensorrt/test/TensorRT/invalid.mlir
+++ b/mlir-tensorrt/tensorrt/test/TensorRT/invalid.mlir
@@ -1452,7 +1452,7 @@ func.func @resize_nearest_static(%arg0: tensor<2x2x2x2x2xf32>) -> tensor<2x4x4x4
   %0 = tensorrt.resize_nearest {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x2x2xf32> to tensor<2x4x4x4x4xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x2x2xf32>) -> tensor<2x4x4x4x4xf32>
   return %0 : tensor<2x4x4x4x4xf32>
 }
 
@@ -1464,18 +1464,18 @@ func.func @resize_nearest_static(%arg0: tensor<2x2x2x2xf32>) -> tensor<2x4x4x4xf
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     scales = array<f32: 2.0, 3.0>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x2xf32> to tensor<2x4x4x4xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x2xf32>) -> tensor<2x4x4x4xf32>
   return %0 : tensor<2x4x4x4xf32>
 }
 
 // -----
 
 func.func @resize_nearest_dynamic(%arg0: tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32> {
-  // expected-error @below {{'tensorrt.resize_nearest' op output innermost min(3, rank(input)) dimension that resize on cannot be dynamic when resize scales parameter is NOT specified}}
+  // expected-error @below {{'tensorrt.resize_nearest' op input innermost min(3, rank(input)) dimension that resize on cannot be dynamic when output_shape parameter is NOT specified and it cannot be inferred statically}}
   %0 = tensorrt.resize_nearest {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x?x?xf32> to tensor<2x2x2x?x?xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32>
   return %0 : tensor<2x2x2x?x?xf32>
 }
 
@@ -1487,7 +1487,7 @@ func.func @resize_nearest_dynamic(%arg0: tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     scales = array<f32: 1.0, 1.0, 2.0, 2.0, 2.0>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x?x?xf32> to tensor<2x2x2x?x?xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32>
   return %0 : tensor<2x2x2x?x?xf32>
 }
 
@@ -1499,7 +1499,7 @@ func.func @resize_nearest_dynamic(%arg0: tensor<2x2x2x?x?xf32>) -> tensor<2x4x4x
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     scales = array<f32: 1.0, 2.0, 2.0, 2.0, 2.0>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x?x?xf32> to tensor<2x4x4x?x?xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x?x?xf32>) -> tensor<2x4x4x?x?xf32>
   return %0 : tensor<2x4x4x?x?xf32>
 }
 
@@ -1511,7 +1511,7 @@ func.func @resize_nearest_dynamic(%arg0: tensor<2x3xf32>) -> tensor<4x6xf16> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     scales = array<f32: 2.0, 2.0>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x3xf32> to tensor<4x6xf16>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x3xf32>) -> tensor<4x6xf16>
   return %0 : tensor<4x6xf16>
 }
 // -----
@@ -1520,7 +1520,7 @@ func.func @resize_linear_static(%arg0: tensor<2x2x2x2x2xf32>) -> tensor<2x4x4x4x
   // expected-error @below {{'tensorrt.resize_linear' op only supports resizing on the innermost min(3, rank(input)) dimensions}}
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x2x2xf32> to tensor<2x4x4x4x4xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x2x2xf32>) -> tensor<2x4x4x4x4xf32>
   return %0 : tensor<2x4x4x4x4xf32>
 }
 
@@ -1531,17 +1531,17 @@ func.func @resize_linear_static(%arg0: tensor<2x2x2x2x2xf32>) -> tensor<2x2x4x4x
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
-    scales = array<f32: 2.0, 3.0>} %arg0 : tensor<2x2x2x2x2xf32> to tensor<2x2x4x4x4xf32>
+    scales = array<f32: 2.0, 3.0>} %arg0 : (tensor<2x2x2x2x2xf32>) -> tensor<2x2x4x4x4xf32>
   return %0 : tensor<2x2x4x4x4xf32>
 }
 
 // -----
 
 func.func @resize_linear_dynamic(%arg0: tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32> {
-  // expected-error @below {{'tensorrt.resize_linear' op output innermost min(3, rank(input)) dimension that resize on cannot be dynamic when resize scales parameter is NOT specified}}
+  // expected-error @below {{'tensorrt.resize_linear' op input innermost min(3, rank(input)) dimension that resize on cannot be dynamic when output_shape parameter is NOT specified and it cannot be inferred statically}}
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2x?x?xf32> to tensor<2x2x2x?x?xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32>
   return %0 : tensor<2x2x2x?x?xf32>
 }
 
@@ -1552,7 +1552,7 @@ func.func @resize_linear_dynamic(%arg0: tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
-    scales = array<f32: 1.0, 1.0, 2.0, 3.0, 3.0>} %arg0 : tensor<2x2x2x?x?xf32> to tensor<2x2x2x?x?xf32>
+    scales = array<f32: 1.0, 1.0, 2.0, 3.0, 3.0>} %arg0 : (tensor<2x2x2x?x?xf32>) -> tensor<2x2x2x?x?xf32>
   return %0 : tensor<2x2x2x?x?xf32>
 }
 
@@ -1563,7 +1563,7 @@ func.func @resize_linear_dynamic(%arg0: tensor<2x2x2x3x3xf32>) -> tensor<2x4x4x9
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
-    scales = array<f32: 1.0, 2.0, 2.0, 3.0, 3.0>} %arg0 : tensor<2x2x2x3x3xf32> to tensor<2x4x4x9x9xf32>
+    scales = array<f32: 1.0, 2.0, 2.0, 3.0, 3.0>} %arg0 : (tensor<2x2x2x3x3xf32>) -> tensor<2x4x4x9x9xf32>
   return %0 : tensor<2x4x4x9x9xf32>
 }
 
@@ -1574,7 +1574,7 @@ func.func @resize_linear_dynamic(%arg0: tensor<2x?xf32>) -> tensor<10x?xf32> {
   %0 = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
-    scales = array<f32: 4.0, 5.0>} %arg0 : tensor<2x?xf32> to tensor<10x?xf32>
+    scales = array<f32: 4.0, 5.0>} %arg0 : (tensor<2x?xf32>) -> tensor<10x?xf32>
   return %0 : tensor<10x?xf32>
 }
 
@@ -1585,7 +1585,7 @@ func.func @resize_cubic_rank1(%arg0: tensor<2xf32>) -> tensor<4xf32> {
   %0 = tensorrt.resize_cubic {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     cubicCoeff = -0.75 : f32,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2xf32> to tensor<4xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
@@ -1596,7 +1596,7 @@ func.func @resize_cubic_static(%arg0: tensor<2x2x2xf32>) -> tensor<4x4x4xf32> {
   %0 = tensorrt.resize_cubic {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     cubicCoeff = -0.5 : f32,
-    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : tensor<2x2x2xf32> to tensor<4x4x4xf32>
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>} %arg0 : (tensor<2x2x2xf32>) -> tensor<4x4x4xf32>
   return %0 : tensor<4x4x4xf32>
 }
 
@@ -1608,18 +1608,18 @@ func.func @resize_cubic_static(%arg0: tensor<2x2x2xf32>) -> tensor<4x4x4xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
     scales = array<f32: 1.0, 1.0, 2.0, 3.0, 3.0>,
-    cubicCoeff = -0.5 : f32} %arg0 : tensor<2x2x2xf32> to tensor<4x4x4xf32>
+    cubicCoeff = -0.5 : f32} %arg0 : (tensor<2x2x2xf32>) -> tensor<4x4x4xf32>
   return %0 : tensor<4x4x4xf32>
 }
 
 // -----
 
 func.func @resize_cubic_dynamic(%arg0: tensor<2x?x?xf32>) -> tensor<2x?x?xf32> {
-  // expected-error @below {{'tensorrt.resize_cubic' op output innermost 2 dimensions that resize on cannot be dynamic when resize scales parameter is NOT specified}}
+  // expected-error @below {{'tensorrt.resize_cubic' op input innermost 2 dimensions that resize on cannot be dynamic when output_shape parameter is NOT specified and it cannot be inferred statically}}
   %0 = tensorrt.resize_cubic {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
-    cubicCoeff = -1.0 : f32} %arg0 : tensor<2x?x?xf32> to tensor<2x?x?xf32>
+    cubicCoeff = -1.0 : f32} %arg0 : (tensor<2x?x?xf32>) -> tensor<2x?x?xf32>
   return %0 : tensor<2x?x?xf32>
 }
 
@@ -1631,7 +1631,7 @@ func.func @resize_cubic_dynamic(%arg0: tensor<2x2x?xf32>) -> tensor<2x4x?xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
     scales = array<f32: 1.0, 3.0, 3.0>,
-    cubicCoeff = -1.0 : f32} %arg0 : tensor<2x2x?xf32> to tensor<2x4x?xf32>
+    cubicCoeff = -1.0 : f32} %arg0 : (tensor<2x2x?xf32>) -> tensor<2x4x?xf32>
   return %0 : tensor<2x4x?xf32>
 }
 
@@ -1643,7 +1643,7 @@ func.func @resize_cubic_dynamic(%arg0: tensor<2x2x3x?xf32>) -> tensor<2x4x6x?xf3
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
     scales = array<f32: 1.0, 2.0, 2.0, 2.0>,
-    cubicCoeff = -1.0 : f32} %arg0 : tensor<2x2x3x?xf32> to tensor<2x4x6x?xf32>
+    cubicCoeff = -1.0 : f32} %arg0 : (tensor<2x2x3x?xf32>) -> tensor<2x4x6x?xf32>
   return %0 : tensor<2x4x6x?xf32>
 }
 

--- a/mlir-tensorrt/tensorrt/test/TensorRT/roundtrip.mlir
+++ b/mlir-tensorrt/tensorrt/test/TensorRT/roundtrip.mlir
@@ -1236,7 +1236,7 @@ func.func @trt_resize_nearest(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 
@@ -1245,26 +1245,24 @@ func.func @trt_resize_nearest(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
 //  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>
 //  CHECK-SAME: nearestRounding = #tensorrt.resize_round_mode<kFLOOR>
 //  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-//  CHECK-SAME: %{{.+}} : tensor<10x10xf32> to tensor<20x20xf32>
+//  CHECK-SAME: %{{.+}} : (tensor<10x10xf32>) -> tensor<20x20xf32>
 
 // -----
 
-func.func @trt_resize_nearest_dynamic(%arg0: tensor<10x?xf32>) -> tensor<20x?xf32> {
+func.func @trt_resize_nearest_output_shape(%arg0: tensor<?x?xf32>, %arg1: tensor<2xi32>) -> tensor<?x?xf32> {
   %result = tensorrt.resize_nearest {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
-    scales = array<f32: 2.0, 3.0>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-  } %arg0 : tensor<10x?xf32> to tensor<20x?xf32>
-  return %result : tensor<20x?xf32>
+  } %arg0, %arg1 : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  return %result : tensor<?x?xf32>
 }
-// CHECK-LABEL: @trt_resize_nearest_dynamic
+// CHECK-LABEL: @trt_resize_nearest_output_shape
 //       CHECK: tensorrt.resize_nearest
 //  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>
 //  CHECK-SAME: nearestRounding = #tensorrt.resize_round_mode<kFLOOR>
-//  CHECK-SAME: scales = array<f32: 2.000000e+00, 3.000000e+00>
 //  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-//  CHECK-SAME: %{{.+}} : tensor<10x?xf32> to tensor<20x?xf32>
+//  CHECK-SAME: %[[arg0:.+]], %[[arg1:.+]] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
 
 // -----
 
@@ -1272,14 +1270,29 @@ func.func @trt_resize_linear(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
   %result = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     selectorForSinglePixel = #tensorrt.resize_selector<kUPPER>
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 // CHECK-LABEL: @trt_resize_linear
 //       CHECK: tensorrt.resize_linear
 //  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>
 //  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kUPPER>
-//  CHECK-SAME: %{{.+}} : tensor<10x10xf32> to tensor<20x20xf32>
+//  CHECK-SAME: %{{.+}} : (tensor<10x10xf32>) -> tensor<20x20xf32>
+
+// -----
+
+func.func @trt_resize_linear_output_shape(%arg0: tensor<?x?xf32>, %arg1: tensor<2xi32>) -> tensor<?x?xf32> {
+  %result = tensorrt.resize_linear {
+    coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
+    selectorForSinglePixel = #tensorrt.resize_selector<kUPPER>
+  } %arg0, %arg1 : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  return %result : tensor<?x?xf32>
+}
+// CHECK-LABEL: @trt_resize_linear_output_shape
+//       CHECK: tensorrt.resize_linear
+//  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>
+//  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kUPPER>
+//  CHECK-SAME: %[[arg0:.+]], %[[arg1:.+]] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
 
 // -----
 
@@ -1288,7 +1301,7 @@ func.func @trt_resize_cubic(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kHALF_PIXEL>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
     cubicCoeff = -0.75 : f32
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 // CHECK-LABEL: @trt_resize_cubic
@@ -1296,7 +1309,24 @@ func.func @trt_resize_cubic(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
 //  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kHALF_PIXEL>
 //  CHECK-SAME: cubicCoeff = -7.500000e-01 : f32
 //  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-//  CHECK-SAME: %{{.+}} : tensor<10x10xf32> to tensor<20x20xf32>
+//  CHECK-SAME: %{{.+}} : (tensor<10x10xf32>) -> tensor<20x20xf32>
+
+// -----
+
+func.func @trt_resize_cubic_output_shape(%arg0: tensor<?x?xf32>, %arg1: tensor<2xi32>) -> tensor<?x?xf32> {
+  %result = tensorrt.resize_cubic {
+    coordinateTransformation = #tensorrt.resize_coordinate_transformation<kHALF_PIXEL>,
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
+    cubicCoeff = -0.75 : f32
+  } %arg0, %arg1 : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  return %result : tensor<?x?xf32>
+}
+// CHECK-LABEL: @trt_resize_cubic_output_shape
+//       CHECK: tensorrt.resize_cubic
+//  CHECK-SAME: coordinateTransformation = #tensorrt.resize_coordinate_transformation<kHALF_PIXEL>
+//  CHECK-SAME: cubicCoeff = -7.500000e-01 : f32
+//  CHECK-SAME: selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
+//  CHECK-SAME: %[[arg0:.+]], %[[arg1:.+]] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
 
 // -----
 

--- a/mlir-tensorrt/test/Target/TensorRT/resize.mlir
+++ b/mlir-tensorrt/test/Target/TensorRT/resize.mlir
@@ -6,7 +6,7 @@ func.func @trt_resize_nearest(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 
@@ -21,18 +21,32 @@ func.func @trt_resize_nearest_dynamic(
     scales = array<f32: 2.0, 3.0>,
     nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
-  } %arg0 : tensor<10x?xf32> to tensor<20x?xf32>
+  } %arg0 : (tensor<10x?xf32>) -> tensor<20x?xf32>
   return %result : tensor<20x?xf32>
 }
 
-// CHECK-LABEL: @trt_resize_nearest
+// CHECK-LABEL: @trt_resize_nearest_dynamic
+//  CHECK-SAME: tensorrt.engine
+
+func.func @trt_resize_nearest_output_shape(
+  %arg0: tensor<10x10xf32>, %arg1: tensor<2xi32>) -> tensor<?x?xf32> {
+  %result = tensorrt.resize_nearest {
+    coordinateTransformation = #tensorrt.resize_coordinate_transformation<kASYMMETRIC>,
+    nearestRounding = #tensorrt.resize_round_mode<kFLOOR>,
+    selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>
+  } %arg0, %arg1 : (tensor<10x10xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  return %result : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @trt_resize_nearest_output_shape
+//  CHECK-SAME: tensorrt.engine
 
 
 func.func @trt_resize_linear(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
   %result = tensorrt.resize_linear {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kALIGN_CORNERS>,
     selectorForSinglePixel = #tensorrt.resize_selector<kUPPER>
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 
@@ -44,7 +58,7 @@ func.func @trt_resize_cubic(%arg0: tensor<10x10xf32>) -> tensor<20x20xf32> {
     coordinateTransformation = #tensorrt.resize_coordinate_transformation<kHALF_PIXEL>,
     selectorForSinglePixel = #tensorrt.resize_selector<kFORMULA>,
     cubicCoeff = -0.75 : f32
-  } %arg0 : tensor<10x10xf32> to tensor<20x20xf32>
+  } %arg0 : (tensor<10x10xf32>) -> tensor<20x20xf32>
   return %result : tensor<20x20xf32>
 }
 


### PR DESCRIPTION
Add `output_shape` argument to all resize ops in TRT dialect.