### PR TITLE
Create memerf with None stream for host data

### DIFF
--- a/tripy/tripy/backend/mlir/memref.py
+++ b/tripy/tripy/backend/mlir/memref.py
@@ -28,12 +28,13 @@ import mlir_tensorrt.runtime.api as runtime
 @lru_cache(maxsize=None)
 def _cached_create_empty_memref(shape: Sequence[int], dtype: str, device_kind: str, stream):
     mlirtrt_device = mlir_utils.MLIRRuntimeClient().get_devices()[0] if device_kind == "gpu" else None
+    mlirtrt_stream = stream if device_kind == "gpu" else None
     mlir_dtype = mlir_utils.convert_tripy_dtype_to_runtime_dtype(dtype)
     return mlir_utils.MLIRRuntimeClient().create_memref(
         shape=list(shape),
         dtype=mlir_dtype,
         device=mlirtrt_device,
-        stream=stream,
+        stream=mlirtrt_stream,
     )
 
 


### PR DESCRIPTION
Several tests creating memref for host data with stream are failing https://github.com/NVIDIA/TensorRT-Incubator/commit/54f98196d4f72f02f4dc97afa24963e8ee608d6d#diff-d10f6cc35783e94f23c4ff7a348efac1ede25554509e0631d82ba6701f838455R71.

It looks like MLIR-TRT is now propagating the stream correctly. Failure is observed in following check:
```
  if (type == PointerType::host) {
    assert(alignment && !stream &&
           "expected alignment, no stream for host allocation");
   ...
 }
```

Tripy side fix is to pass None stream for host memref data.