### PR TITLE
[Dialect/TensorRTRuntime] Update tensorrt runtime dialect to use non-dps calling convention

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/TensorRTRuntime/IR/TensorRTRuntimeOps.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/TensorRTRuntime/IR/TensorRTRuntimeOps.td
@@ -105,9 +105,54 @@ def TensorRTRuntime_EnqueueOp : TensorRTRuntime_Op<"enqueue", [
     // Declare the outs as inits/outs to DestinationStyleOpInterface.
     MutableOperandRange getDpsInitsMutable() { return getOutsMutable(); }
 
-    /// Return true if the operand at the specified index is a host tensor
-    /// argument.
-    bool isOperandOnHost(int64_t operandIdx) {
+    /// Return true if the operand is a host tensor argument.
+    bool isOperandOnHost(OpOperand *operand) {
+      unsigned operandIdx = operand->getOperandNumber();
+      if(std::optional<ArrayRef<int64_t>> indices = getHostTensorArgs()) {
+        return llvm::is_contained(*indices, operandIdx - 2);
+      }
+      return false;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// EnqueueAllocOp
+//===----------------------------------------------------------------------===//
+
+def TensorRTRuntime_EnqueueAllocOp : TensorRTRuntime_Op<"enqueue_alloc", [
+    DeclareOpInterfaceMethods<TensorKindOpInterface>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+]> {
+  let description = [{
+    Asynchronously executes the computation represented by the
+    `execution_context` on the specified CUDA stream. This operation
+    can accept inputs of either tensor or memref types and returns
+    results of either tensor or memref types.
+  }];
+
+  let arguments = (ins 
+    TensorRTRuntime_Context:$execution_context,
+    CUDA_Stream:$stream,
+    Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$inputs,
+    OptionalAttr<DenseI64ArrayAttr>:$host_tensor_args
+  );
+
+  let results = (outs Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$results);
+
+  let assemblyFormat = [{
+    $execution_context `stream` `(` $stream `)` ` `
+    (`host_tensor_args` $host_tensor_args^ ` ` )?
+    `(` $inputs `)`
+    attr-dict `:` functional-type($inputs, $results)
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Return true if the operand is a host tensor argument.
+    bool isOperandOnHost(OpOperand *operand) {
+      unsigned operandIdx = operand->getOperandNumber();
       if(std::optional<ArrayRef<int64_t>> indices = getHostTensorArgs()) {
         return llvm::is_contained(*indices, operandIdx - 2);
       }

--- a/mlir-tensorrt/test/Conversion/TensorRTRuntimeToExecutor/tensorrt-runtime-to-executor.mlir
+++ b/mlir-tensorrt/test/Conversion/TensorRTRuntimeToExecutor/tensorrt-runtime-to-executor.mlir
@@ -52,3 +52,85 @@ func.func @main(%arg0: memref<1x3x256x256xf32>, %arg1: memref<1x3x256x256xf32>) 
 //   CHECK-DAG:     executor.call @_trtrt_enqueue(%[[v2]], %[[v4]], %[[v7]]) : (!executor.opaque<"trtrt_context">, !executor.ptr<host>, !executor.table<!executor.ptr<host>, i64, i64, i64, i64, i64, i64, !executor.ptr<host>, i64, i64, i64, i64, i64, i64>) -> ()
 //   CHECK-DAG:     cuda.stream.sync %[[v3]] : !cuda.stream
 //   CHECK-DAG:     return %[[alloc]] : memref<1x3x256x256xf32>
+
+// -----
+
+tensorrt.module @trt_funcs {
+  func.func @my_func() attributes {tensorrt.engine = dense<0> : vector<10xi8>} {
+    return
+  }
+}
+
+func.func @main(%arg0: memref<1x3x256x256xf32, #executor.memory_type<device>>) -> memref<?x?x?x?xf32, #executor.memory_type<device>> {
+  %0 = trtrt.compile @trt_funcs::@my_func : !trtrt.context
+  %1 = cuda.stream.create : !cuda.stream
+  %2 = trtrt.enqueue_alloc %0 stream(%1) (%arg0) : (memref<1x3x256x256xf32, #executor.memory_type<device>>) -> memref<?x?x?x?xf32, #executor.memory_type<device>>
+  cuda.stream.sync %1 : !cuda.stream
+  return %2 : memref<?x?x?x?xf32, #executor.memory_type<device>>
+}
+
+// CHECK-LABEL: module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 64 : i64>, #dlti.dl_entry<!executor.ptr<host>, 64 : i64>, #dlti.dl_entry<!executor.ptr<device>, 64 : i64>>} {
+// CHECK-DAG: executor.func private @_trtrt_enqueue_alloc(!executor.opaque<"trtrt_context">, !executor.ptr<host>, !executor.ptr<host>, ...)
+// CHECK-DAG: executor.func private @_trtrt_create_runtime() -> !executor.opaque<"trtrt_runtime">
+// CHECK-DAG: executor.func private @_trtrt_create_context(!executor.opaque<"trtrt_engine">) -> !executor.opaque<"trtrt_context">
+// CHECK-DAG: executor.func private @_trtrt_load(!executor.opaque<"trtrt_runtime">, !executor.ptr<host>, i64) -> !executor.opaque<"trtrt_engine">
+// CHECK-LABEL: executor.global @tensorrt_runtime : !executor.opaque<"trtrt_runtime"> {
+// CHECK: %[[v0:.*]] = executor.call @_trtrt_create_runtime() : () -> !executor.opaque<"trtrt_runtime">
+// CHECK: executor.return %[[v0]] : !executor.opaque<"trtrt_runtime">
+// CHECK: }
+// CHECK: executor.constant_resource @my_func_engine_data dense<0> : vector<10xi8>
+// CHECK-LABEL: executor.global @my_func_exec_ctx constant : !executor.opaque<"trtrt_context"> {
+// CHECK-DAG: %[[v1:.*]] = executor.load_constant_resource @my_func_engine_data : !executor.ptr<host>
+// CHECK-DAG: %[[v2:.*]] = executor.getoffset[10] : () -> i64, i8
+// CHECK-DAG: %[[v3:.*]] = executor.get_global @tensorrt_runtime : !executor.opaque<"trtrt_runtime">
+// CHECK: %[[v4:.*]] = executor.call @_trtrt_load(%[[v3]], %[[v1]], %[[v2]]) : (!executor.opaque<"trtrt_runtime">, !executor.ptr<host>, i64) -> !executor.opaque<"trtrt_engine">
+// CHECK: %[[v5:.*]] = executor.call @_trtrt_create_context(%[[v4]]) : (!executor.opaque<"trtrt_engine">) -> !executor.opaque<"trtrt_context">
+// CHECK: executor.return %[[v5]] : !executor.opaque<"trtrt_context">
+// CHECK: }
+// CHECK-LABEL: tensorrt.module @trt_funcs {
+// CHECK: func.func @my_func() attributes {tensorrt.engine = dense<0> : vector<10xi8>}
+// CHECK: }
+// CHECK-LABEL: func.func @main
+// CHECK-SAME: (%[[arg0:.*]]: memref<1x3x256x256xf32, #executor.memory_type<device>>) -> memref<?x?x?x?xf32, #executor.memory_type<device>> {
+// CHECK-DAG: %[[c256:.*]] = executor.constant 256 : i64
+// CHECK-DAG: %[[c3:.*]] = executor.constant 3 : i64
+// CHECK-DAG: %[[c4:.*]] = executor.constant 4 : i64
+// CHECK-DAG: %[[c0:.*]] = executor.constant 0 : i64
+// CHECK-DAG: %[[c1:.*]] = executor.constant 1 : i64
+// CHECK: %[[v6:.*]] = builtin.unrealized_conversion_cast %[[arg0]] : memref<1x3x256x256xf32, #executor.memory_type<device>> to !executor.table<!executor.ptr<device>, !executor.ptr<device>, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v7:.*]] = executor.get_global @my_func_exec_ctx : !executor.opaque<"trtrt_context">
+// CHECK: %[[v8:.*]] = cuda.stream.create : !cuda.stream
+// CHECK: %[[v9:.*]] = builtin.unrealized_conversion_cast %[[v8]] : !cuda.stream to !executor.ptr<host>
+// CHECK: %[[v10:.*]] = executor.alloca %[[c1]] x !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64> : (i64) -> !executor.ptr<host>
+// CHECK: %[[v11:.*]] = executor.getoffset[0, 0] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: executor.store %[[c1]] to %[[v10]] + %[[v11]] : i64, !executor.ptr<host>, i64
+// CHECK: %[[v12:.*]] = executor.getoffset[0, 1] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: executor.store %[[c4]] to %[[v10]] + %[[v12]] : i64, !executor.ptr<host>, i64
+// CHECK: %[[v13:.*]] = executor.table.get %[[v6]][1] : <!executor.ptr<device>, !executor.ptr<device>, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v14:.*]] = executor.table.create(%[[v13]], %[[c0]], %[[c4]], %[[c1]], %[[c3]], %[[c256]], %[[c256]] : !executor.ptr<device>, i64, i64, i64, i64, i64, i64) : <!executor.ptr<device>, i64, i64, i64, i64, i64, i64>
+// CHECK: executor.call @_trtrt_enqueue_alloc(%[[v7]], %[[v9]], %[[v10]], %[[v14]]) : (!executor.opaque<"trtrt_context">, !executor.ptr<host>, !executor.ptr<host>, !executor.table<!executor.ptr<device>, i64, i64, i64, i64, i64, i64>) -> ()
+// CHECK: %[[v15:.*]] = executor.getoffset[0, 2] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v16:.*]] = executor.load %[[v10]] + %[[v12]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v17:.*]] = executor.load %[[v10]] + %[[v15]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v18:.*]] = executor.inttoptr %[[v17]] : (i64) -> !executor.ptr<device>
+// CHECK: %[[v19:.*]] = executor.getoffset[0, 3] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v20:.*]] = executor.load %[[v10]] + %[[v19]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v21:.*]] = executor.getoffset[0, 4] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v22:.*]] = executor.load %[[v10]] + %[[v21]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v23:.*]] = executor.getoffset[0, 5] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v24:.*]] = executor.load %[[v10]] + %[[v23]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v25:.*]] = executor.getoffset[0, 6] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v26:.*]] = executor.load %[[v10]] + %[[v25]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v27:.*]] = executor.getoffset[0, 7] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v28:.*]] = executor.load %[[v10]] + %[[v27]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v29:.*]] = executor.getoffset[0, 8] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v30:.*]] = executor.load %[[v10]] + %[[v29]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v31:.*]] = executor.getoffset[0, 9] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v32:.*]] = executor.load %[[v10]] + %[[v31]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v33:.*]] = executor.getoffset[0, 10] : () -> i64, !executor.table<i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v34:.*]] = executor.load %[[v10]] + %[[v33]] : (!executor.ptr<host>, i64) -> i64
+// CHECK: %[[v35:.*]] = executor.table.create(%[[v18]], %[[v18]], %[[c0]], %[[v20]], %[[v22]], %[[v24]], %[[v26]], %[[v28]], %[[v30]], %[[v32]], %[[v34]] : !executor.ptr<device>, !executor.ptr<device>, i64, i64, i64, i64, i64, i64, i64, i64, i64) : <!executor.ptr<device>, !executor.ptr<device>, i64, i64, i64, i64, i64, i64, i64, i64, i64>
+// CHECK: %[[v36:.*]] = builtin.unrealized_conversion_cast %[[v35]] : !executor.table<!executor.ptr<device>, !executor.ptr<device>, i64, i64, i64, i64, i64, i64, i64, i64, i64> to memref<?x?x?x?xf32, #executor.memory_type<device>>
+// CHECK: cuda.stream.sync %[[v8]] : !cuda.stream
+// CHECK: return %[[v36]] : memref<?x?x?x?xf32, #executor.memory_type<device>>
+// CHECK: }

--- a/mlir-tensorrt/test/Dialect/TensorRTRuntime/one-shot-bufferize.mlir
+++ b/mlir-tensorrt/test/Dialect/TensorRTRuntime/one-shot-bufferize.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-tensorrt-opt %s -split-input-file -empty-tensor-to-alloc-tensor -plan-bufferize | FileCheck %s
+// RUN: mlir-tensorrt-opt %s -verify-diagnostics -split-input-file -empty-tensor-to-alloc-tensor -plan-bufferize | FileCheck %s
 
 func.func @enqueue_simple(
     %ctx: !trtrt.context, %stream: !cuda.stream,
@@ -39,3 +39,57 @@ func.func @enqueue_host_tensors_space_check(
 //       CHECK:     memref.copy %[[arg2]], %[[alloc_0]] : memref<4xi32, #plan.memory_space<device>> to memref<4xi32, #plan.memory_space<host_pinned>>
 //       CHECK:     trtrt.enqueue %[[arg0]] stream(%[[arg1]]) host_tensor_args [0, 1, 3] (%[[alloc]], %[[alloc]], %[[arg2]], %[[alloc_0]]) outs(%[[arg3]]) : (memref<4xi32, #plan.memory_space<host_pinned>>, memref<4xi32, #plan.memory_space<host_pinned>>, memref<4xi32, #plan.memory_space<device>>, memref<4xi32, #plan.memory_space<host_pinned>>) -> memref<128xf32, #plan.memory_space<device>>
 //       CHECK:     return %[[arg3]]
+
+// -----
+
+func.func @enqueue_alloc_simple(
+  %ctx: !trtrt.context, %stream: !cuda.stream,
+  %arg0: tensor<1x3x256x256xf32>) -> tensor<?x?x?x?xf32> {
+  %result = trtrt.enqueue_alloc %ctx stream(%stream) (%arg0) : (tensor<1x3x256x256xf32>) -> tensor<?x?x?x?xf32>
+  return %result : tensor<?x?x?x?xf32>
+}
+
+// CHECK-LABEL: @enqueue_alloc_simple
+//  CHECK-SAME: (%[[arg0:.+]]: !trtrt.context, %[[arg1:.+]]: !cuda.stream, %[[arg2:.+]]: memref<1x3x256x256xf32, #plan.memory_space<device>>) -> memref<?x?x?x?xf32, #plan.memory_space<device>>
+//       CHECK: %[[result:.+]] = trtrt.enqueue_alloc %[[arg0]] stream(%[[arg1]]) (%[[arg2]]) : (memref<1x3x256x256xf32, #plan.memory_space<device>>) -> memref<?x?x?x?xf32, #plan.memory_space<device>>
+//       CHECK:     return %[[result]] : memref<?x?x?x?xf32, #plan.memory_space<device>>
+
+// -----
+
+module {
+  func.func @enqueue_alloc_multiple_returns(%arg0: !trtrt.context, %arg1: !cuda.stream, %arg2: memref<1x3x256x256xf32, #plan.memory_space<device>>) -> (memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>) {
+    %0:2 = trtrt.enqueue_alloc %arg0 stream(%arg1) (%arg2) : (memref<1x3x256x256xf32, #plan.memory_space<device>>) -> (memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>)
+    return %0#0, %0#1 : memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>
+  }
+}
+
+// CHECK-LABEL: @enqueue_alloc_multiple_returns
+//  CHECK-SAME: (%[[arg0:.+]]: !trtrt.context, %[[arg1:.+]]: !cuda.stream, %[[arg2:.+]]: memref<1x3x256x256xf32, #plan.memory_space<device>>) -> (memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>
+//       CHECK: %[[result:.+]]:2 = trtrt.enqueue_alloc %[[arg0]] stream(%[[arg1]]) (%[[arg2]]) : (memref<1x3x256x256xf32, #plan.memory_space<device>>) -> (memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>)
+//       CHECK:     return %[[result]]#0, %[[result]]#1 : memref<?x?x?x?xf32, #plan.memory_space<device>>, memref<?x?x?x?xf32, #plan.memory_space<device>>
+
+// -----
+
+func.func @enqueue_alloc_host_tensors_space_check(
+    %ctx: !trtrt.context, %stream: !cuda.stream,
+    %arg0: tensor<4xi32>, %arg1: tensor<128xf32>) -> tensor<128xf32> {
+  %host_tensor_alloc = bufferization.alloc_tensor() {
+    memory_space = #plan.memory_space<host_pinned>
+  } : tensor<4xi32>
+  %host_tensor = bufferization.materialize_in_destination %arg0 in %host_tensor_alloc :
+    (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  %3 = trtrt.enqueue_alloc %ctx
+    stream(%stream)
+    host_tensor_args [0, 1, 3]
+    (%host_tensor, %host_tensor, %arg0, %arg0) : (tensor<4xi32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) -> tensor<128xf32>
+  return %3 : tensor<128xf32>
+}
+
+// CHECK-LABEL: @enqueue_alloc_host_tensors_space_check
+//  CHECK-SAME: (%[[arg0:.+]]: !trtrt.context, %[[arg1:.+]]: !cuda.stream, %[[arg2:.+]]: memref<4xi32, #plan.memory_space<device>>, %[[arg3:.+]]: memref<128xf32, #plan.memory_space<device>>) -> memref<128xf32, #plan.memory_space<device>>
+//       CHECK:     %[[alloc:.+]] = memref.alloc() {alignment = 16 : i64} : memref<4xi32, #plan.memory_space<host_pinned>>
+//       CHECK:     memref.copy %[[arg2]], %[[alloc]] : memref<4xi32, #plan.memory_space<device>> to memref<4xi32, #plan.memory_space<host_pinned>>
+//       CHECK:     %[[alloc_0:.+]] = memref.alloc() {alignment = 16 : i64} : memref<4xi32, #plan.memory_space<host_pinned>>
+//       CHECK:     memref.copy %[[arg2]], %[[alloc_0]] : memref<4xi32, #plan.memory_space<device>> to memref<4xi32, #plan.memory_space<host_pinned>>
+//       CHECK:    %[[res:.+]] = trtrt.enqueue_alloc %[[arg0]] stream(%[[arg1]]) host_tensor_args [0, 1, 3] (%[[alloc]], %[[alloc]], %[[arg2]], %[[alloc_0]]) : (memref<4xi32, #plan.memory_space<host_pinned>>, memref<4xi32, #plan.memory_space<host_pinned>>, memref<4xi32, #plan.memory_space<device>>, memref<4xi32, #plan.memory_space<host_pinned>>) -> memref<128xf32, #plan.memory_space<device>>
+//       CHECK:     return %[[res]] : memref<128xf32, #plan.memory_space<device>>

--- a/mlir-tensorrt/test/Dialect/TensorRTRuntime/roundtrip.mlir
+++ b/mlir-tensorrt/test/Dialect/TensorRTRuntime/roundtrip.mlir
@@ -25,6 +25,18 @@ func.func @enqueue(%arg0: memref<10xf32>, %arg1: memref<10xf32>, %ctx: !trtrt.co
 
 // -----
 
+func.func @enqueue_alloc(%arg0: memref<10xf32>, %ctx: !trtrt.context, %stream: !cuda.stream) -> memref<10xf32> {
+  %result = trtrt.enqueue_alloc %ctx stream(%stream) (%arg0) : (memref<10xf32>) -> (memref<10xf32>)
+  return %result : memref<10xf32>
+}
+
+// CHECK-LABEL: @enqueue_alloc
+//  CHECK-SAME: (%[[arg0:.+]]: memref<10xf32>, %[[arg1:.+]]: !trtrt.context, %[[arg2:.+]]: !cuda.stream) -> memref<10xf32> {
+//       CHECK: %[[v1:.+]] = trtrt.enqueue_alloc %[[arg1]] stream(%[[arg2]]) (%[[arg0]]) : (memref<10xf32>) -> memref<10xf32>
+//       CHECK: return %[[v1]] : memref<10xf32>
+
+// -----
+
 
 func.func @enqueue_host_tensor(%arg0: !trtrt.context, %arg1: !cuda.stream,
                 %arg2: tensor<1xf32>, %arg3: tensor<1xi32>, %arg4: tensor<1xf32>) -> tensor<1xf32> {


### PR DESCRIPTION
Extend ConvertTensorRTToTensorRTRuntime to handle both DPS and non-DPS calling styles. Introduce EnqueueAllocOp for non-DPS execution and its conversion to executor CallOp.