### PR TITLE
Avoids passing stream when creating host memrefs to not trip an assertion

### DIFF
--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -116,28 +116,27 @@ def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool =
     exclude_file_lines = {}  # Maps filenames to ranges of lines that should be ignored.
     for func in EXCLUDE_FUNCTIONS:
         filename, start_line, end_line = _get_function_file_and_lines(func)
-
         exclude_file_lines[filename] = (start_line, end_line)
 
-    def should_exclude(frame):
-        if frame.file not in exclude_file_lines:
+    def should_exclude(source_info):
+        if source_info.code is None:
+            return True
+
+        # Exclude frames from some modules that are not very useful to users:
+        if source_info.module in utils.get_module_names_to_exclude_from_stack_info():
+            return True
+
+        if source_info.file not in exclude_file_lines:
             return False
 
-        start_line, end_line = exclude_file_lines[frame.file]
-        return frame.line >= start_line and frame.line <= end_line
+        start_line, end_line = exclude_file_lines[source_info.file]
+        return source_info.line >= start_line and source_info.line <= end_line
 
     frame_strs = []
     num_frames_printed = 0
 
     stack_info.fetch_source_code()
     for index, source_info in enumerate(stack_info):
-        if source_info.code is None:
-            continue
-
-        # Exclude frames from some modules that are not very useful to users:
-        if source_info.module in utils.get_module_names_to_exclude_from_stack_info():
-            continue
-
         if should_exclude(source_info):
             continue
 

--- a/tripy/tripy/common/utils.py
+++ b/tripy/tripy/common/utils.py
@@ -16,11 +16,10 @@
 #
 
 import array
-import struct
 from typing import Any, List, Sequence
 
-from tripy.common.exception import raise_error
 import tripy.common.datatype
+from tripy.common.exception import raise_error
 
 
 def is_int32(data):
@@ -72,16 +71,3 @@ def convert_list_to_array(values: List[Any], dtype: str) -> bytes:
 
 def is_empty(data: Sequence) -> bool:
     return isinstance(data, Sequence) and all(map(is_empty, data))
-
-
-def is_shape_empty(shape: Sequence[int]) -> bool:
-    """
-    A shape is considered empty if any of its dimensions is zero.
-
-    Args:
-        shape (Tuple[int, ...]): A tuple representing the shape of a tensor.
-
-    Returns:
-        bool: True if the shape represents an empty tensor, False otherwise.
-    """
-    return any(dim == 0 for dim in shape)

--- a/tripy/tripy/flat_ir/ops/constant.py
+++ b/tripy/tripy/flat_ir/ops/constant.py
@@ -15,17 +15,17 @@
 # limitations under the License.
 #
 
-import numbers
 from dataclasses import dataclass
 from typing import Sequence, Set, Union
 
+import mlir_tensorrt.runtime.api as runtime
 from mlir_tensorrt.compiler import ir
 from mlir_tensorrt.compiler.dialects import stablehlo
 
 from tripy import utils
+from tripy.backend.mlir.memref import create_memref
+from tripy.common import device
 from tripy.flat_ir.ops.base import BaseFlatIROp
-
-import mlir_tensorrt.runtime.api as runtime
 
 
 @dataclass(repr=False)
@@ -40,6 +40,7 @@ class ConstantOp(BaseFlatIROp):
 
     def to_mlir(self, operands):
         import array
+
         import tripy.common.datatype as datatype
         from tripy.backend.mlir import utils as mlir_utils
 
@@ -58,11 +59,11 @@ class ConstantOp(BaseFlatIROp):
             # so we have to represent them as ints and then cast the result
             if self.outputs[0].dtype == datatype.bool:
                 # need to use memoryview.cast to ensure that the view will be flattened
-                int_memref = runtime_client.create_memref(
-                    array.array("i", memoryview(data_memref).cast("b").tolist()),
+                int_memref = create_memref(
+                    array=array.array("i", memoryview(data_memref).cast("b").tolist()),
                     shape=self.data.shape,
-                    dtype=mlir_utils.convert_tripy_dtype_to_runtime_dtype(datatype.int32),
-                    device=None,
+                    dtype=datatype.int32,
+                    device=device("cpu"),
                 )
                 attr = ir.DenseElementsAttr.get(
                     array=int_memref, type=mlir_utils.get_mlir_dtype(datatype.int32), shape=data_memref.shape

--- a/tripy/tripy/frontend/trace/ops/storage.py
+++ b/tripy/tripy/frontend/trace/ops/storage.py
@@ -58,7 +58,7 @@ class Storage(BaseTraceOp):
             # special case: empty tensor
             self.dtype = utils.default(dtype, datatype.float32)
             self.shape = tuple(utils.get_shape(data))
-            self.data = memref.create_empty_memref(shape=self.shape, dtype=self.dtype)
+            self.data = memref.create_memref(shape=self.shape, dtype=self.dtype)
             self.device = utils.default(device, tp_device(("gpu", 0)))
             self.has_memref = True
         else:

--- a/tripy/tripy/frontend/trace/ops/utils.py
+++ b/tripy/tripy/frontend/trace/ops/utils.py
@@ -17,9 +17,24 @@
 
 from typing import Any, List, Optional, Sequence
 
-from tripy import utils
-from tripy.utils import Result
 import tripy.common.datatype as tp_dtype
+from tripy import utils
+from tripy.backend.mlir.memref import create_memref
+from tripy.common.datatype import bool as tp_bool
+from tripy.common.datatype import int32
+from tripy.common.device import device
+from tripy.common.exception import raise_error
+from tripy.flat_ir.ops import (
+    CompareOp,
+    ConcatenateOp,
+    ConstantOp,
+    DynamicReshapeOp,
+    DynamicSliceOp,
+    GetDimensionSizeOp,
+    SelectOp,
+)
+from tripy.flat_ir.tensor import FlatIRTensor
+from tripy.utils import Result
 
 
 # Utility for error messages in wrap_shape_inputs
@@ -32,20 +47,6 @@ def write_shape_input_indices_message(inputs: List["tripy.Tensor"]) -> str:
     if len(shape_indices) == 1:
         return f"input with index {shape_indices[0]} is tp.Shape"
     return f"inputs with indices {', '.join(shape_indices)} are tp.Shape"
-
-
-def get_broadcast_dim(dim1, dim2):
-    if dim1.is_dynamic_dim():
-        return dim1
-    elif dim2.is_dynamic_dim():
-        return dim2
-    else:
-        assert dim1 == 1 or dim2 == 1 or dim1 == dim2
-        # can't just return max(dim1, dim2) because one may be 0
-        if dim1 == 1:
-            return dim2
-        # dim1 == dim2 or dim2 == 1
-        return dim1
 
 
 ##
@@ -100,10 +101,6 @@ class InferLenPolicies:
 
 
 def get_dim_size_1d_tensor(tensor: "FlatIRTensor", dim: int):
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import GetDimensionSizeOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
     # GetDimensionSizeOp returns a scalar
     dim_scalar = FlatIRTensor.build(
         shape=(),
@@ -119,11 +116,6 @@ def get_dim_size_1d_tensor(tensor: "FlatIRTensor", dim: int):
 
 
 def get_shape_of_tensor(tensor: "FlatIRTensor", out: "FlatIRTensor" = None):
-    from tripy.backend.mlir.memref import create_empty_memref
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import ConstantOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
     if tensor.rank > 0:
         inp_rank = tensor.rank
         dim_sizes = [None] * inp_rank
@@ -146,18 +138,12 @@ def get_shape_of_tensor(tensor: "FlatIRTensor", out: "FlatIRTensor" = None):
         ConstantOp.build(
             [],
             [shape_output_tensor],
-            data=create_empty_memref(shape=(0,), dtype=int32, device=tensor.device),
+            data=create_memref(shape=(0,), dtype=int32, device=tensor.device),
         )
     return shape_output_tensor
 
 
 def add_constant_tensor_from_list(data: list, device: "tripy.device"):
-    from tripy.backend.mlir.memref import create_empty_memref
-    from tripy.common.datatype import int32
-    from tripy.common.device import device
-    from tripy.flat_ir.ops import ConstantOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
     const_output_tensor = FlatIRTensor.build(
         shape=[len(data)],
         rank=1,
@@ -166,16 +152,12 @@ def add_constant_tensor_from_list(data: list, device: "tripy.device"):
         reason_details=[f"create constant rank 1 int32 tensor filled with {data}."],
     )
     if not data:
-        data = create_empty_memref(shape=(0,), dtype=int32)
+        data = create_memref(shape=(0,), dtype=int32)
     ConstantOp.build([], [const_output_tensor], data=data)
     return const_output_tensor
 
 
-def concatenate_tensors(inputs: List["FlatIRTensor"], dim: int, out: "FlatIRTensor" = None):
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import ConcatenateOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
+def concatenate_tensors(inputs: List["FlatIRTensor"], dim: int, out: Optional["FlatIRTensor"] = None):
     if out is None:
         out = FlatIRTensor.build(
             rank=1,
@@ -192,10 +174,6 @@ def concatenate_tensors(inputs: List["FlatIRTensor"], dim: int, out: "FlatIRTens
 
 
 def reshape_scalar_to_1d(input: "FlatIRTensor"):
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import DynamicReshapeOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
     shape_1d = add_constant_tensor_from_list([1], input.device)
     out = FlatIRTensor.build(
         shape=(1,),
@@ -241,10 +219,6 @@ def is_broadcast_compatible(shape1, shape2) -> Result:
 def compute_shape_of_broadcast(
     shape1, shape2, output_rank: int, shape1_name: Optional[str] = None, shape2_name: Optional[str] = None
 ):
-    from tripy.common.datatype import bool as tp_bool
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import CompareOp, SelectOp
-    from tripy.flat_ir.tensor import FlatIRTensor
     from tripy.frontend.trace.ops.binary_elementwise import Comparison
 
     shape1_name = utils.default(shape1_name, "a tensor")
@@ -331,10 +305,6 @@ def insert_broadcast(
 
 # Expands rank of a tensor via prepending extra dims provided by nb_extra_dims.
 def expand_rank_of_tensor(input: "FlatIRTensor", nb_extra_dims: int):
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import ConcatenateOp
-    from tripy.flat_ir.tensor import FlatIRTensor
-
     if nb_extra_dims == 0:
         return input
 
@@ -376,9 +346,6 @@ def slice_rank1_tensor(rank1_tensor: "FlatIRTensor", slice_index: int, reason_de
     Slice a rank 1 tensor tensor along a certain index.
     Ex: tensor [1,2,3,4,5,6] sliced at slice_index 2 will return 3.
     """
-    from tripy.common.datatype import int32
-    from tripy.flat_ir.ops import DynamicSliceOp
-    from tripy.flat_ir.tensor import FlatIRTensor
 
     device = rank1_tensor.device
     start_idx = add_constant_tensor_from_list([slice_index], device)
@@ -411,10 +378,6 @@ def is_quantizable_dtype(dtype: "tripy.common.datatype.dtype") -> bool:
 
 
 def get_clamp_min_max(element_dtype, quant_dtype):
-    from tripy.common.device import device
-    from tripy.flat_ir.tensor import FlatIRTensor
-    from tripy.flat_ir.ops import ConstantOp
-
     QUANT_CLAMP_MIN_MAX = {
         tp_dtype.int8: (-128.0, 127.0),
         tp_dtype.int4: (-8.0, 7.0),
@@ -441,8 +404,6 @@ def get_clamp_min_max(element_dtype, quant_dtype):
 
 
 def check_qdq_args(input, scale, dtype, dim, is_quantize):
-    from tripy.common.exception import raise_error
-
     valid_input_dtypes = QUANTIZABLE_DTYPES if is_quantize else QUANTIZED_DTYPES
     valid_target_dtypes = QUANTIZED_DTYPES if is_quantize else QUANTIZABLE_DTYPES
     op_str = "quantize op" if is_quantize else "dequantize op"
@@ -503,8 +464,6 @@ def check_qdq_args(input, scale, dtype, dim, is_quantize):
 ## Conv & Pooling
 ##
 def check_conv_pooling_args(kernel_dims, stride, padding, dilation=None):
-    from tripy.common.exception import raise_error
-
     spatial_dims = len(kernel_dims)
 
     if stride is not None:

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -79,7 +79,8 @@ def _add_column_info_for_non_tensor(
     else:
         # Fallback path is just to look at the user code
         frame_index = arg.stack_info.get_first_user_frame_index()
-        dispatch_target = arg.stack_info[frame_index - 1]._dispatch_target
+        if frame_index is not None:
+            dispatch_target = arg.stack_info[frame_index - 1]._dispatch_target
 
     source_info = arg.stack_info[frame_index]
 

--- a/tripy/tripy/utils/stack_info.py
+++ b/tripy/tripy/utils/stack_info.py
@@ -49,34 +49,42 @@ class SourceInfo:
         module = self.module or ""
         return "tripy" not in module.split(".")
 
+    def fetch_source_code(self):
+        if self.code is not None:
+            return
+
+        # Note that in some cases, e.g. when code is being provided via the interactive shell, we may not be able to retrieve it.
+        # In that case we just leave it empty.
+        try:
+            lines = open(self.file, "r").readlines()
+        except OSError:
+            self.code = ""
+        else:
+            self.code = lines[self.line - 1].rstrip()
+
 
 class StackInfo(list):
     def __init__(self, lst, include_code_index: Optional[int] = None):
         super().__init__(lst)
         self.include_code_index = include_code_index
+        self._code_fetched = False
 
     def fetch_source_code(self):
+        if self._code_fetched:
+            return
+
         first_user_frame_found = False
         for index, source_info in enumerate(self):
-
-            def add_code():
-                # Note that in some cases, e.g. when code is being provided via the interactive shell, we may not be able to retrieve it.
-                # In that case we just leave it empty.
-                try:
-                    lines = open(source_info.file, "r").readlines()
-                except OSError:
-                    return
-
-                source_info.code = lines[source_info.line - 1].rstrip()
-
             if not first_user_frame_found:
                 if source_info.is_user_frame():
-                    add_code()
+                    source_info.fetch_source_code()
                     first_user_frame_found = True
                 elif self.include_code_index is not None and index >= self.include_code_index:
-                    add_code()
+                    source_info.fetch_source_code()
 
-    def get_first_user_frame_index(self) -> int:
+        self._code_fetched = True
+
+    def get_first_user_frame_index(self) -> Optional[int]:
         for index, source_info in enumerate(self):
             if source_info.is_user_frame():
                 return index


### PR DESCRIPTION
MLIR-TRT includes an assertion that disallows a stream from being provided when creating a host memref. This change adds a new `create_memref` helper which will avoid passing the stream in such cases. This also unifies all the call-sites to use this new helper.