### PR TITLE
Print fully qualified type name in case of type mismatch

### DIFF
--- a/tripy/tripy/function_registry.py
+++ b/tripy/tripy/function_registry.py
@@ -100,7 +100,11 @@ class FuncOverload:
 
         def sanitize_name(annotation):
             # typing module annotations are likely to be better when pretty-printed due to including subscripts
-            return annotation if annotation.__module__ == "typing" else annotation.__qualname__
+            return (
+                annotation
+                if annotation.__module__ == "typing"
+                else f"{annotation.__module__}.{annotation.__qualname__}"
+            )
 
         def render_arg_type(arg: Any) -> str:
             # it is more useful to report more detailed types for sequences/tuples in error messages
@@ -116,7 +120,7 @@ class FuncOverload:
                 return f"List[Union[{', '.join(arg_types)}]]"
             if isinstance(arg, Tuple):
                 return f"Tuple[{', '.join(map(render_arg_type, arg))}]"
-            return type(arg).__qualname__
+            return f"{type(arg).__module__}.{type(arg).__qualname__}"
 
         def matches_type(name: str, annotation: type, arg: Any) -> bool:
             from collections.abc import Sequence as ABCSequence


### PR DESCRIPTION
Passing a Torch tensor to Tripy operations produces a cryptic error message since both Tripy and Torch use the same qualified name i.e. "Tensor" for their corresponding Tensor class i.e. `torch.Tensor` and `tripy.frontend.tensor.Tensor`. 

```
    def test_tensor_mismatch_tripy(self):
        a = torch.arange(1)
        b = torch.arange(1)
        print(tp.equal(a, b))

```

Error:
```
E For parameter: 'a', expected an instance of type: 'Tensor' but got argument of type: 'Tensor'.
```

Fix is to simplify prepend `obj.__qualname__` with `obj.__module__` to generate a fully qualified name.

```
E For parameter: 'a', expected an instance of type: 'tripy.frontend.tensor.Tensor' but got argument of type: 'torch.Tensor'.
```