### PR TITLE
[tensorrt] Add canonicalizer for resize to absorb generalizing casts

### DIFF
--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/Passes.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/Passes.cpp
@@ -39,6 +39,7 @@ void plan::buildPlanSegmentationPipeline(
       plan::createMaterializeShapeCalculationsPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addPass(plan::createPlanRefineTypesPass());
+  pm.addPass(createCanonicalizerPass());
   if (!opts.disableCreateShapeFuncPass)
     pm.addPass(createPlanCreateShapeFuncsPass());
   pm.addNestedPass<func::FuncOp>(

--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -3670,6 +3670,7 @@ def TensorRT_ResizeNearestOp : TensorRT_Op<"resize_nearest", [Pure,
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
   let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let extraClassDeclaration = [{
     /// Returns true if created op is valid for TensorRT major version.
     bool isValidForTensorRTVersion(int64_t trtMajorVersion);
@@ -3743,6 +3744,7 @@ def TensorRT_ResizeLinearOp : TensorRT_Op<"resize_linear", [Pure,
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
   let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let extraClassDeclaration = [{
     /// Returns true if created op is valid for TensorRT major version.
     bool isValidForTensorRTVersion(int64_t trtMajorVersion);
@@ -3818,6 +3820,7 @@ def TensorRT_ResizeCubicOp : TensorRT_Op<"resize_cubic", [Pure,
     TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
   let assemblyFormat = "attr-dict $input ( `,` $output_shape^ )? `:` functional-type(operands,results) ";
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
   let extraClassDeclaration = [{
     /// Returns true if created op is valid for TensorRT major version.
     bool isValidForTensorRTVersion(int64_t trtMajorVersion);


### PR DESCRIPTION
Adds canonicalizer for resize ops to absorb cast ops which cast from more specifics types into dynamic types.