### PR TITLE
[Tripy][hotfix] Remove broken ArXiv link

### DIFF
--- a/tripy/docs/pre0_user_guides/02-compiler.md
+++ b/tripy/docs/pre0_user_guides/02-compiler.md
@@ -4,7 +4,7 @@
 
 ## Model Compilation And Deployment
 
-Let's walk through a simple example of a [GEGLU](https://arxiv.org/abs/2002.05202v1) module defined below:
+Let's walk through a simple example of a [GEGLU](https://arxiv.org/abs/2002.05202) module defined below:
 
 ```py
 # doc: no-print-locals


### PR DESCRIPTION
The link https://arxiv.org/abs/2002.05202v1 in `docs/pre0_user_guides/02-compiler.md` is currently (probably temporarily) broken, which causes the CI check for valid URLs to fail. Oddly, the link without the version number, https://arxiv.org/abs/2002.05202, does work. There isn't a v2 (and a second version of a 2020 paper is unlikely to be posted), so we might as well use the first link.