### PR TITLE
Updates the compiler to emit errors if evaluating while tracing

### DIFF
--- a/tripy/docs/pre0_user_guides/02-compiler.md
+++ b/tripy/docs/pre0_user_guides/02-compiler.md
@@ -114,33 +114,3 @@ We can also query properties about the executable:
 input_info = loaded_fast_geglu.get_input_info()
 output_info = loaded_fast_geglu.get_output_info()
 ```
-
-## Common Pitfalls
-
-### Functions Must Be Pure
-
-Tripy expects that the functions that will be compiled are pure functions with no side effects.
-Consider this example:
-
-```py
-# doc: print-locals out
-def add_times_two(a, b):
-    c = a + b
-    print(f"c : {c}")
-    return c + a + b
-
-inp_info = tp.InputInfo(shape=(1, 2), dtype=tp.float32)
-fast_myadd = tp.compile(add_times_two, args=[inp_info, inp_info])
-a = tp.Tensor([[1.0, 2.0]], dtype=tp.float32)
-b = tp.Tensor([[2.0, 3.0]], dtype=tp.float32)
-
-out = fast_myadd(a, b)
-```
-
-We would expect that the output `out` is `[6.0, 10.0]` and `c` gets evaluated to `[3.0, 5.0]`.
-
-This unexpected behavior occurs because Tripy uses dummy tensors filled with 1's during the
-compilation process. When the print(c) statement is encountered during compilation, it
-outputs the result of adding two tensors filled with 1's, which is `[2.0, 2.0]`.
-The compiled function then uses this dummy result in place of the actual c value,
-leading to incorrect calculations in the final output.

--- a/tripy/tripy/frontend/tensor.py
+++ b/tripy/tripy/frontend/tensor.py
@@ -189,6 +189,7 @@ class Tensor(metaclass=TensorMeta):
         self.device = flat_ir.outputs[0].device
 
         Storage.build_internal([], [self.trace_tensor], data)
+        self.trace_tensor.eval_stack_info = utils.get_stack_info()
         return data
 
     def tolist(self):

--- a/tripy/tripy/frontend/trace/ops/base.py
+++ b/tripy/tripy/frontend/trace/ops/base.py
@@ -49,8 +49,11 @@ class BaseTraceOp(abc.ABC):
         *args and **kwargs are passed along to the trace operation's constructor.
         """
         op = cls(inputs, outputs, *args, **kwargs)
+
+        is_compile_tracer = any(inp.is_compile_tracer for inp in inputs)
         for out in op.outputs:
             out.producer = op
+            out.is_compile_tracer |= is_compile_tracer
 
         op.infer_dtypes()
         op.infer_rank()

--- a/tripy/tripy/frontend/trace/ops/storage.py
+++ b/tripy/tripy/frontend/trace/ops/storage.py
@@ -18,17 +18,16 @@
 from dataclasses import dataclass
 from typing import List, Sequence, Set, Union
 
+import mlir_tensorrt.runtime.api as runtime
+
 from tripy import utils
 from tripy.backend.mlir import memref
 from tripy.backend.mlir import utils as mlir_utils
 from tripy.common import datatype
-from tripy.frontend import utils as frontend_utils
-from tripy.common import utils as common_utils
 from tripy.common import device as tp_device
+from tripy.common import utils as common_utils
 from tripy.frontend.trace.ops import utils as op_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
-
-import mlir_tensorrt.runtime.api as runtime
 
 
 @dataclass(repr=False)

--- a/tripy/tripy/frontend/trace/tensor.py
+++ b/tripy/tripy/frontend/trace/tensor.py
@@ -35,6 +35,12 @@ class TraceTensor:
     producer: "BaseTraceOp"
     shape: Optional[List[int]] = None
 
+    # Whether this tensor was constructed in order to trace a computation graph for the compiler.
+    is_compile_tracer: bool = False
+    # Stack information for the point at which this tensor was evaluated if it was.
+    # This is useful in the compiler to disallow evaluation during tracing.
+    eval_stack_info: Optional[utils.StackInfo] = None
+
     def __str__(self) -> str:
         return (
             f"{self.name}: [rank=({self.rank}), "


### PR DESCRIPTION
Updates the `tp.compile` API so that an error is emitted if a tensor is evaluated while tracing for the purposes of compiling.