### PR TITLE
[Tripy] Rename `infer_shape_output_idxs` to `infer_tensor_variants`

### DIFF
--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -125,10 +125,10 @@ class Theta(BaseTraceOp):
     dim: int
     dtype: datatype.dtype
 
-    # The `infer_shape_output_idxs` method should indicate which outputs of this operator represent shapes.
-    # The corresponding outputs will be wrapped as `tripy.Shape` objects instead of regular `tripy.Tensor`s.
+    # The `infer_tensor_variants` method should indicate which outputs of this operator represent shapes or shape scalars;
+    # the corresponding outputs will be wrapped as `tripy.Shape` or `tripy.ShapeScalar` objects instead of regular `tripy.Tensor`s.
     # Our `Theta` operation should never return shapes, so we can use the corresponding preexisting policy.
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     # *Optional* `infer_dtypes()` populates the data types of the
     # output `TraceTensor`s. The default implementation copies the input

--- a/tripy/tripy/frontend/trace/ops/base.py
+++ b/tripy/tripy/frontend/trace/ops/base.py
@@ -72,6 +72,7 @@ class BaseTraceOp(abc.ABC):
 
         from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.frontend.tensor import Tensor
+        from tripy.frontend.trace.ops.utils import TensorVariants
 
         # NOTE: If you change the stack depth where the tensors are constructed, update STACK_DEPTH_OF_BUILD in
         # the Tensor constructor!
@@ -81,8 +82,8 @@ class BaseTraceOp(abc.ABC):
         out_trace_tensors = [out.trace_tensor for out in outputs]
         op = cls.build_internal(inp_trace_tensors, out_trace_tensors, *args, **kwargs)
 
-        # wrap shape outputs if necessary
-        res = op.infer_shape_output_idxs(inputs)
+        # wrap outputs in Shape or ShapeScalar if necessary
+        res = op.infer_tensor_variants(inputs)
         if not res:
             custom_err = "" if not res.error_details else " Further information: " + "\n".join(res.error_details)
             shape_arg_idxs = [i for i in range(len(inputs)) if isinstance(inputs[i], Shape)]
@@ -91,7 +92,11 @@ class BaseTraceOp(abc.ABC):
                 f"Error processing shape inputs in operator {cls.__name__}{custom_err}\n(Shape input indices: {shape_arg_msg}.)"
             )
 
-        shape = res.value.get("shape")
+        assert all(
+            map(lambda k: k == TensorVariants.SHAPE or k == TensorVariants.SCALAR, res.value.keys())
+        ), "Invalid key returned by infer_tensor_variants"
+
+        shape = res.value.get(TensorVariants.SHAPE)
         if shape is not None:
             # for shape outputs, we infer the length
             if len(shape) != 0:
@@ -102,7 +107,7 @@ class BaseTraceOp(abc.ABC):
                 if inferred_lengths[idx] is not None:
                     out_trace_tensors[idx].shape = [inferred_lengths[idx]]
 
-        scalar_shape = res.value.get("scalar")
+        scalar_shape = res.value.get(TensorVariants.SCALAR)
         if scalar_shape is not None:
             for idx in scalar_shape:
                 outputs[idx] = ShapeScalar(outputs[idx])
@@ -111,7 +116,7 @@ class BaseTraceOp(abc.ABC):
             return outputs[0]
         return outputs
 
-    def infer_shape_output_idxs(self, inputs: List["Tensor"]) -> Result:
+    def infer_tensor_variants(self, inputs: List["Tensor"]) -> Result:
         """
         Given the operator's inputs, this method returns a `Result` containing a dict of the operator's output indices
         that should be wrapped in `tp.Shape` or `tp.ShapeScalar`.
@@ -130,15 +135,17 @@ class BaseTraceOp(abc.ABC):
             inputs: The operator's (front-end `Tensor`) inputs
 
         Returns:
-            A `Result` containing, if successful, a list of indices of outputs that should be converted to `tp.Shape`.
+            A `Result` containing, if successful, a dict keyed by `TensorVariants.SHAPE` and `TensorVariants.SCALAR` where the values
+            list which indices of the output should be wrapped in `tp.Shape` and `tp.ShapeScalar`, respectively.
         """
         from tripy.frontend.shape import Shape
+        from tripy.frontend.trace.ops.utils import TensorVariants
 
         is_shape = lambda t: isinstance(t, Shape)
 
         if any(map(is_shape, inputs)):
             if all(map(is_shape, inputs)):
-                return Result.ok({"shape": list(range(len(self.outputs))), "scalar": []})
+                return Result.ok({TensorVariants.SHAPE: list(range(len(self.outputs))), TensorVariants.SCALAR: []})
             return Result.err(["Either all inputs must be tp.Shape or all must be tp.Tensor."])
         return Result.ok({})
 

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -49,7 +49,7 @@ class BinaryElementwise(BaseTraceOp):
             op_str = f"{self.kind}({self.inputs[0].name}, {self.inputs[1].name})"
         return f"{self.outputs[0].name} = {op_str}"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         # permit one input to be a shape but require the output to be a shape
         from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
@@ -69,10 +69,10 @@ class BinaryElementwise(BaseTraceOp):
                         f"The following inputs have invalid ranks: {invalid_indices_message}",
                     ]
                 )
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         elif all(map(lambda t: isinstance(t, ShapeScalar), inputs)):
             # Binary operation on ShapeScalar should yield another ShapeScalar.
-            return Result.ok({"scalar": [0]})
+            return Result.ok({op_utils.TensorVariants.SCALAR: [0]})
         else:
             return Result.ok({})
 
@@ -211,7 +211,7 @@ class Comparison(BinaryElementwise):
     kind: Kind.KindElem
 
     # the result of a comparison will be bool, so do not wrap
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = datatype.bool

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -19,14 +19,14 @@ from dataclasses import dataclass
 from tripy import export, constraints
 from tripy.frontend import utils as frontend_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
-from tripy.frontend.trace.ops.utils import InferLenPolicies
+from tripy.frontend.trace.ops.utils import InferLenPolicies, TensorVariants
 
 
 @dataclass(repr=False)
 class Cast(BaseTraceOp):
     dtype: "tripy.common.dtype"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.common.datatype import int32
         from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
@@ -34,9 +34,9 @@ class Cast(BaseTraceOp):
         # Only still a valid shape if it remains int32
         if self.dtype == int32:
             if isinstance(inputs[0], Shape):
-                return Result.ok({"shape": [0]})
+                return Result.ok({TensorVariants.SHAPE: [0]})
             elif isinstance(inputs[0], ShapeScalar):
-                return Result.ok({"scalar": [0]})
+                return Result.ok({TensorVariants.SCALAR: [0]})
 
         return Result.ok({})
 

--- a/tripy/tripy/frontend/trace/ops/convolution.py
+++ b/tripy/tripy/frontend/trace/ops/convolution.py
@@ -43,7 +43,7 @@ class Convolution(BaseTraceOp):
                 ],
             )
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def validate_inputs(self, tensor_shape, kernel_shape):
         if len(tensor_shape) != len(kernel_shape):

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -34,12 +34,13 @@ class Expand(BaseTraceOp):
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype
 
-    def infer_shape_output_idxs(self, inputs) -> Result:
+    def infer_tensor_variants(self, inputs) -> Result:
         from tripy.frontend.shape import Shape
+        from tripy.frontend.trace.ops.utils import TensorVariants
 
         # wrap if the first input is a shape and the output is rank-1
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({"shape": [0]})
+            return Result.ok({TensorVariants.SHAPE: [0]})
         return Result.ok({})
 
     def infer_len(self):

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -33,7 +33,7 @@ class Fill(BaseTraceOp):
     output_rank: int
     dtype: datatype.dtype
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.dtype

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -29,7 +29,7 @@ class Gather(BaseTraceOp):
     axis: int
 
     # the output is a shape if the value input is a shape
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank + self.inputs[1].rank - 1

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -32,7 +32,7 @@ class Iota(BaseTraceOp):
     output_rank: int
     dtype: datatype.dtype
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         if self.output_rank is None:

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -30,7 +30,7 @@ class MatrixMultiplication(BaseTraceOp):
     def __str__(self):
         return f"{self.outputs[0].name} = {' @ '.join([inp.name for inp in self.inputs])}"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 

--- a/tripy/tripy/frontend/trace/ops/pad.py
+++ b/tripy/tripy/frontend/trace/ops/pad.py
@@ -28,7 +28,7 @@ class Pad(BaseTraceOp):
 
     padding_value: Union[int, float]
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -28,7 +28,7 @@ class Permute(BaseTraceOp):
     permutation: Sequence[int]
 
     # note that permuting a shape would not do anything
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     infer_len = op_utils.InferLenPolicies.infer_same_as_first_input
 

--- a/tripy/tripy/frontend/trace/ops/pooling.py
+++ b/tripy/tripy/frontend/trace/ops/pooling.py
@@ -40,7 +40,7 @@ class Pooling(BaseTraceOp):
     stride: Sequence[int]
     padding: Sequence[Tuple[int]]
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -46,7 +46,7 @@ class Reduce(BaseTraceOp):
     kind: Kind
 
     # if the input is a shape, the output is likely not going to be rank 1 so we should not wrap as a shape
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         if self.dim is None:

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -40,13 +40,13 @@ class Reshape(BaseTraceOp):
         # not just its shape
         return [None]
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 
         # Only wrap the reshaped output if the result is rank 1, otherwise don't wrap
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         return Result.ok({})
 
     def infer_rank(self):
@@ -156,7 +156,7 @@ class Squeeze(BaseTraceOp):
 
     # Even if given a shape input, the output should not be a shape because the result will not be rank 1.
     # We should permit this, though, since it may be useful to extract a dimension from a shape as a scalar.
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
 

--- a/tripy/tripy/frontend/trace/ops/resize.py
+++ b/tripy/tripy/frontend/trace/ops/resize.py
@@ -32,7 +32,7 @@ class Resize(BaseTraceOp):
     scales: Sequence[float]
     align_corners: bool
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -27,8 +27,10 @@ from tripy.common.datatype import DATA_TYPES
 class Shape(BaseTraceOp):
 
     # always return a shape
-    def infer_shape_output_idxs(self, inputs) -> Result:
-        return Result.ok({"shape": [0]})
+    def infer_tensor_variants(self, inputs) -> Result:
+        from tripy.frontend.trace.ops.utils import TensorVariants
+
+        return Result.ok({TensorVariants.SHAPE: [0]})
 
     def infer_len(self):
         return [self.inputs[0].rank]

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -79,7 +79,7 @@ class Slice(BaseTraceOp):
         return [None]
 
     # we only care about the data input
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     @frontend_utils.make_function
     def to_flat_ir(self, inputs, outputs):

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -37,7 +37,7 @@ class Split(BaseTraceOp):
             return len(self.indices_or_sections) + 1
 
     # we only care about the data input
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     def infer_len(self):
         # since this only runs in the shape case, this is rank 1

--- a/tripy/tripy/frontend/trace/ops/storage.py
+++ b/tripy/tripy/frontend/trace/ops/storage.py
@@ -69,7 +69,7 @@ class Storage(BaseTraceOp):
             self.has_memref = False
 
     # for storage, we will always consider the result to be an ordinary tensor
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def str_skip_fields(self) -> Set[str]:
         # skip data if i) it is a MemRefValue or ii) its volume exceeds threshold

--- a/tripy/tripy/frontend/trace/ops/unsqueeze.py
+++ b/tripy/tripy/frontend/trace/ops/unsqueeze.py
@@ -29,7 +29,7 @@ class Unsqueeze(BaseTraceOp):
     dim: int
 
     # the result will not be rank 1 and so can't be a shape but we may want to unsqueeze shapes
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from enum import Enum
 from typing import Any, List, Optional, Sequence
 
 from tripy import utils
@@ -49,24 +50,34 @@ def get_broadcast_dim(dim1, dim2):
 
 
 ##
-## Handling shape outputs: These are common policies to use for overring infer_shape_output_idxs
+## Handling returning different tensor variants (Shape or ShapeScalars) from operators
 ##
 
+"""
+Enum representing the tensor variants encoded in the result of `infer_tensor_variants`.
+"""
 
-class ShapeOutputIdxPolicies:
+
+class TensorVariants(Enum):
+    SHAPE = 1
+    SCALAR = 2
+
+
+# These are common policies to use for overring infer_tensor_variants
+class InferVariantPolicies:
     def infer_from_first_input_only(self, inputs):
         """
-        Common override for `infer_shape_output_idxs`: Treat the outputs as shapes if the *first* input is a shape.
+        Treat the outputs as shapes if the *first* input is a shape.
         """
         from tripy.frontend.shape import Shape
 
         if isinstance(inputs[0], Shape):
-            return Result.ok({"shape": list(range(len(self.outputs)))})
+            return Result.ok({TensorVariants.SHAPE: list(range(len(self.outputs)))})
         return Result.ok({})
 
     def never_return_shape(self, inputs):
         """
-        Accepts shapes but the result is always no shape indices
+        Accepts shapes but the result is always no shape indices.
         """
         return Result.ok({})
 

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -27,7 +27,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 @dataclass(repr=False)
 class Where(BaseTraceOp):
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 
@@ -41,7 +41,7 @@ class Where(BaseTraceOp):
                         f" the Boolean input must be rank 1, but given rank {inputs[0].rank}",
                     ]
                 )
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         elif not isinstance(inputs[1], Shape) and not isinstance(inputs[2], Shape):
             return Result.ok({})
         else:


### PR DESCRIPTION
Partly addresses #233. `infer_shape_output_idxs` is no longer a very descriptive name since it can distinguish `Shape` outputs and `ShapeScalar` outputs. This PR renames it to `infer_tensor_variants`. Additionally, it uses an enum for the dict key to avoid having magic string constants throughout the codebase.

Happy to consider other names as well.