### PR TITLE
[Tripy] Rename `infer_shape_output_idxs` to `infer_tensor_variants`

### DIFF
--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -125,10 +125,10 @@ class Theta(BaseTraceOp):
     dim: int
     dtype: datatype.dtype
 
-    # The `infer_shape_output_idxs` method should indicate which outputs of this operator represent shapes.
-    # The corresponding outputs will be wrapped as `tripy.Shape` objects instead of regular `tripy.Tensor`s.
+    # The `infer_tensor_variants` method should indicate which outputs of this operator represent shapes or shape scalars;
+    # the corresponding outputs will be wrapped as `tripy.Shape` or `tripy.ShapeScalar` objects instead of regular `tripy.Tensor`s.
     # Our `Theta` operation should never return shapes, so we can use the corresponding preexisting policy.
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     # *Optional* `infer_dtypes()` populates the data types of the
     # output `TraceTensor`s. The default implementation copies the input

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -49,7 +49,7 @@ class BinaryElementwise(BaseTraceOp):
             op_str = f"{self.kind}({self.inputs[0].name}, {self.inputs[1].name})"
         return f"{self.outputs[0].name} = {op_str}"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         # To avoid issues, we do not permit both Shape and Tensor args and recommend explicit conversion if they do need to combined.
         # ShapeScalar args can be broadcast up into Shapes and so do not pose an issue.
         from tripy.frontend.shape import Shape, ShapeScalar
@@ -70,10 +70,10 @@ class BinaryElementwise(BaseTraceOp):
                         f" Indices of tensor arguments: {', '.join(tensor_arg_indices)}.",
                     ]
                 )
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         elif all(map(lambda t: isinstance(t, ShapeScalar), inputs)):
             # Binary operation on ShapeScalar should yield another ShapeScalar.
-            return Result.ok({"scalar": [0]})
+            return Result.ok({op_utils.TensorVariants.SCALAR: [0]})
         else:
             return Result.ok({})
 
@@ -212,7 +212,7 @@ class Comparison(BinaryElementwise):
     kind: Kind.KindElem
 
     # the result of a comparison will be bool, so do not wrap
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = datatype.bool

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -70,12 +70,12 @@ class BinaryElementwise(BaseTraceOp):
                         f" Indices of tensor arguments: {', '.join(tensor_arg_indices)}.",
                     ]
                 )
-            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
+            return Result.ok([Shape])
         elif all(map(lambda t: isinstance(t, ShapeScalar), inputs)):
             # Binary operation on ShapeScalar should yield another ShapeScalar.
-            return Result.ok({op_utils.TensorVariants.SCALAR: [0]})
+            return Result.ok([ShapeScalar])
         else:
-            return Result.ok({})
+            return Result.ok([None])
 
     def infer_len(self):
         # For the shape case, the result will be broadcast to the max of the input shapes

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from tripy import export, constraints
 from tripy.frontend import utils as frontend_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
-from tripy.frontend.trace.ops.utils import InferLenPolicies, TensorVariants
+from tripy.frontend.trace.ops.utils import InferLenPolicies
 
 
 @dataclass(repr=False)
@@ -33,12 +33,9 @@ class Cast(BaseTraceOp):
 
         # Only still a valid shape if it remains int32
         if self.dtype == int32:
-            if isinstance(inputs[0], Shape):
-                return Result.ok({TensorVariants.SHAPE: [0]})
-            elif isinstance(inputs[0], ShapeScalar):
-                return Result.ok({TensorVariants.SCALAR: [0]})
-
-        return Result.ok({})
+            if isinstance(inputs[0], (Shape, ShapeScalar)):
+                return Result.ok([type(inputs[0])])
+        return Result.ok([None])
 
     infer_len = InferLenPolicies.infer_same_as_first_input
 

--- a/tripy/tripy/frontend/trace/ops/cast.py
+++ b/tripy/tripy/frontend/trace/ops/cast.py
@@ -19,14 +19,14 @@ from dataclasses import dataclass
 from tripy import export, constraints
 from tripy.frontend import utils as frontend_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
-from tripy.frontend.trace.ops.utils import InferLenPolicies
+from tripy.frontend.trace.ops.utils import InferLenPolicies, TensorVariants
 
 
 @dataclass(repr=False)
 class Cast(BaseTraceOp):
     dtype: "tripy.common.dtype"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.common.datatype import int32
         from tripy.frontend.shape import Shape, ShapeScalar
         from tripy.utils import Result
@@ -34,9 +34,9 @@ class Cast(BaseTraceOp):
         # Only still a valid shape if it remains int32
         if self.dtype == int32:
             if isinstance(inputs[0], Shape):
-                return Result.ok({"shape": [0]})
+                return Result.ok({TensorVariants.SHAPE: [0]})
             elif isinstance(inputs[0], ShapeScalar):
-                return Result.ok({"scalar": [0]})
+                return Result.ok({TensorVariants.SCALAR: [0]})
 
         return Result.ok({})
 

--- a/tripy/tripy/frontend/trace/ops/convolution.py
+++ b/tripy/tripy/frontend/trace/ops/convolution.py
@@ -43,7 +43,7 @@ class Convolution(BaseTraceOp):
                 ],
             )
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def validate_inputs(self, tensor_shape, kernel_shape):
         if len(tensor_shape) != len(kernel_shape):

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -36,12 +36,11 @@ class Expand(BaseTraceOp):
 
     def infer_tensor_variants(self, inputs) -> Result:
         from tripy.frontend.shape import Shape
-        from tripy.frontend.trace.ops.utils import TensorVariants
 
         # wrap if the first input is a shape and the output is rank-1
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({TensorVariants.SHAPE: [0]})
-        return Result.ok({})
+            return Result.ok([Shape])
+        return Result.ok([None])
 
     def infer_len(self):
         if self.output_len is not None:

--- a/tripy/tripy/frontend/trace/ops/expand.py
+++ b/tripy/tripy/frontend/trace/ops/expand.py
@@ -34,12 +34,13 @@ class Expand(BaseTraceOp):
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype
 
-    def infer_shape_output_idxs(self, inputs) -> Result:
+    def infer_tensor_variants(self, inputs) -> Result:
         from tripy.frontend.shape import Shape
+        from tripy.frontend.trace.ops.utils import TensorVariants
 
         # wrap if the first input is a shape and the output is rank-1
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({"shape": [0]})
+            return Result.ok({TensorVariants.SHAPE: [0]})
         return Result.ok({})
 
     def infer_len(self):

--- a/tripy/tripy/frontend/trace/ops/fill.py
+++ b/tripy/tripy/frontend/trace/ops/fill.py
@@ -33,7 +33,7 @@ class Fill(BaseTraceOp):
     output_rank: int
     dtype: datatype.dtype
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.dtype

--- a/tripy/tripy/frontend/trace/ops/gather.py
+++ b/tripy/tripy/frontend/trace/ops/gather.py
@@ -29,7 +29,7 @@ class Gather(BaseTraceOp):
     axis: int
 
     # the output is a shape if the value input is a shape
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank + self.inputs[1].rank - 1

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -32,7 +32,7 @@ class Iota(BaseTraceOp):
     output_rank: int
     dtype: datatype.dtype
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         if self.output_rank is None:

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -39,7 +39,7 @@ class MatrixMultiplication(BaseTraceOp):
         if (isinstance(inputs[0], Shape) and isinstance(inputs[1], Shape)) or (
             not isinstance(inputs[0], Shape) and not isinstance(inputs[1], Shape)
         ):
-            return Result.ok({})
+            return Result.ok([None])
         return Result.err(None)
 
     def infer_rank(self):

--- a/tripy/tripy/frontend/trace/ops/matmul.py
+++ b/tripy/tripy/frontend/trace/ops/matmul.py
@@ -30,7 +30,7 @@ class MatrixMultiplication(BaseTraceOp):
     def __str__(self):
         return f"{self.outputs[0].name} = {' @ '.join([inp.name for inp in self.inputs])}"
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 

--- a/tripy/tripy/frontend/trace/ops/pad.py
+++ b/tripy/tripy/frontend/trace/ops/pad.py
@@ -28,7 +28,7 @@ class Pad(BaseTraceOp):
 
     padding_value: Union[int, float]
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_dtypes(self):
         self.outputs[0].dtype = self.inputs[0].dtype

--- a/tripy/tripy/frontend/trace/ops/permute.py
+++ b/tripy/tripy/frontend/trace/ops/permute.py
@@ -28,7 +28,7 @@ class Permute(BaseTraceOp):
     permutation: Sequence[int]
 
     # note that permuting a shape would not do anything
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     infer_len = op_utils.InferLenPolicies.infer_same_as_first_input
 

--- a/tripy/tripy/frontend/trace/ops/pooling.py
+++ b/tripy/tripy/frontend/trace/ops/pooling.py
@@ -40,7 +40,7 @@ class Pooling(BaseTraceOp):
     stride: Sequence[int]
     padding: Sequence[Tuple[int]]
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank

--- a/tripy/tripy/frontend/trace/ops/reduce.py
+++ b/tripy/tripy/frontend/trace/ops/reduce.py
@@ -46,7 +46,7 @@ class Reduce(BaseTraceOp):
     kind: Kind
 
     # if the input is a shape, the output is likely not going to be rank 1 so we should not wrap as a shape
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         if self.dim is None:

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -44,10 +44,10 @@ class Reshape(BaseTraceOp):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 
-        # Only wrap the reshaped output if the result is rank 1, otherwise don't wrap
+        # Only wrap the reshaped output if the result is rank 1
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
-        return Result.ok({})
+            return Result.ok([Shape])
+        return Result.ok([None])
 
     def infer_rank(self):
         if self.output_rank is None:

--- a/tripy/tripy/frontend/trace/ops/reshape.py
+++ b/tripy/tripy/frontend/trace/ops/reshape.py
@@ -40,13 +40,13 @@ class Reshape(BaseTraceOp):
         # not just its shape
         return [None]
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 
         # Only wrap the reshaped output if the result is rank 1, otherwise don't wrap
         if isinstance(inputs[0], Shape) and self.output_rank == 1:
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         return Result.ok({})
 
     def infer_rank(self):
@@ -160,7 +160,7 @@ class Squeeze(BaseTraceOp):
 
     # Even if given a shape input, the output should not be a shape because the result will not be rank 1.
     # We should permit this, though, since it may be useful to extract a dimension from a shape as a scalar.
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
 

--- a/tripy/tripy/frontend/trace/ops/resize.py
+++ b/tripy/tripy/frontend/trace/ops/resize.py
@@ -32,7 +32,7 @@ class Resize(BaseTraceOp):
     scales: Sequence[float]
     align_corners: bool
 
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def infer_rank(self):
         self.outputs[0].rank = self.inputs[0].rank

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -28,9 +28,9 @@ class Shape(BaseTraceOp):
 
     # always return a shape
     def infer_tensor_variants(self, inputs) -> Result:
-        from tripy.frontend.trace.ops.utils import TensorVariants
+        from tripy.frontend.shape import Shape as ShapeType
 
-        return Result.ok({TensorVariants.SHAPE: [0]})
+        return Result.ok([ShapeType])
 
     def infer_len(self):
         return [self.inputs[0].rank]

--- a/tripy/tripy/frontend/trace/ops/shape.py
+++ b/tripy/tripy/frontend/trace/ops/shape.py
@@ -27,8 +27,10 @@ from tripy.common.datatype import DATA_TYPES
 class Shape(BaseTraceOp):
 
     # always return a shape
-    def infer_shape_output_idxs(self, inputs) -> Result:
-        return Result.ok({"shape": [0]})
+    def infer_tensor_variants(self, inputs) -> Result:
+        from tripy.frontend.trace.ops.utils import TensorVariants
+
+        return Result.ok({TensorVariants.SHAPE: [0]})
 
     def infer_len(self):
         return [self.inputs[0].rank]

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -79,7 +79,7 @@ class Slice(BaseTraceOp):
         return [None]
 
     # we only care about the data input
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     @frontend_utils.make_function
     def to_flat_ir(self, inputs, outputs):

--- a/tripy/tripy/frontend/trace/ops/split.py
+++ b/tripy/tripy/frontend/trace/ops/split.py
@@ -37,7 +37,7 @@ class Split(BaseTraceOp):
             return len(self.indices_or_sections) + 1
 
     # we only care about the data input
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.infer_from_first_input_only
+    infer_tensor_variants = op_utils.InferVariantPolicies.infer_from_first_input_only
 
     def infer_len(self):
         # since this only runs in the shape case, this is rank 1

--- a/tripy/tripy/frontend/trace/ops/storage.py
+++ b/tripy/tripy/frontend/trace/ops/storage.py
@@ -68,7 +68,7 @@ class Storage(BaseTraceOp):
             self.has_memref = False
 
     # for storage, we will always consider the result to be an ordinary tensor
-    infer_shape_output_idxs = op_utils.ShapeOutputIdxPolicies.never_return_shape
+    infer_tensor_variants = op_utils.InferVariantPolicies.never_return_shape
 
     def str_skip_fields(self) -> Set[str]:
         # skip data if i) it is a MemRefValue or ii) its volume exceeds threshold

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from enum import Enum
 from typing import Any, List, Optional, Sequence
 
 import tripy.common.datatype as tp_dtype
@@ -50,24 +51,34 @@ def write_shape_input_indices_message(inputs: List["tripy.Tensor"]) -> str:
 
 
 ##
-## Handling shape outputs: These are common policies to use for overring infer_shape_output_idxs
+## Handling returning different tensor variants (Shape or ShapeScalars) from operators
 ##
 
+"""
+Enum representing the tensor variants encoded in the result of `infer_tensor_variants`.
+"""
 
-class ShapeOutputIdxPolicies:
+
+class TensorVariants(Enum):
+    SHAPE = 1
+    SCALAR = 2
+
+
+# These are common policies to use for overring infer_tensor_variants
+class InferVariantPolicies:
     def infer_from_first_input_only(self, inputs):
         """
-        Common override for `infer_shape_output_idxs`: Treat the outputs as shapes if the *first* input is a shape.
+        Treat the outputs as shapes if the *first* input is a shape.
         """
         from tripy.frontend.shape import Shape
 
         if isinstance(inputs[0], Shape):
-            return Result.ok({"shape": list(range(len(self.outputs)))})
+            return Result.ok({TensorVariants.SHAPE: list(range(len(self.outputs)))})
         return Result.ok({})
 
     def never_return_shape(self, inputs):
         """
-        Accepts shapes but the result is always no shape indices
+        Accepts shapes but the result is always no shape indices.
         """
         return Result.ok({})
 

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -54,15 +54,6 @@ def write_shape_input_indices_message(inputs: List["tripy.Tensor"]) -> str:
 ## Handling returning different tensor variants (Shape or ShapeScalars) from operators
 ##
 
-"""
-Enum representing the tensor variants encoded in the result of `infer_tensor_variants`.
-"""
-
-
-class TensorVariants(Enum):
-    SHAPE = 1
-    SCALAR = 2
-
 
 # These are common policies to use for overring infer_tensor_variants
 class InferVariantPolicies:
@@ -73,14 +64,14 @@ class InferVariantPolicies:
         from tripy.frontend.shape import Shape
 
         if isinstance(inputs[0], Shape):
-            return Result.ok({TensorVariants.SHAPE: list(range(len(self.outputs)))})
-        return Result.ok({})
+            return Result.ok([Shape] * len(self.outputs))
+        return Result.ok([None] * len(self.outputs))
 
     def never_return_shape(self, inputs):
         """
         Accepts shapes but the result is always no shape indices.
         """
-        return Result.ok({})
+        return Result.ok([None] * len(self.outputs))
 
 
 ##

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from enum import Enum
 from typing import Any, List, Optional, Sequence
 
 import tripy.common.datatype as tp_dtype

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -41,9 +41,9 @@ class Where(BaseTraceOp):
                         f" the Boolean input must be rank 1, but given rank {inputs[0].rank}",
                     ]
                 )
-            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
+            return Result.ok([Shape])
         elif not isinstance(inputs[1], Shape) and not isinstance(inputs[2], Shape):
-            return Result.ok({})
+            return Result.ok([None])
         else:
             return Result.err(
                 [

--- a/tripy/tripy/frontend/trace/ops/where.py
+++ b/tripy/tripy/frontend/trace/ops/where.py
@@ -27,7 +27,7 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 @dataclass(repr=False)
 class Where(BaseTraceOp):
 
-    def infer_shape_output_idxs(self, inputs):
+    def infer_tensor_variants(self, inputs):
         from tripy.frontend.shape import Shape
         from tripy.utils import Result
 
@@ -41,7 +41,7 @@ class Where(BaseTraceOp):
                         f" the Boolean input must be rank 1, but given rank {inputs[0].rank}",
                     ]
                 )
-            return Result.ok({"shape": [0]})
+            return Result.ok({op_utils.TensorVariants.SHAPE: [0]})
         elif not isinstance(inputs[1], Shape) and not isinstance(inputs[2], Shape):
             return Result.ok({})
         else:


### PR DESCRIPTION
Partly addresses https://github.com/NVIDIA/TensorRT-Incubator/issues/233, reopened from #266 and incorporating feedback (thanks, @pranavm-nvidia). `infer_shape_output_idx`s is no longer a very descriptive name since it can now distinguish `Shape` outputs and `ShapeScalar` outputs. This PR renames it to `infer_tensor_variants`. Additionally, it changes the format of the return value for that method to use `Shape` and `ShapeScalar` types as outputs directly, avoiding magic string constants.