### PR TITLE
[Dialect/Plan] Update Plan dialect to use non-dps calling convention

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
@@ -128,6 +128,9 @@ struct StableHLOToExecutableOptions : public mlir::OptionsContext {
   /// Whether to disallow host tensors in TensorRT clusters.
   bool disallowHostTensorsInTensorRTClusters = false;
 
+  /// Whether to use non-DPS style calling convention.
+  bool useNonDPSCallConv = false;
+
   /// Entrypoint function name.
   std::string entrypoint = "main";
 

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
@@ -128,8 +128,9 @@ struct StableHLOToExecutableOptions : public mlir::OptionsContext {
   /// Whether to disallow host tensors in TensorRT clusters.
   bool disallowHostTensorsInTensorRTClusters = false;
 
-  /// Whether to use non-DPS style calling convention.
-  bool useNonDPSCallConv = false;
+  /// Use non-DPS style calling convention for entrypoint function
+  /// and backend types that support allocating results.
+  bool enableNonDPSReturns = false;
 
   /// Entrypoint function name.
   std::string entrypoint = "main";

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanOps.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanOps.td
@@ -277,10 +277,10 @@ def Plan_InlineClosedGroupOp : Plan_InlineClosedGroupBase<"inline_closed_group",
 }
 
 //===----------------------------------------------------------------------===//
-// InlineClosedGroupNonDPSOp
+// InlineClosedAllocGroupOp
 //===----------------------------------------------------------------------===//
 
-def Plan_InlineClosedGroupNonDPSOp : Plan_InlineClosedGroupBase<"inline_closed_group_non_dps", [
+def Plan_InlineClosedAllocGroupOp : Plan_InlineClosedGroupBase<"inline_closed_alloc_group", [
   IsolatedFromAbove,
   SingleBlockImplicitTerminator<"plan::YieldOp">,
   DeclareOpInterfaceMethods<RegionBranchOpInterface,
@@ -289,10 +289,12 @@ def Plan_InlineClosedGroupNonDPSOp : Plan_InlineClosedGroupBase<"inline_closed_g
     ["getAsmBlockArgumentNames"]>
 ]> {
   let description = [{
-  The `plan.inline_closed_group_non_dps` operation is a variant of the
+  The `plan.inline_closed_alloc_group` operation is a variant of the
   `plan.inline_closed_group` operation that does not use destination-passing style
-  (DPS). It is isolated from above and explicitly captures input operands,
-  but unlike its DPS counterpart, it does not capture destination operands.
+  (DPS). It is isolated from above and explicitly captures input operands, but unlike
+  its DPS counterpart, it does not capture destination operands because its results must
+  be lowered to allocation(s). The allocations may or may not be of a size that can only 
+  be computed inside of the region.
   This operation takes input operands and their corresponding bounds attributes, 
   and produces results. The `input_attrs` hold bounds attribute information for 
   the input operands. The absence of bounds information is allowed (`none` bounds).
@@ -307,9 +309,9 @@ def Plan_InlineClosedGroupNonDPSOp : Plan_InlineClosedGroupBase<"inline_closed_g
   %0 = ... : tensor<?xf32> // A dynamically shaped operand
   %1 = ... : index         // A dynamic calculation of %0's extent
 
-  %2 = plan.inline_closed_group_non_dps target(#plan.cluster_target<tensorrt>)
+  %2 = plan.inline_closed_alloc_group target(#plan.cluster_target<tensorrt>)
     inputs(%0, %1 : tensor<?xf32>, index)
-    in_attrs [#plan.bounds<shape, , >, #plan.bounds<none>] -> tensor<?xf32> {
+    in_attrs [#plan.bounds<shape, [10], [20]>, #plan.bounds<none>]-> tensor<?xf32> {
     %3 = plan.with_shape %0 (%1) : (tensor<?xf32>, index) -> tensor<?xf32>
     %4 = stablehlo.exponential %3 : tensor<?xf32>
     yield %4 : tensor<?xf32>
@@ -353,7 +355,7 @@ def Plan_YieldOp : Plan_Op<"yield", [
       Terminator,
       ReturnLike,
       ParentOneOf<["plan::InlineGroupOp",
-                   "plan::InlineClosedGroupOp", "plan::InlineClosedGroupNonDPSOp"]>]> {
+                   "plan::InlineClosedGroupOp", "plan::InlineClosedAllocGroupOp"]>]> {
 
   let arguments = (ins Variadic<AnyType>:$results);
 

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanOps.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanOps.td
@@ -131,11 +131,41 @@ def Plan_InlineGroupOp : Plan_GroupOpBase<"inline_group", [
 }
 
 //===----------------------------------------------------------------------===//
-// InlineClosedGroupOp
+// Plan_InlineClosedGroupBase
 //===----------------------------------------------------------------------===//
 
-def Plan_InlineClosedGroupOp : Plan_GroupOpBase<"inline_closed_group", [
-  IsolatedFromAbove,
+class Plan_InlineClosedGroupBase<string mnemonic, list<Trait> traits = []> :
+    Plan_GroupOpBase<mnemonic, traits # [IsolatedFromAbove]> {
+
+  code baseInlineClosedExtraClassDeclaration = baseExtraClassDeclaration # [{
+    // Common methods for both DPS and non-DPS versions
+    bool argHasTensorType(unsigned inputIdx) {
+      assert(inputIdx < getInputs().size() && "input index out-of-bounds");
+      return isa<RankedTensorType>(getInputs()[inputIdx].getType());
+    }
+
+    BoundsAttr getInputBoundsAttr(unsigned inputIdx) {
+      assert(inputIdx < getInputs().size() && "input index out-of-bounds");
+      return cast<BoundsAttr>(getInputAttrs()[inputIdx]);
+    }
+
+    /// Populate the `input_attrs` from an array of BoundsAttrs.
+    void setInputAttrsAttr(ArrayRef<BoundsAttr> boundsAttrs) {
+      setInputAttrsAttr(::mlir::ArrayAttr::get(
+        getOperation()->getContext(),
+        ArrayRef<Attribute>(boundsAttrs.begin(), boundsAttrs.end())
+      ));
+    }
+  }];
+
+  let extraClassDeclaration = baseInlineClosedExtraClassDeclaration;
+}
+
+//===----------------------------------------------------------------------===//
+// Plan_InlineClosedGroupOp
+//===----------------------------------------------------------------------===//
+
+def Plan_InlineClosedGroupOp : Plan_InlineClosedGroupBase<"inline_closed_group", [
   AttrSizedOperandSegments,
   DestinationStyleOpInterface,
   SingleBlockImplicitTerminator<"plan::YieldOp">,
@@ -226,22 +256,10 @@ def Plan_InlineClosedGroupOp : Plan_GroupOpBase<"inline_closed_group", [
                    CArg<"ArrayRef<BoundsAttr>", "{}">:$res_attrs)>
   ];
 
-  let extraClassDeclaration = baseExtraClassDeclaration # [{
+  let extraClassDeclaration = baseInlineClosedExtraClassDeclaration # [{
 
     MutableOperandRange getDpsInitsMutable() {
       return getOutsMutable();
-    }
-
-    /// Returns true if the `i-th` input argument has a tensor type.
-    bool argHasTensorType(unsigned inputIdx) {
-      assert(inputIdx < getInputs().size() && "input index out-of-bounds");
-      return isa<RankedTensorType>(getInputs()[inputIdx].getType());
-    }
-
-    /// Returns the i-th input argument's bounds attribute.
-    BoundsAttr getInputBoundsAttr(unsigned inputIdx) {
-      assert(inputIdx < getInputs().size() && "input index out-of-bounds");
-      return cast<BoundsAttr>(getInputAttrs()[inputIdx]);
     }
 
     ArrayRef<BlockArgument> getRegionOutArgs() {
@@ -255,16 +273,75 @@ def Plan_InlineClosedGroupOp : Plan_GroupOpBase<"inline_closed_group", [
         ArrayRef<Attribute>(boundsAttrs.begin(), boundsAttrs.end())
       ));
     }
+  }];
+}
 
-    /// Populate the `input_attrs` from an array of BoundsAttrs.
-    void setInputAttrsAttr(ArrayRef<BoundsAttr> boundsAttrs) {
-      setInputAttrsAttr(::mlir::ArrayAttr::get(
-        getOperation()->getContext(),
-        ArrayRef<Attribute>(boundsAttrs.begin(), boundsAttrs.end())
-      ));
-    }
+//===----------------------------------------------------------------------===//
+// InlineClosedGroupNonDPSOp
+//===----------------------------------------------------------------------===//
+
+def Plan_InlineClosedGroupNonDPSOp : Plan_InlineClosedGroupBase<"inline_closed_group_non_dps", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"plan::YieldOp">,
+  DeclareOpInterfaceMethods<RegionBranchOpInterface,
+    ["getEntrySuccessorOperands"]>,
+  DeclareOpInterfaceMethods<OpAsmOpInterface,
+    ["getAsmBlockArgumentNames"]>
+]> {
+  let description = [{
+  The `plan.inline_closed_group_non_dps` operation is a variant of the
+  `plan.inline_closed_group` operation that does not use destination-passing style
+  (DPS). It is isolated from above and explicitly captures input operands,
+  but unlike its DPS counterpart, it does not capture destination operands.
+  This operation takes input operands and their corresponding bounds attributes, 
+  and produces results. The `input_attrs` hold bounds attribute information for 
+  the input operands. The absence of bounds information is allowed (`none` bounds).
+
+  The `target` attribute specifies the execution target for the group.    
+
+  #### Example
+
+  Consider the following simple program containing operations with dynamically shaped operands:
+
+  ```mlir
+  %0 = ... : tensor<?xf32> // A dynamically shaped operand
+  %1 = ... : index         // A dynamic calculation of %0's extent
+
+  %2 = plan.inline_closed_group_non_dps target(#plan.cluster_target<tensorrt>)
+    inputs(%0, %1 : tensor<?xf32>, index)
+    in_attrs [#plan.bounds<shape, , >, #plan.bounds<none>] -> tensor<?xf32> {
+    %3 = plan.with_shape %0 (%1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %4 = stablehlo.exponential %3 : tensor<?xf32>
+    yield %4 : tensor<?xf32>
+  }
 
   }];
+  let arguments = (ins Variadic<AnyTypeOf<[AnyRankedTensor, AnySignlessIntegerOrIndex]>>:$inputs,
+                       BoundsAttrArray:$input_attrs,
+                       AnyAttr:$target);
+
+  let results = (outs Variadic<AnyTypeOf<[AnyRankedTensor]>>:$results);
+
+  let assemblyFormat = [{
+    `target` `(` $target `)` `\n`
+    `inputs` `(` ( $inputs^ `:` type($inputs) `)` ) : ( `)` ) ?  `\n`
+    `in_attrs` $input_attrs `\n`
+     attr-dict-with-keyword `->` type($results)
+     $body
+  }];
+
+  let hasVerifier = 1;
+
+  let skipDefaultBuilders = 1;
+
+  let builders = [
+    OpBuilder<(ins "TypeRange":$results, 
+                   "Attribute":$target,
+                   "ValueRange":$inputs,
+                   CArg<"ArrayRef<BoundsAttr>", "{}">:$input_attrs)>,
+  ];
+
+  let extraClassDeclaration = baseInlineClosedExtraClassDeclaration;
 }
 
 //===----------------------------------------------------------------------===//
@@ -276,7 +353,7 @@ def Plan_YieldOp : Plan_Op<"yield", [
       Terminator,
       ReturnLike,
       ParentOneOf<["plan::InlineGroupOp",
-                   "plan::InlineClosedGroupOp"]>]> {
+                   "plan::InlineClosedGroupOp", "plan::InlineClosedGroupNonDPSOp"]>]> {
 
   let arguments = (ins Variadic<AnyType>:$results);
 

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.h
@@ -69,7 +69,8 @@ executorOneShotModuleBufferize(ModuleOp targetOp,
                                const ExecutorBufferizationOptions &options);
 
 /// Build a pipeline (targeting ModuleOp) for bufferization.
-void buildPlanBufferizationPipeline(OpPassManager &pm);
+void buildPlanBufferizationPipeline(
+    OpPassManager &pm, const plan::PlanAllocTensorsPassOptions &options);
 
 /// Build a post-bufferization pipeline that performs optimizations on memrefs.
 void buildPlanBufferOptimizationPipeline(OpPassManager &pm);

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
@@ -248,6 +248,9 @@ def StablehloClusteringPass : Pass<"stablehlo-clustering", "::mlir::ModuleOp"> {
     Option<"entrypoint", "entrypoint", "std::string", "\"\"",
       "the name of the entrypoint function; if empty then the clustering runs"
       " on all functions">,
+    Option<"useNonDPSCallConv",
+      "use-non-dps-call-conv", "bool", "false",
+      "allow tensorrt based output allocations using output allocator">,      
     Option<"disallowHostTensorsInTensorRTClusters",
       "disallow-host-tensors-in-tensorrt-clusters", "bool", "false",
       "don't cluster host tensors in TensorRT clusters">,
@@ -332,7 +335,10 @@ def CreateClosedRegionsPass : Pass<"plan-create-closed-regions", "::mlir::Module
     Option<"testPreWalkOrder", "test-pre-walk-order", "bool", "false",
       "(used only in testing) specifies to outline regions by walking in "
       " pre-order; used for verifying results are not sensitive "
-      "to traversal order">
+      "to traversal order">,
+    Option<"useNonDPSCallConv", "use-non-dps-call-conv", "bool", 
+           /*default=*/"false", 
+           "Allow TensorRT-based output allocations using output allocator">
   ];
 
   let dependentDialects = [
@@ -428,6 +434,13 @@ def PlanAllocTensorsPass : Pass<"plan-alloc-tensors",
     "::mlir::bufferization::BufferizationDialect",
     "::mlir::plan::PlanDialect"
   ];
+
+  let options = [
+    Option<"useNonDPSCallConv", "use-non-dps-call-conv", "bool", 
+           /*default=*/"false", 
+           "Allow TensorRT-based output allocations using output allocator">
+  ];
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
@@ -248,9 +248,9 @@ def StablehloClusteringPass : Pass<"stablehlo-clustering", "::mlir::ModuleOp"> {
     Option<"entrypoint", "entrypoint", "std::string", "\"\"",
       "the name of the entrypoint function; if empty then the clustering runs"
       " on all functions">,
-    Option<"useNonDPSCallConv",
-      "use-non-dps-call-conv", "bool", "false",
-      "allow tensorrt based output allocations using output allocator">,      
+    Option<"enableNonDPSReturns",
+      "enable-non-dps-returns", "bool", "false",
+      "allow backend clusters to directly allocate outputs">,      
     Option<"disallowHostTensorsInTensorRTClusters",
       "disallow-host-tensors-in-tensorrt-clusters", "bool", "false",
       "don't cluster host tensors in TensorRT clusters">,
@@ -336,9 +336,9 @@ def CreateClosedRegionsPass : Pass<"plan-create-closed-regions", "::mlir::Module
       "(used only in testing) specifies to outline regions by walking in "
       " pre-order; used for verifying results are not sensitive "
       "to traversal order">,
-    Option<"useNonDPSCallConv", "use-non-dps-call-conv", "bool", 
+    Option<"enableNonDPSReturns", "enable-non-dps-returns", "bool", 
            /*default=*/"false", 
-           "Allow TensorRT-based output allocations using output allocator">
+           "Allow backend clusters to directly allocate outputs">
   ];
 
   let dependentDialects = [
@@ -436,9 +436,9 @@ def PlanAllocTensorsPass : Pass<"plan-alloc-tensors",
   ];
 
   let options = [
-    Option<"useNonDPSCallConv", "use-non-dps-call-conv", "bool", 
+    Option<"enableNonDPSReturns", "enable-non-dps-returns", "bool", 
            /*default=*/"false", 
-           "Allow TensorRT-based output allocations using output allocator">
+           "Allow backend clusters to directly allocate outputs">
   ];
 
 }

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/IR/PlanOps.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/IR/PlanOps.cpp
@@ -295,7 +295,7 @@ void InlineGroupOp::getSuccessorRegions(
 }
 
 //===----------------------------------------------------------------------===//
-// InlineClosedGroupOp
+// InlineClosedGroupOp and InlineClosedGroupNonDPSOp Helpers
 //===----------------------------------------------------------------------===//
 
 static LogicalResult
@@ -371,36 +371,38 @@ verifyBoundsAttr(StringRef argOrResult, unsigned idx, Type type,
   return success();
 }
 
+static LogicalResult verifyBoundsAttrs(Operation *op, ValueRange operands,
+                                       ArrayAttr attrsArray, StringRef attrName,
+                                       StringRef boundName) {
+  SmallVector<BoundsAttr> attrs =
+      llvm::to_vector(attrsArray.getAsRange<BoundsAttr>());
+  if (attrs.size() != operands.size())
+    return op->emitOpError("expected number of ")
+           << attrName << " (" << operands.size() << ") to equal the number of "
+           << boundName << " BoundsAttrs (" << attrs.size() << ")";
+
+  for (auto [idx, type] : llvm::enumerate(TypeRange(operands))) {
+    BoundsAttr boundsAttr = attrs[idx];
+    if (failed(verifyBoundsAttr(attrName, idx, type, boundsAttr,
+                                [&]() { return op->emitOpError(); })))
+      return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// InlineClosedGroupOp
+//===----------------------------------------------------------------------===//
+
 LogicalResult InlineClosedGroupOp::verify() {
-  SmallVector<BoundsAttr> inputAttrs =
-      llvm::to_vector(getInputAttrs().getAsRange<BoundsAttr>());
-  if (inputAttrs.size() != getInputs().size())
-    return emitOpError("expected number of inputs (")
-           << getInputs().size()
-           << " to equal the number of input_attrs BoundsAttrs ("
-           << inputAttrs.size() << ")";
+  if (failed(verifyBoundsAttrs(getOperation(), getInputs(), getInputAttrs(),
+                               "inputs", "input_attrs")))
+    return failure();
 
-  for (auto [idx, type] : llvm::enumerate(TypeRange(getInputs()))) {
-    BoundsAttr boundsAttr = inputAttrs[idx];
-    if (failed(verifyBoundsAttr("input argument", idx, type, boundsAttr,
-                                [&]() { return emitOpError(); })))
-      return failure();
-  }
-
-  SmallVector<BoundsAttr> resAttrs =
-      llvm::to_vector(getResAttrs().getAsRange<BoundsAttr>());
-  if (resAttrs.size() != getNumResults())
-    return emitOpError("expected number of results (")
-           << getNumResults()
-           << ") to equal the number of res_attrs BoundsAttrs ("
-           << resAttrs.size() << ")";
-
-  for (auto [idx, type] : llvm::enumerate(getResultTypes())) {
-    BoundsAttr boundsAttr = resAttrs[idx];
-    if (failed(verifyBoundsAttr("result", idx, type, boundsAttr,
-                                [&]() { return emitOpError(); })))
-      return failure();
-  }
+  if (failed(verifyBoundsAttrs(getOperation(), getResults(), getResAttrs(),
+                               "results", "result_attrs")))
+    return failure();
 
   return success();
 }
@@ -463,6 +465,63 @@ void InlineClosedGroupOp::build(OpBuilder &b, OperationState &state,
   body->addArguments(TypeRange(inputs), getLocs(inputs));
   body->addArguments(TypeRange(outs), getLocs(outs));
   state.addTypes(TypeRange(outs));
+}
+
+//===----------------------------------------------------------------------===//
+// InlineClosedGroupNonDPSOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult InlineClosedGroupNonDPSOp::verify() {
+  return verifyBoundsAttrs(getOperation(), getInputs(), getInputAttrs(),
+                           "inputs", "input_attrs");
+}
+
+void InlineClosedGroupNonDPSOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  // If the predecessor is the InlineClosedGroupOp, branch into the body.
+  if (point.isParent()) {
+    regions.push_back(RegionSuccessor(&getBody(), getBody().getArguments()));
+    return;
+  }
+  // Otherwise, the region branches back to the parent operation.
+  regions.push_back(RegionSuccessor(getResults()));
+}
+
+OperandRange
+InlineClosedGroupNonDPSOp::getEntrySuccessorOperands(RegionBranchPoint point) {
+  return getOperands();
+}
+
+void InlineClosedGroupNonDPSOp::getAsmBlockArgumentNames(
+    Region &region, OpAsmSetValueNameFn setNameFn) {
+  assert(region.front().getNumArguments() == getInputs().size() &&
+         "expected one block arg for each input argument");
+  unsigned numInputs = getInputs().size();
+  for (BlockArgument arg : region.front().getArguments()) {
+    assert(arg.getArgNumber() < numInputs);
+    setNameFn(arg, "in");
+  }
+}
+
+void InlineClosedGroupNonDPSOp::build(OpBuilder &b, OperationState &state,
+                                      TypeRange resultTypes, Attribute target,
+                                      ValueRange inputs,
+                                      ArrayRef<BoundsAttr> input_attrs) {
+  state.addTypes(resultTypes);
+  state.addOperands(inputs);
+  state.getOrAddProperties<Properties>().target = target;
+  state.getOrAddProperties<Properties>().setInputAttrs(b.getArrayAttr(
+      SmallVector<Attribute>(input_attrs.begin(), input_attrs.end())));
+  Region *body = state.addRegion();
+  auto getLocs = [](ValueRange r) {
+    SmallVector<Location> locs;
+    locs.reserve(r.size());
+    for (Value v : r)
+      locs.push_back(v.getLoc());
+    return locs;
+  };
+  (void)body->emplaceBlock();
+  body->addArguments(TypeRange(inputs), getLocs(inputs));
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/AllocTensors.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/AllocTensors.cpp
@@ -857,7 +857,7 @@ public:
     }
 
     IRRewriter rewriter(ctx);
-    if (!useNonDPSCallConv) {
+    if (!enableNonDPSReturns) {
       // First rewrite public functions to conform to DPS style.
       if (failed(rewriteNotPrivateFuncsToDPS(rewriter, op))) {
         op->emitError("Failed to convert non-private functions to DPS");

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/AllocTensors.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/AllocTensors.cpp
@@ -856,11 +856,13 @@ public:
       }
     }
 
-    // First rewrite public functions to conform to DPS style.
     IRRewriter rewriter(ctx);
-    if (failed(rewriteNotPrivateFuncsToDPS(rewriter, op))) {
-      op->emitError("Failed to convert non-private functions to DPS");
-      return signalPassFailure();
+    if (!useNonDPSCallConv) {
+      // First rewrite public functions to conform to DPS style.
+      if (failed(rewriteNotPrivateFuncsToDPS(rewriter, op))) {
+        op->emitError("Failed to convert non-private functions to DPS");
+        return signalPassFailure();
+      }
     }
 
     // Rewrite SCF for and while loop bodies for better bufferization results,

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CreateClosedRegions.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CreateClosedRegions.cpp
@@ -353,8 +353,7 @@ static void remapAnalysisState(DataFlowSolver &solver, ValueRange originals,
 
 static FailureOr<SmallVector<BoundsAttr>>
 getInputAttributes(RewriterBase &rewriter, DataFlowSolver &solver, Location loc,
-                   SmallVector<Value> const &inputs) {
-
+                   const ValueRange &inputs) {
   // Compute input tensor kinds.
   SmallVector<TensorKindInfo> inputTensorKinds;
   inputTensorKinds.reserve(inputs.size());
@@ -367,7 +366,7 @@ getInputAttributes(RewriterBase &rewriter, DataFlowSolver &solver, Location loc,
         solver.lookupState<TensorKindLattice>(input);
     if (!tensorKindLattice || tensorKindLattice->getValue().isUninitialized())
       return emitError(loc)
-             << ("input operand #") << idx << " of type " << input.getType()
+             << "input operand #" << idx << " of type " << input.getType()
              << " does not have a TensorKind associated with it";
     inputTensorKinds.push_back(tensorKindLattice->getValue());
   }
@@ -436,28 +435,27 @@ getInputAttributes(RewriterBase &rewriter, DataFlowSolver &solver, Location loc,
 
 static LogicalResult materializeDestinationOperands(
     RewriterBase &rewriter, plan::InlineGroupOp op, DataFlowSolver &solver,
-    SmallVector<DestinationOperandMaterializationResult> &destinationOperands) {
+    SmallVectorImpl<DestinationOperandMaterializationResult>
+        &destinationOperands) {
   destinationOperands.reserve(op.getNumResults());
   for (OpResult res : op->getOpResults()) {
     FailureOr<DestinationOperandMaterializationResult> destResult =
         materializeDestinationOperand(rewriter, res.getLoc(), op,
                                       res.getResultNumber(), solver);
-    if (failed(destResult)) {
+    if (failed(destResult))
       return emitError(res.getLoc())
              << "failed to materialize destination operand of type "
              << res.getType();
-    }
     destinationOperands.push_back(*destResult);
   }
   return success();
 }
 
 // Helper function to create DPS closed group op.
-static LogicalResult createDPSClosedGroupOp(
+static LogicalResult createInlineClosedGroupOp(
     RewriterBase &rewriter, plan::InlineGroupOp op, DataFlowSolver &solver,
-    const SmallVector<Value> &inputs,
-    const SmallVector<DestinationOperandMaterializationResult>
-        &destinationOperands) {
+    const ValueRange &inputs,
+    ArrayRef<DestinationOperandMaterializationResult> destinationOperands) {
   InlineClosedGroupOp closedGroupOp = rewriter.create<InlineClosedGroupOp>(
       op.getLoc(), /*target=*/op.getTarget(),
       /*inputs=*/inputs,
@@ -474,8 +472,8 @@ static LogicalResult createDPSClosedGroupOp(
   SmallVector<Value> replacements;
   replacements.reserve(destinationOperands.size());
   for (auto [newResult, destOperand, originalType] :
-       llvm::zip(closedGroupOp->getResults(), destinationOperands,
-                 op->getResultTypes())) {
+       llvm::zip_equal(closedGroupOp->getResults(), destinationOperands,
+                       op->getResultTypes())) {
     if (destOperand.strategy ==
         DestinationOperandMaterializationStrategy::ExactShape) {
       replacements.push_back(newResult);
@@ -500,8 +498,9 @@ static LogicalResult createDPSClosedGroupOp(
   for (const DestinationOperandMaterializationResult &dest :
        destinationOperands) {
     auto boundsAttr = BoundsAttr::getChecked(
-        mlir::detail::getDefaultDiagnosticEmitFn(op->getLoc()), rewriter.getContext(),
-        BoundsKind::Shape, ArrayRef(dest.constantShapeLowerBound),
+        mlir::detail::getDefaultDiagnosticEmitFn(op->getLoc()),
+        rewriter.getContext(), BoundsKind::Shape,
+        ArrayRef(dest.constantShapeLowerBound),
         ArrayRef(dest.constantShapeUpperBound));
     if (!boundsAttr)
       return failure();
@@ -510,8 +509,9 @@ static LogicalResult createDPSClosedGroupOp(
   closedGroupOp.setResAttrsAttr(resultAttrs);
 
   // Create the closed region input profilw attrs.
-  auto inputAttr = getInputAttributes(rewriter, solver, closedGroupOp->getLoc(),
-                                      closedGroupOp.getInputs());
+  FailureOr<SmallVector<BoundsAttr>> inputAttr = getInputAttributes(
+      rewriter, solver, closedGroupOp->getLoc(), closedGroupOp.getInputs());
+
   if (failed(inputAttr))
     return emitError(closedGroupOp.getLoc())
            << "failed to compute input attribute ";
@@ -523,12 +523,12 @@ static LogicalResult createDPSClosedGroupOp(
 
 // Helper function to create non-DPS closed group op.
 static LogicalResult
-createNonDPSClosedGroupOp(RewriterBase &rewriter, plan::InlineGroupOp op,
-                          DataFlowSolver &solver,
-                          const SmallVector<Value> &inputs) {
+createInlineClosedAllocGroupOp(RewriterBase &rewriter, plan::InlineGroupOp op,
+                               DataFlowSolver &solver,
+                               const SmallVector<Value> &inputs) {
   // Create a new closed group op and move blocks into it.
-  InlineClosedGroupNonDPSOp closedGroupOp =
-      rewriter.create<InlineClosedGroupNonDPSOp>(
+  InlineClosedAllocGroupOp closedGroupOp =
+      rewriter.create<InlineClosedAllocGroupOp>(
           op.getLoc(), /*result type*/ op->getResultTypes(),
           /*target=*/op.getTarget(),
           /*inputs=*/inputs);
@@ -539,11 +539,16 @@ createNonDPSClosedGroupOp(RewriterBase &rewriter, plan::InlineGroupOp op,
       closedGroupOp.getRegion().getArguments().take_front(
           op.getRegion().getNumArguments()));
 
+  // Since we are about to replace values that may be inputs to other regions
+  // ops, we need to update the solver to populate the replacement TensorKind
+  // information.
+  remapAnalysisState(solver, op->getResults(), closedGroupOp->getResults());
   rewriter.replaceOp(op, closedGroupOp->getResults());
 
   // Create the closed region input profilw attrs.
-  auto inputAttr = getInputAttributes(rewriter, solver, closedGroupOp->getLoc(),
-                                      closedGroupOp.getInputs());
+  FailureOr<SmallVector<BoundsAttr>> inputAttr = getInputAttributes(
+      rewriter, solver, closedGroupOp->getLoc(), closedGroupOp.getInputs());
+
   if (failed(inputAttr))
     return emitError(closedGroupOp.getLoc())
            << "failed to compute input attribute ";
@@ -556,12 +561,12 @@ createNonDPSClosedGroupOp(RewriterBase &rewriter, plan::InlineGroupOp op,
 static LogicalResult createClosedGroupOp(RewriterBase &rewriter,
                                          plan::InlineGroupOp op,
                                          DataFlowSolver &solver,
-                                         bool useNonDPSCallConv) {
+                                         bool enableNonDPSReturns) {
   OpBuilder::InsertionGuard g(rewriter);
 
   // Materialize destination operands if not using non-DPS call convention.
   SmallVector<DestinationOperandMaterializationResult> destinationOperands;
-  if (!useNonDPSCallConv)
+  if (!enableNonDPSReturns)
     if (failed(materializeDestinationOperands(rewriter, op, solver,
                                               destinationOperands)))
       return failure();
@@ -576,10 +581,10 @@ static LogicalResult createClosedGroupOp(RewriterBase &rewriter,
 
   // Create and populate the appropriate closed group op based on call
   // convention.
-  if (!useNonDPSCallConv)
-    return createDPSClosedGroupOp(rewriter, op, solver, inputs,
-                                  destinationOperands);
-  return createNonDPSClosedGroupOp(rewriter, op, solver, inputs);
+  if (!enableNonDPSReturns)
+    return createInlineClosedGroupOp(rewriter, op, solver, inputs,
+                                     destinationOperands);
+  return createInlineClosedAllocGroupOp(rewriter, op, solver, inputs);
 }
 
 namespace {
@@ -624,7 +629,7 @@ public:
     IRRewriter rewriter(ctx);
     for (InlineGroupOp groupOp : groupOps) {
       if (failed(createClosedGroupOp(rewriter, groupOp, solver,
-                                     useNonDPSCallConv)))
+                                     enableNonDPSReturns)))
         return signalPassFailure();
     }
   }

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
@@ -284,7 +284,7 @@ public:
     for (func::FuncOp func : funcs) {
       if (failed(applyClusteringToFunc(
               rewriter, func, solver, schedule,
-              StablehloClusteringPassOptions{entrypoint, useNonDPSCallConv,
+              StablehloClusteringPassOptions{entrypoint, enableNonDPSReturns,
                                              false, false, trtMajorVersion})))
         return signalPassFailure();
     }

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
@@ -284,8 +284,8 @@ public:
     for (func::FuncOp func : funcs) {
       if (failed(applyClusteringToFunc(
               rewriter, func, solver, schedule,
-              StablehloClusteringPassOptions{entrypoint, false, false,
-                                             trtMajorVersion})))
+              StablehloClusteringPassOptions{entrypoint, useNonDPSCallConv,
+                                             false, false, trtMajorVersion})))
         return signalPassFailure();
     }
 

--- a/mlir-tensorrt/test/Dialect/Plan/invalid.mlir
+++ b/mlir-tensorrt/test/Dialect/Plan/invalid.mlir
@@ -63,6 +63,20 @@ func.func @inline_closed_group_wrong_num_block_args(%arg0: tensor<?xf32>, %arg1:
   return %2 : tensor<?xf32>
 }
 
+// -----
+
+func.func @inline_closed_alloc_group_wrong_num_block_args(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op  region control flow edge from parent operands to Region #0: source has 2 operands, but target successor needs 3}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<?xf32>, index)
+    in_attrs [#plan.bounds<shape, [10], [20]>, #plan.bounds<none>] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>, %in1: index, %out0: tensor<?xf32>):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %res = stablehlo.exponential %2 : tensor<?xf32>
+    yield %res : tensor<?xf32>
+  }
+  return %2 : tensor<?xf32>
+}
 
 // -----
 
@@ -74,6 +88,21 @@ func.func @inline_closed_group_wrong_size_bounds_attrs(%arg0: tensor<?xf32>, %ar
     in_attrs []
     res_attrs [#plan.bounds<shape, [10], [20]>] -> tensor<?xf32> {
   ^bb0(%in0: tensor<?xf32>, %in1: index, %out0: tensor<?xf32>):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %res = stablehlo.exponential %2 : tensor<?xf32>
+    yield %res : tensor<?xf32>
+  }
+  return %2 : tensor<?xf32>
+}
+
+// -----
+
+func.func @inline_closed_alloc_group_wrong_size_bounds_attrs(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op expected number of inputs (2) to equal the number of input_attrs BoundsAttrs (0)}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<?xf32>, index)
+    in_attrs [] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>, %in1: index):
     %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
     %res = stablehlo.exponential %2 : tensor<?xf32>
     yield %res : tensor<?xf32>
@@ -100,6 +129,21 @@ func.func @inline_closed_group_wrong_scalar_bounds_type(%arg0: tensor<?xf32>, %a
 
 // -----
 
+func.func @inline_closed_group_alloc_wrong_scalar_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op expected only value bounds or none bounds for scalar inputs #0 of type 'index', but got #plan.bounds<shape, [10], [20]>}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg1, %arg0 : index, tensor<?xf32>)
+    in_attrs [#plan.bounds<shape, [10], [20]>, #plan.bounds<none>] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>, %in1: index):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %res = stablehlo.exponential %2 : tensor<?xf32>
+    yield %res : tensor<?xf32>
+  }
+  return %2 : tensor<?xf32>
+}
+
+// -----
+
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
   // expected-error @below {{'plan.inline_closed_group' op inputs #0 has type 'tensor<?xf32>', whose rank is not equal to the rank of the corresponding shape bounds #plan.bounds<shape, [10, 10], [20, 20]>}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
@@ -108,6 +152,20 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: in
     in_attrs [#plan.bounds<shape, [10, 10], [20, 20]>, #plan.bounds<none>]
     res_attrs [#plan.bounds<shape, [10], [20]>] -> tensor<?xf32> {
   ^bb0(%in0: tensor<?xf32>, %in1: index, %out0: tensor<?xf32>):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %res = stablehlo.exponential %2 : tensor<?xf32>
+    yield %res : tensor<?xf32>
+  }
+  return %2 : tensor<?xf32>
+}
+// -----
+
+func.func @inline_closed_alloc_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op inputs #0 has type 'tensor<?xf32>', whose rank is not equal to the rank of the corresponding shape bounds #plan.bounds<shape, [10, 10], [20, 20]>}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<?xf32>, index)
+    in_attrs [#plan.bounds<shape, [10, 10], [20, 20]>, #plan.bounds<none>] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>, %in1: index):
     %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
     %res = stablehlo.exponential %2 : tensor<?xf32>
     yield %res : tensor<?xf32>
@@ -135,6 +193,22 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: in
 
 // -----
 
+func.func @inline_closed_alloc_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op inputs #0 has type 'tensor<?xf32>', but has a corresponding bounds attribute of 'value' kind, which is only allowed for staticly shaped operands}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<?xf32>, index)
+    in_attrs [#plan.bounds<value, dense<[10]> : tensor<1xi64>, dense<[10]> : tensor<1xi64>>,
+              #plan.bounds<none>] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>, %in1: index):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<?xf32>, index) -> tensor<?xf32>
+    %res = stablehlo.exponential %2 : tensor<?xf32>
+    yield %res : tensor<?xf32>
+  }
+  return %2 : tensor<?xf32>
+}
+
+// -----
+
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: index, %arg2: tensor<1xf32>) -> tensor<1xf32> {
   // expected-error @below {{'plan.inline_closed_group' op inputs #0 expected element type of value bounds elements ('i64') to be compatible with the type ('tensor<1xf32>')}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
@@ -144,6 +218,23 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: in
               #plan.bounds<none>]
     res_attrs [#plan.bounds<shape, [10], [20]>] -> tensor<1xf32> {
   ^bb0(%in0: tensor<1xf32>, %in1: index, %out0: tensor<1xf32>):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<1xf32>, index) -> tensor<1xf32>
+    %res = stablehlo.exponential %2 : tensor<1xf32>
+    yield %res : tensor<1xf32>
+  }
+  return %2 : tensor<1xf32>
+}
+
+
+// -----
+
+func.func @inline_closed_alloc_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: index, %arg2: tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op inputs #0 expected element type of value bounds elements ('i64') to be compatible with the type ('tensor<1xf32>')}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<1xf32>, index)
+    in_attrs [#plan.bounds<value, dense<[10]> : tensor<1xi64>, dense<[10]> : tensor<1xi64>>,
+              #plan.bounds<none>] -> tensor<1xf32> {
+  ^bb0(%in0: tensor<1xf32>, %in1: index):
     %2 = plan.with_shape %in0 (%in1) : (tensor<1xf32>, index) -> tensor<1xf32>
     %res = stablehlo.exponential %2 : tensor<1xf32>
     yield %res : tensor<1xf32>
@@ -167,6 +258,48 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: in
     yield %res : tensor<1xf32>
   }
   return %2 : tensor<1xf32>
+}
+
+// -----
+
+func.func @inline_closed_alloc_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: index, %arg2: tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'plan.inline_closed_alloc_group' op inputs #0 expected type of values bounds elements ('tensor<2xf32>') to be compatible with the type ('tensor<1xf32>')}}
+  %2 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0, %arg1 : tensor<1xf32>, index)
+    in_attrs [#plan.bounds<value, dense<[10., 20.]> : tensor<2xf32>, dense<[20., 30.]> : tensor<2xf32>>,
+              #plan.bounds<none>] -> tensor<1xf32> {
+  ^bb0(%in0: tensor<1xf32>, %in1: index):
+    %2 = plan.with_shape %in0 (%in1) : (tensor<1xf32>, index) -> tensor<1xf32>
+    %res = stablehlo.exponential %2 : tensor<1xf32>
+    yield %res : tensor<1xf32>
+  }
+  return %2 : tensor<1xf32>
+}
+
+// -----
+
+func.func @inline_closed_alloc_group_missing_input_attr(%arg0: tensor<1xf32>) -> tensor<1xf32> {
+  %1 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+  // expected-error @below {{'plan.inline_closed_alloc_group' expected 'in_attrs'}}
+    inputs(%arg0: tensor<1xf32>) -> tensor<1xf32> {
+  ^bb0(%in0: tensor<1xf32>):
+    yield %in0 : tensor<1xf32>
+  }
+  return %1 : tensor<1xf32>
+}
+
+// -----
+
+func.func @inline_closed_alloc_group_unallowed_res_attr(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  %1 = plan.inline_closed_alloc_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
+    inputs(%arg0: tensor<?xf32>)
+  // expected-error @below {{expected '->'}}
+    in_attrs [#plan.bounds<shape, [10], [20]>, #plan.bounds<none>]
+    res_attrs [#plan.bounds<shape, [10], [20]>, #plan.bounds<none>] -> tensor<?xf32> {
+  ^bb0(%in0: tensor<?xf32>):
+    yield %in0 : tensor<?xf32>
+  }
+  return %1 : tensor<?xf32>
 }
 
 // -----

--- a/mlir-tensorrt/test/Dialect/Plan/invalid.mlir
+++ b/mlir-tensorrt/test/Dialect/Plan/invalid.mlir
@@ -67,7 +67,7 @@ func.func @inline_closed_group_wrong_num_block_args(%arg0: tensor<?xf32>, %arg1:
 // -----
 
 func.func @inline_closed_group_wrong_size_bounds_attrs(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op expected number of inputs (2 to equal the number of input_attrs BoundsAttrs (0)}}
+  // expected-error @below {{'plan.inline_closed_group' op expected number of inputs (2) to equal the number of input_attrs BoundsAttrs (0)}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg0, %arg1 : tensor<?xf32>, index)
     outs(%arg2 : tensor<?xf32>)
@@ -84,7 +84,7 @@ func.func @inline_closed_group_wrong_size_bounds_attrs(%arg0: tensor<?xf32>, %ar
 // -----
 
 func.func @inline_closed_group_wrong_scalar_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op expected only value bounds or none bounds for scalar input argument #0 of type 'index', but got #plan.bounds<shape, [10], [20]>}}
+  // expected-error @below {{'plan.inline_closed_group' op expected only value bounds or none bounds for scalar inputs #0 of type 'index', but got #plan.bounds<shape, [10], [20]>}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg1, %arg0 : index, tensor<?xf32>)
     outs(%arg2 : tensor<?xf32>)
@@ -101,7 +101,7 @@ func.func @inline_closed_group_wrong_scalar_bounds_type(%arg0: tensor<?xf32>, %a
 // -----
 
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op input argument #0 has type 'tensor<?xf32>', whose rank is not equal to the rank of the corresponding shape bounds #plan.bounds<shape, [10, 10], [20, 20]>}}
+  // expected-error @below {{'plan.inline_closed_group' op inputs #0 has type 'tensor<?xf32>', whose rank is not equal to the rank of the corresponding shape bounds #plan.bounds<shape, [10, 10], [20, 20]>}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg0, %arg1 : tensor<?xf32>, index)
     outs(%arg2 : tensor<?xf32>)
@@ -118,7 +118,7 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: in
 // -----
 
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: index, %arg2: tensor<?xf32>) -> tensor<?xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op input argument #0 has type 'tensor<?xf32>', but has a corresponding bounds attribute of 'value' kind, which is only allowed for staticly shaped operands}}
+  // expected-error @below {{'plan.inline_closed_group' op inputs #0 has type 'tensor<?xf32>', but has a corresponding bounds attribute of 'value' kind, which is only allowed for staticly shaped operands}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg0, %arg1 : tensor<?xf32>, index)
     outs(%arg2 : tensor<?xf32>)
@@ -136,7 +136,7 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<?xf32>, %arg1: in
 // -----
 
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: index, %arg2: tensor<1xf32>) -> tensor<1xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op input argument #0 expected element type of value bounds elements ('i64') to be compatible with the type ('tensor<1xf32>')}}
+  // expected-error @below {{'plan.inline_closed_group' op inputs #0 expected element type of value bounds elements ('i64') to be compatible with the type ('tensor<1xf32>')}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg0, %arg1 : tensor<1xf32>, index)
     outs(%arg2 : tensor<1xf32>)
@@ -154,7 +154,7 @@ func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: in
 // -----
 
 func.func @inline_closed_group_wrong_bounds_type(%arg0: tensor<1xf32>, %arg1: index, %arg2: tensor<1xf32>) -> tensor<1xf32> {
-  // expected-error @below {{'plan.inline_closed_group' op input argument #0 expected type of values bounds elements ('tensor<2xf32>') to be compatible with the type ('tensor<1xf32>')}}
+  // expected-error @below {{'plan.inline_closed_group' op inputs #0 expected type of values bounds elements ('tensor<2xf32>') to be compatible with the type ('tensor<1xf32>')}}
   %2 = plan.inline_closed_group target(#plan.tensorrt_cluster<benefit=1, disallow_shape_tensor_calculations=false>)
     inputs(%arg0, %arg1 : tensor<1xf32>, index)
     outs(%arg2 : tensor<1xf32>)


### PR DESCRIPTION
The Plan dialect has been enhanced to support non-DPS calling conventions, with updates to PlanAllocTensorsPass and CreateClosedRegionsPass. Additionally, the Plan transformation now converts both non-DPS and DPS group operations to CallAllocOp and CallOp respectively, required for subsequent transformations.