### PR TITLE
[Tripy] Disallow passing both Shapes and Tensors with the `convert_inputs_to_tensors` decorator

### DIFF
--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -510,7 +510,8 @@ class TestShape:
 
     def test_binary_elementwise_broadcast_rejected(self, values):
         with raises(
-            tp.TripyException, match="For binary elementwise operators on Shapes, all inputs must be of rank at most 1"
+            tp.TripyException,
+            match="This operator expects all arguments to be tp.Tensor or all to be tp.Shape but was given arguments of mixed types",
         ):
             tp.Shape(values).multiply(tp.Tensor([values, values]))
 

--- a/tripy/tripy/frontend/ops/repeat.py
+++ b/tripy/tripy/frontend/ops/repeat.py
@@ -95,6 +95,6 @@ def repeat(input: "tripy.Tensor", repeats: Union[int, "tripy.ShapeScalar"], dim:
     repeat_mask = concatenate(
         [reshape(repeats, (1,)) if idx == dim else Tensor([1]) for idx in range(input.rank)], dim=0
     )
-    new_shape = input.shape.multiply(repeat_mask)
+    new_shape = input.shape.multiply(Shape(repeat_mask))
     out = reshape(out, new_shape)
     return out

--- a/tripy/tripy/frontend/shape.py
+++ b/tripy/tripy/frontend/shape.py
@@ -112,13 +112,14 @@ class Shape(Tensor):
         ret.stack_info = self.stack_info
         return ret
 
-    def add(self, other: Union["tripy.Shape", Tensor]) -> "tripy.Shape":
+    def add(self, other: Union["tripy.Shape", "tripy.ShapeScalar"]) -> "tripy.Shape":
         """
         The + operator for shapes is concatenation. This method is exposed to allow for elementwise addition,
         should it be necessary.
 
         Args:
-            other: Another :class:`Shape` or :class:`Tensor` .
+            other: Another :class:`Shape` or a :class:`ShapeScalar`. :class:`Tensor` is not permitted and should be
+                   explicitly converted if this is desired.
 
         Returns:
             The result of elementwise addition of this :class:`Shape` and `other`, returned as a :class:`Shape` .
@@ -135,13 +136,14 @@ class Shape(Tensor):
         """
         return super().__add__(other)
 
-    def multiply(self, other: Union["tripy.Shape", Tensor]) -> "tripy.Shape":
+    def multiply(self, other: Union["tripy.Shape", "tripy.ShapeScalar"]) -> "tripy.Shape":
         """
         The * operator for shapes is tiling. This method is exposed to allow for elementwise multiplication,
         should it be necessary.
 
         Args:
-            other: Another :class:`Shape` or :class:`Tensor` .
+            other: Another :class:`Shape` or a :class:`tripy.ShapeScalar`. :class:`Tensor` is not permitted and should be
+                   explicitly converted if this is desired.
 
         Returns:
             The result of elementwise multiplication of this :class:`Shape` and `other`, returned as a :class:`Shape` .

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -245,26 +245,44 @@ def convert_inputs_to_tensors(
 
             all_args = utils.merge_function_arguments(func, *args, **kwargs)
 
-            # TODO (#233): Disallow mixing Tensor/Shape. The workaround below works
-            # because ShapeScalars will typically be broadcasted in order to operate
-            # with Tensors/Shapes. Otherwise, Shape and ShapeScalar would have been
-            # at the same level of hierarchy.
-            #
-            # When a function has multiple arguments, the order of precedence is:
-            #
-            # 1. Tensor
-            # 2. Shape
-            # 3. ShapeScalar
-            #
-            # That is, if we have an operation with a mixture of types, all arguments are
-            # converted to the type with the highest precedence, e.g. Tensor + Shape -> Tensor.
+            # Disallow mixing Tensor and Shape by default. If it makes sense in a given function
+            # to have both Tensor and Shape arguments, that might suggest that custom handling
+            # rather than relying on this decorator would make sense.
+            tensor_args = []
+            shape_args = []
+            # Don't need special handling for ShapeScalars because they get broadcast up into larger sizes
+            # as needed -- can treat them as a tensor or a shape whenever we need
+            shape_scalar_encountered = False
+            for arg_name, arg in all_args:
+                if arg_name in exclude:
+                    continue
+                if isinstance(arg, Shape):
+                    shape_args.append((arg_name, arg))
+                elif isinstance(arg, ShapeScalar):
+                    shape_scalar_encountered = True
+                elif isinstance(arg, Tensor):
+                    tensor_args.append((arg_name, arg))
+
+            if len(shape_args) and len(tensor_args):
+
+                def format_args(arg_info):
+                    return ", ".join(map(lambda name_value: f"{name_value[1]} (`{name_value[0]}`)", arg_info))
+
+                raise_error(
+                    "This operator expects all arguments to be tp.Tensor or all to be tp.Shape but was given arguments of mixed types."
+                    " Consider explicitly converting between these types using tp.Shape(value) or value.as_tensor()."
+                    f" Arguments that are tp.Shape: {format_args(shape_args)}."
+                    f" Arguments that are tp.Tensor: {format_args(tensor_args)}."
+                )
+
+            # Result is a shape scalar only if we can't broadcast it up to anything else
             TensorType = None
-            MaxType = max(
-                (type(arg) for arg_name, arg in all_args if arg_name not in exclude),
-                key=lambda typ: {Tensor: 2, Shape: 1, ShapeScalar: 0}.get(typ, -1),
-            )
-            if issubclass(MaxType, Tensor):
-                TensorType = MaxType
+            if shape_scalar_encountered and not len(tensor_args) and not len(shape_args):
+                TensorType = ShapeScalar
+            if len(tensor_args):
+                TensorType = Tensor
+            if len(shape_args):
+                TensorType = Shape
 
             def get_arg(name: str):
                 for arg_name, arg in all_args:
@@ -639,6 +657,7 @@ def pretty_print(data_list, shape, threshold=1000, linewidth=10, edgeitems=3):
     """
     Returns a pretty-print string of list format data.
     """
+
     def _data_str(data, summarize, linewidth, edgeitems, indent=0):
         if isinstance(data, (float, int)):
             return str(data)


### PR DESCRIPTION
Addresses issue #233. Per discussions, there are not many remaining uses of the `convert_inputs_to_tensors` decorator in the codebase and it also seems that in just about all of those cases, it would not make sense to accept both shapes and tensors.