### PR TITLE
[Python/Runtime] Add bindings to enable llvm global debug flag from runtime api

### DIFF
--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -56,6 +56,22 @@ extern "C" {
 typedef struct MTRT_RuntimeClient MTRT_Runtimeclient;
 
 //===----------------------------------------------------------------------===//
+// MTRT_GlobalDebug
+//===----------------------------------------------------------------------===//
+
+/// Enables or disables global debug flag.
+MTRT_Status mtrtEnableGlobalDebug(bool enable);
+
+/// Retrieves the current state of the global debug flag.
+MTRT_Status mtrtIsGlobalDebugEnabled(bool *enable);
+
+/// Sets the current global debug type.
+MTRT_Status mtrtSetGlobalDebugType(const char *type);
+
+/// Sets multiple global debug types.
+MTRT_Status mtrtSetGlobalDebugTypes(const char **types, size_t n);
+
+//===----------------------------------------------------------------------===//
 // MTRT_Stream
 //===----------------------------------------------------------------------===//
 

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -29,9 +29,10 @@
 #include "mlir-executor/Runtime/Backend/Lua/LuaRuntime.h"
 #include "mlir-executor/Support/Status.h"
 #include "mlir/Support/FileUtilities.h"
+#include "llvm/Support/Debug.h"
+
 #include "llvm/ADT/SmallVectorExtras.h"
 #include <memory>
-
 #ifdef MLIR_EXECUTOR_ENABLE_CUDA
 #include "cuda_runtime_api.h"
 #endif
@@ -140,6 +141,35 @@ static MTRT_Status wrap(const Status &status) {
   return mtrtStatusCreate(
       getMTRTStatusCodeFromRuntimeStatusCode(status.getCode()),
       status.getString().c_str());
+}
+
+//===----------------------------------------------------------------------===//
+// MTRT_Stream
+//===----------------------------------------------------------------------===//
+
+MTRT_Status mtrtEnableGlobalDebug(bool enable) {
+  llvm::DebugFlag = enable;
+  return mtrtStatusGetOk();
+}
+
+MTRT_Status mtrtIsGlobalDebugEnabled(bool *enable) {
+  *enable = llvm::DebugFlag;
+  return mtrtStatusGetOk();
+}
+
+MTRT_Status mtrtSetGlobalDebugType(const char *type) {
+  // Depending on the NDEBUG flag, this name can be either a function or a macro
+  // that expands to something that isn't a funciton call, so we cannot
+  // explicitly prefix it with `llvm::` or declare `using` it.
+  using namespace llvm;
+  setCurrentDebugType(type);
+  return mtrtStatusGetOk();
+}
+
+MTRT_Status mtrtSetGlobalDebugTypes(const char **types, size_t n) {
+  using namespace llvm;
+  setCurrentDebugTypes(types, n);
+  return mtrtStatusGetOk();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_runtime_debug_dump.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_runtime/test_runtime_debug_dump.py
@@ -1,0 +1,91 @@
+# RUN: %PYTHON %s 2>&1
+# REQUIRES: host-has-at-least-1-gpus
+
+import mlir_tensorrt.compiler.api as compiler
+import mlir_tensorrt.compiler.ir as ir
+import mlir_tensorrt.runtime.api as runtime
+import numpy as np
+
+ASM = """
+func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+  %1 = stablehlo.add %arg0, %arg0 : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  func.return %1 : tensor<2x3x4xf32>
+}
+"""
+
+
+def stablehlo_add():
+    # Build/parse the main function.
+    with ir.Context() as context:
+        m = ir.Module.parse(ASM)
+
+        # Use the compiler API to compile to executable.
+        client = compiler.CompilerClient(context)
+        opts = compiler.StableHLOToExecutableOptions(
+            client,
+            ["--tensorrt-builder-opt-level=3", "--tensorrt-strongly-typed=false"],
+        )
+        exe = compiler.compiler_stablehlo_to_executable(client, m.operation, opts)
+
+    # The RuntimeClient can and should persist across multiple Executables, RuntimeSessions, etc.
+    # It is primarily an interface for creating and manipulating buffers.
+    client = runtime.RuntimeClient()
+    stream = client.create_stream()
+    devices = client.get_devices()
+
+    if len(devices) == 0:
+        return
+
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+
+    arg0 = client.create_memref(
+        np.arange(0.0, 24.0, dtype=np.float32).reshape(2, 3, 4).data,
+        device=devices[0],
+        stream=stream,
+    )
+    arg1 = client.create_memref(
+        np.zeros(shape=(2, 3, 4), dtype=np.float32).data,
+        device=devices[0],
+        stream=stream,
+    )
+    session.execute_function("main", in_args=[arg0], out_args=[arg1], stream=stream)
+
+    data = np.asarray(client.copy_to_host(arg1, stream=stream))
+    stream.sync()
+
+    print(data)
+
+
+def test_global_debug():
+    print("Testing GlobalDebug functionality")
+
+    # Test setting and getting the flag
+    print("\nTesting flag property:")
+    runtime.GlobalDebug.flag = True
+    assert runtime.GlobalDebug.flag == True, "Flag should be True"
+    print("Flag set to True: Passed")
+
+    runtime.GlobalDebug.flag = False
+    assert runtime.GlobalDebug.flag == False, "Flag should be False"
+    print("Flag set to False: Passed")
+
+    # Enable global debug flag and test various debug types.
+    runtime.GlobalDebug.flag = True
+    print("\nTesting set_types method:")
+
+    # Test with a single type
+    runtime.GlobalDebug.set_types("runtime")
+    stablehlo_add()
+    print("Set single debug type 'runtime': Passed")
+
+    # Test with multiple types
+    debug_types = ["allocator", "runtime"]
+    runtime.GlobalDebug.set_types(debug_types)
+    stablehlo_add()
+    print("Set multiple debug types ['allocator', 'runtime']: Passed")
+
+    print("\nAll tests passed successfully!")
+
+
+test_global_debug()


### PR DESCRIPTION
Allow enabling global llvm::DebugFlag and setting current debug types from runtime python bindings.

Usage:
```
runtime.GlobalDebug.flag = True
runtime.GlobalDebug.set_types(["runtime", "allocator"])
```

Runtime debug dumps:
```
/workspaces/TensorRT-Incubator/mlir-tensorrt/executor/lib/Runtime/API/API.cpp:457 AllocTracker is now tracking 0x5b6000200 size=96 space=device ownership=internal
[runtime] copying 0x00005C9147A03470 to 0x00000005B6000200 size=96 bytes asynchronously via pinned staging buffer at 0x00000005B5000000
/workspaces/TensorRT-Incubator/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/TensorRT/TensorRTModule.cpp:133 freeing execution context at 101779074191656
```