### PR TITLE
Replaces `convert_inputs_to_tensors` decorator with a better decorator

### DIFF
--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -54,7 +54,6 @@ python_use_unqualified_type_names = True
 nitpick_ignore = {
     ("py:class", "tripy.types.ShapeLike"),
     ("py:class", "tripy.types.TensorLike"),
-    ("py:class", "tripy.types.NestedNumberSequence"),
     ("py:class", "Tensor"),
     ("py:class", "Shape"),
 }

--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -201,7 +201,7 @@ import tripy.frontend.utils as frontend_utils
 @export.public_api(document_under="tensor_operations")
 
 # The `convert_shape_inputs` decorator converts the specified function arguments into `tripy.Shape`s,
-# which would allow for using Python numbers and sequences. The `convert_inputs_to_tensors` decorator more generally converts
+# which would allow for using Python numbers and sequences. The `convert_to_tensors` decorator more generally converts
 # function arguments into Tripy tensors and is also commonly used in the codebase.
 @frontend_utils.convert_shape_inputs(["shape"])
 def theta(shape: Tuple[int], dim: int = 0, dtype: datatype.dtype = datatype.float32) -> "tripy.Tensor":

--- a/tripy/tests/constraints/object_builders.py
+++ b/tripy/tests/constraints/object_builders.py
@@ -20,6 +20,7 @@ from typing import ForwardRef, List, Optional, Union, get_args, get_origin
 
 import tripy as tp
 from tripy.common import datatype
+from tripy.types import TensorLike
 
 
 def tensor_builder(init, dtype, namespace):
@@ -64,6 +65,7 @@ def default_builder(init, dtype, namespace):
 find_func = {
     "tripy.Tensor": tensor_builder,
     "tripy.types.TensorLike": tensor_builder,
+    TensorLike: tensor_builder,
     "tripy.Shape": tensor_builder,
     "tripy.dtype": dtype_builder,
     datatype.dtype: dtype_builder,

--- a/tripy/tests/frontend/test_shape.py
+++ b/tripy/tests/frontend/test_shape.py
@@ -511,7 +511,7 @@ class TestShape:
     def test_binary_elementwise_broadcast_rejected(self, values):
         with raises(
             tp.TripyException,
-            match=r"\_\_mul\_\_ expects tensor arguments to have matching class types, but got mixed `tp\.Tensor` and `tp\.Shape` arguments\.",
+            match=r"Error processing shape inputs in operator BinaryElementwise Further information: Binary elementwise operators do not accept combinations of Shape and Tensor arguments.",
         ):
             tp.Shape(values).multiply(tp.Tensor([values, values]))
 

--- a/tripy/tests/frontend/test_utils.py
+++ b/tripy/tests/frontend/test_utils.py
@@ -20,66 +20,10 @@ import numpy as np
 
 import tripy as tp
 from tripy.frontend.shape import ShapeScalar
-from tripy.frontend.utils import convert_inputs_to_tensors, convert_shape_inputs
+from tripy.frontend.utils import convert_shape_inputs, convert_to_tensors
 from tests import helper
-
-# Putting underscores at the beginning and end of the names to get around the check
-# for magic methods. We would not want to see this outside of tests.
-
-
-@convert_inputs_to_tensors(["a"])
-def __func_test_basic__(a):
-    return a
-
-
-@convert_inputs_to_tensors(["a", "b", "c"])
-def __func_test_multi_input__(a, b, c):
-    return a, b, c
-
-
-@convert_inputs_to_tensors(["a", "b", "c"], sync_arg_types=[("a", "b", "c")])
-def __func_test_sync_arg_types__(a, b, c):
-    return a, b, c
-
-
-@convert_inputs_to_tensors(["args"])
-def __func_test_variadic_positional_args__(*args):
-    return args
-
-
-@convert_inputs_to_tensors(["x", "args"])
-def __func_test_arg_before_variadic_positional_args__(x, *args):
-    return (x,) + args
-
-
-@convert_inputs_to_tensors(["args", "y"])
-def __func_test_kwarg_after_variadic_positional_args__(*args, y):
-    return args + (y,)
-
-
-@convert_inputs_to_tensors(["xs"], unpack_argument=["xs"])
-def __func_test_convert_list_input__(xs):
-    return xs
-
-
-@convert_inputs_to_tensors(["xs"], sync_arg_types=[("xs",)], unpack_argument=["xs"])
-def __func_test_sync_within_list__(xs):
-    return xs
-
-
-@convert_inputs_to_tensors(["x", "ys"], sync_arg_types=[("x", "ys")], unpack_argument=["ys"])
-def __func_test_sync_single_type_to_list__(x, ys):
-    return x, ys
-
-
-@convert_inputs_to_tensors(["xs", "y"], sync_arg_types=[("xs", "y")], unpack_argument=["xs"])
-def __func_test_sync_list_type_to_single__(xs, y):
-    return xs, y
-
-
-@convert_inputs_to_tensors(["xs", "ys"], sync_arg_types=[("xs", "ys")], unpack_argument=["xs", "ys"])
-def __func_test_sync_list_types__(xs, ys):
-    return xs, ys
+from tripy import constraints
+import pytest
 
 
 @convert_shape_inputs(["s"])
@@ -92,50 +36,7 @@ def ignore_not_named(s, t):
     return (s, t)
 
 
-class TestConvertInputsToTensors:
-    def test_args(self):
-        assert isinstance(__func_test_basic__(0), tp.Tensor)
-
-    def test_kwargs(self):
-        assert isinstance(__func_test_basic__(a=0), tp.Tensor)
-
-    def test_convert_list_into_tensor(self):
-        t1 = __func_test_basic__([1, 2, 3])
-        assert isinstance(t1, tp.Tensor)
-        assert t1.shape == [3]
-
-        t2 = __func_test_basic__([[1, 2], [3, 4]])
-        assert t2.shape == [2, 2]
-
-    def test_convert_list_input(self):
-        xs = __func_test_convert_list_input__([1.0, 2.0, 3.0, 4.0])
-        assert len(xs) == 4
-        for x in xs:
-            assert isinstance(x, tp.Tensor)
-        assert not __func_test_convert_list_input__([])
-
-    def test_convert_tuple_input(self):
-        xs = __func_test_convert_list_input__((1.0, 2.0))
-        assert isinstance(xs, tuple)
-        assert len(xs) == 2
-        assert isinstance(xs[0], tp.Tensor)
-        assert isinstance(xs[1], tp.Tensor)
-
-    def test_variadic_positional_args(self):
-        x, y = __func_test_variadic_positional_args__(1.0, 2.0)
-        assert isinstance(x, tp.Tensor)
-        assert isinstance(y, tp.Tensor)
-
-    def test_arg_before_variadic_positional_args(self):
-        x, y = __func_test_arg_before_variadic_positional_args__(1.0, 2.0)
-        assert isinstance(x, tp.Tensor)
-        assert isinstance(y, tp.Tensor)
-
-    def test_kwarg_after_variadic_positional_args(self):
-        x, y = __func_test_kwarg_after_variadic_positional_args__(1.0, y=2.0)
-        assert isinstance(x, tp.Tensor)
-        assert isinstance(y, tp.Tensor)
-
+class TestConvertShapeInputs:
     def test_convert_shape_basic(self):
         s = convert_shape([1, 2, 3])
         assert isinstance(s, tp.Shape)
@@ -186,50 +87,6 @@ class TestConvertInputsToTensors:
         assert isinstance(s, tp.Shape)
         assert t2 == [4, 5, 6]
 
-    def test_permit_shape_scalars_with_shapes(self):
-        t1 = ShapeScalar(1)
-        t2 = ShapeScalar(2)
-        t3 = tp.Shape([1, 2])
-        a, b, c = __func_test_multi_input__(t1, t2, t3)
-
-        assert isinstance(a, ShapeScalar)
-        assert isinstance(b, ShapeScalar)
-        assert isinstance(c, tp.Shape)
-
-    def test_permit_shape_scalars_with_tensors(self):
-        t1 = ShapeScalar(1)
-        t2 = ShapeScalar(2)
-        t3 = tp.Tensor([[1, 2, 3], [4, 5, 6]])
-        a, b, c = __func_test_multi_input__(t1, t2, t3)
-
-        assert isinstance(a, ShapeScalar)
-        assert isinstance(b, ShapeScalar)
-        assert isinstance(c, tp.Tensor)
-
-    # When we convert arguments to tensors, we should preserve the column range
-    # of the original non-Tensor argument.
-    def test_includes_column_range_for_non_tensors(self):
-        tensor = __func_test_basic__(3.0)
-
-        # Column offset of the `3.0` above.
-        assert tensor.stack_info[tensor.stack_info.get_first_user_frame_index()].column_range == (37, 40)
-
-    def test_includes_column_range_for_non_tensors_multiple_inputs(self):
-        a, b, c = __func_test_multi_input__(1, 2.0, 3)
-
-        # Column offsets of the arguments above.
-        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (44, 45)
-        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (47, 50)
-        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (52, 53)
-
-    def test_includes_column_range_for_non_tensors_multiple_inputs_with_kwargs(self):
-        a, b, c = __func_test_multi_input__(1, b=2.0, c=3)
-
-        # Column offsets of the arguments above.
-        assert a.stack_info[a.stack_info.get_first_user_frame_index()].column_range == (44, 45)
-        assert b.stack_info[b.stack_info.get_first_user_frame_index()].column_range == (47, 52)
-        assert c.stack_info[c.stack_info.get_first_user_frame_index()].column_range == (54, 57)
-
     def test_includes_column_range_for_non_tensors_for_magic_methods(self):
         c = tp.ones((2, 3)) + 3
 
@@ -246,122 +103,105 @@ class TestConvertInputsToTensors:
         # Column offset of the `3` above.
         assert stack_info[stack_info.get_first_user_frame_index()].column_range == (36, 43)
 
-    def test_includes_column_range_for_list_elements(self):
-        xs = __func_test_convert_list_input__([1.0, 2.0])
-        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (47, 50)
-        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (52, 55)
 
-    def test_includes_column_range_for_tuple_elements(self):
-        xs = __func_test_convert_list_input__((1.0, 2.0))
-        assert xs[0].stack_info[xs[0].stack_info.get_first_user_frame_index()].column_range == (47, 50)
-        assert xs[1].stack_info[xs[1].stack_info.get_first_user_frame_index()].column_range == (52, 55)
+class TestConvertToTensors:
+    def test_no_effect_on_non_tensor_likes(self):
+        @convert_to_tensors()
+        def func(a: int, b: int):
+            return a, b
 
-    def test_sync_arg_type_includes_non_tensor_column_range(self):
-        x, y, z = __func_test_sync_arg_types__(tp.Tensor(3.0, dtype=tp.float16), 3, 4.0)
+        a, b = func(3, 4)
 
-        assert y.dtype == tp.float16
-        assert z.dtype == tp.float16
-        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (81, 82)
-        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (84, 87)
+        assert a is 3
+        assert b is 4
 
-    def test_sync_arg_type_includes_non_tensor_column_range_with_kwargs(self):
-        x, y, z = __func_test_sync_arg_types__(tp.Tensor(3.0, dtype=tp.float16), b=3, c=4.0)
+    def test_tensor_likes(self):
+        @convert_to_tensors()
+        def func(a: tp.types.TensorLike):
+            return a
 
-        assert y.dtype == tp.float16
-        assert z.dtype == tp.float16
-        assert y.stack_info[y.stack_info.get_first_user_frame_index()].column_range == (81, 84)
-        assert z.stack_info[z.stack_info.get_first_user_frame_index()].column_range == (86, 91)
+        a = func(1.0)
 
-    def test_sync_arg_type_not_applied_to_tensors(self):
-        x, y, z = __func_test_sync_arg_types__(
-            tp.Tensor(3.0),
-            tp.Tensor(3, dtype=tp.int32),
-            tp.Tensor(4, dtype=tp.float16),
+        assert isinstance(a, tp.Tensor)
+        assert a.stack_info[3].column_range == (17, 20)
+
+    def test_tensor_not_modified(self):
+        @convert_to_tensors()
+        def func(a: tp.types.TensorLike):
+            return a
+
+        a = tp.Tensor([1.0])
+        b = func(a)
+
+        assert b is a
+
+    def test_keyword_args(self):
+        @convert_to_tensors()
+        def func(a: tp.types.TensorLike):
+            return a
+
+        a = func(a=1.0)
+
+        assert isinstance(a, tp.Tensor)
+        assert a.stack_info[3].column_range == (17, 22)
+
+    def test_multiple_args(self):
+        @convert_to_tensors()
+        def func(a: tp.types.TensorLike, b: tp.types.TensorLike):
+            return a, b
+
+        a, b = func(1.0, 2.0)
+
+        assert isinstance(a, tp.Tensor)
+        assert a.stack_info[3].column_range == (20, 23)
+
+        assert isinstance(b, tp.Tensor)
+        assert b.stack_info[3].column_range == (25, 28)
+
+    def test_args_out_of_order(self):
+        @convert_to_tensors()
+        def func(a: tp.types.TensorLike, b: tp.types.TensorLike):
+            return a, b
+
+        a, b = func(b=1.0, a=2.0)
+
+        assert isinstance(a, tp.Tensor)
+        assert a.stack_info[3].column_range == (27, 32)
+        assert a.tolist() == 2.0
+
+        assert isinstance(b, tp.Tensor)
+        assert b.stack_info[3].column_range == (20, 25)
+        assert b.tolist() == 1.0
+
+    def test_cast_dtype(self):
+        # When type constraints are included, the decorator should automatically cast when possible.
+        @convert_to_tensors()
+        @constraints.dtypes(
+            constraints={"a": "T1", "b": "T1", constraints.RETURN_VALUE: "T1"},
+            variables={"T1": ["float16"]},
         )
+        def func(a: tp.Tensor, b: tp.types.TensorLike):
+            return a, b
 
-        assert x.dtype == tp.float32
-        assert y.dtype == tp.int32
-        assert z.dtype == tp.float16
+        a, b = func(tp.Tensor([1.0], dtype=tp.float16), 4.0)
 
-    def test_sync_arg_type_within_list(self):
-        xs = __func_test_sync_within_list__([1.0, tp.Tensor(3, dtype=tp.float16), 5])
+        assert isinstance(b, tp.Tensor)
+        assert b.dtype == tp.float16
 
-        assert xs[0].dtype == tp.float16
-        assert xs[1].dtype == tp.float16
-        assert xs[2].dtype == tp.float16
+        a, b = func(tp.Tensor([1.0], dtype=tp.float16), 4)
 
-    def test_sync_single_arg_type_to_list(self):
-        _, ys = __func_test_sync_single_type_to_list__(tp.Tensor(5, dtype=tp.int32), [2.0, 3.0, 4.0])
+        assert isinstance(b, tp.Tensor)
+        assert b.dtype == tp.float16
 
-        assert ys[0].dtype == tp.int32
-        assert ys[1].dtype == tp.int32
-        assert ys[2].dtype == tp.int32
-
-    def test_sync_list_arg_type_to_single_arg(self):
-        xs, y = __func_test_sync_list_type_to_single__([1.0, tp.Tensor(5, dtype=tp.int32), 4.0], 1.0)
-
-        assert xs[0].dtype == tp.int32
-        assert xs[2].dtype == tp.int32
-        assert y.dtype == tp.int32
-
-    def test_sync_list_arg_types(self):
-        xs, ys = __func_test_sync_list_types__([1.0, 2.0, 3.0], [3, 4, tp.Tensor(6, dtype=tp.int32)])
-
-        for x in xs:
-            assert x.dtype == tp.int32
-        for y in ys:
-            assert y.dtype == tp.int32
-
-    def test_sync_arg_type_list_not_applied_to_tensors(self):
-        xs = __func_test_sync_within_list__(
-            [tp.Tensor(1.0, dtype=tp.int32), tp.Tensor(3, dtype=tp.float16), tp.Tensor(5, dtype=tp.float32)]
+    @pytest.mark.parametrize("arg, dtype", [(1.0, tp.int32), (1.0, tp.int64), (2, tp.bool)])
+    def test_refuse_unsafe_cast(self, arg, dtype):
+        @convert_to_tensors()
+        @constraints.dtypes(
+            constraints={"a": "T1", "b": "T1", constraints.RETURN_VALUE: "T1"},
+            variables={"T1": ["int32", "int64"]},
         )
+        def func(a: tp.Tensor, b: tp.types.TensorLike):
+            return a, b
 
-        assert xs[0].dtype == tp.int32
-        assert xs[1].dtype == tp.float16
-        assert xs[2].dtype == tp.float32
-
-    def test_sync_arg_type_invalid(self):
-        with helper.raises(
-            tp.TripyException,
-            match=r"At least one of the arguments: \('a', 'b', 'c'\) must be a \`tripy.Tensor\`.",
-        ):
-            x, y, z = __func_test_sync_arg_types__(3.0, 3, 4)
-
-    def test_seq_arg_invalid(self):
-        with helper.raises(
-            tp.TripyException,
-            match=r"Encountered non-number of type str in sequence: hello",
-        ):
-            _ = __func_test_basic__([1, 2, "hello"])
-
-    def test_nested_seq_inconsistent_len(self):
-        with helper.raises(
-            tp.TripyException,
-            match=r"Expected a sequence of length 3 but got length 4: \[7, 8, 9, 10\]",
-        ):
-            _ = __func_test_basic__([[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]])
-
-    def test_nested_seq_inconsistent_types(self):
-        with helper.raises(
-            tp.TripyException,
-            match=r"Expected a sequence but got str: hi",
-        ):
-            _ = __func_test_basic__([[1, 2, 3], [4, 5, 6], "hi"])
-
-    def test_mixed_shape_and_tensors_not_permitted(self):
-        t1 = tp.Tensor([1, 2, 3])
-        s1 = ShapeScalar(4)
-        s2 = tp.Shape([5, 6, 7])
-        with helper.raises(
-            tp.TripyException,
-            match=r"\_\_func\_test\_multi\_input\_\_ expects tensor arguments to have matching class types,"
-            r" but got mixed `tp\.Tensor` and `tp\.Shape` arguments\.\n"
-            r"    Consider explicitly converting using tp\.Shape\(tensor\) or shape\.as\_tensor\(\)",
-        ):
-            __func_test_multi_input__(t1, s1, s2)
-
-    def test_invalid_argument_type_not_converted(self):
-        a = np.array([1, 2, 3])
-        b = __func_test_basic__(np.array([1, 2, 3]))
-        assert (a == b).all()
+        with helper.raises(tp.TripyException, "Refusing to automatically cast"):
+            func(tp.ones((2, 2), dtype=dtype), arg)

--- a/tripy/tests/frontend/trace/ops/test_dequantize.py
+++ b/tripy/tests/frontend/trace/ops/test_dequantize.py
@@ -49,7 +49,7 @@ class TestDequantize:
             tp.TripyException,
             match="Unsupported data type for 'dequantize'.",
         ):
-            a = tp.dequantize(a, 0.9, tp.int32)
+            a = tp.dequantize(a, 1, tp.int32)
 
     def test_invalid_scale_per_channel(self):
         a = tp.Tensor([2, 4], dtype=tp.int8)

--- a/tripy/tests/frontend/trace/ops/test_dequantize.py
+++ b/tripy/tests/frontend/trace/ops/test_dequantize.py
@@ -80,7 +80,7 @@ class TestDequantize:
 
     def test_invalid_scale_per_tensor(self):
         a = tp.Tensor(np.ones((4, 4), dtype=np.int8))
-        scale = [0.5] * 4
+        scale = tp.Tensor([0.5] * 4)
         with helper.raises(
             tp.TripyException,
             match="Scale must be a scalar tensor in per-tensor dequantize op",

--- a/tripy/tests/frontend/trace/ops/test_quantize.py
+++ b/tripy/tests/frontend/trace/ops/test_quantize.py
@@ -39,7 +39,7 @@ class TestQuantize:
             tp.TripyException,
             match="Unsupported data type for 'quantize'.",
         ):
-            a = tp.quantize(a, 0.9, tp.int8)
+            a = tp.quantize(a, 1, tp.int8)
 
     def test_unsupported_quant_dtype(self):
         a = tp.Tensor([1.0, 2.0])
@@ -47,7 +47,7 @@ class TestQuantize:
             tp.TripyException,
             match="Unsupported data type for 'quantize'.",
         ):
-            a = tp.quantize(a, 0.9, tp.float16)
+            a = tp.quantize(a, 1, tp.float16)
 
     def test_invalid_scale_per_channel(self):
         a = tp.ones((4, 4))

--- a/tripy/tests/frontend/trace/ops/test_quantize.py
+++ b/tripy/tests/frontend/trace/ops/test_quantize.py
@@ -78,7 +78,7 @@ class TestQuantize:
 
     def test_invalid_scale_per_tensor(self):
         a = tp.ones((4, 4))
-        scale = [0.5, 0.5]
+        scale = tp.Tensor([0.5] * 4)
         with helper.raises(
             tp.TripyException,
             match="Scale must be a scalar tensor in per-tensor quantize op",

--- a/tripy/tests/integration/test_quantize.py
+++ b/tripy/tests/integration/test_quantize.py
@@ -118,4 +118,4 @@ class TestQuantize:
         scale = tp.ones((4,))
         quantized = tp.quantize(input, scale, tp.int8, dim=0)
 
-        assert tp.allclose(quantized, tp.ones((4, 4), dtype=tp.int8), rtol=0.0, atol=0.0)
+        assert bool(tp.all(quantized == tp.ones((4, 4), dtype=tp.int8)))

--- a/tripy/tests/test_function_registry.py
+++ b/tripy/tests/test_function_registry.py
@@ -317,16 +317,6 @@ class TestFunctionRegistry:
         assert registry["test"]([1, 2, 3]) == 3
         assert registry["test"]([[1, 2], [3, 4], [5, 6]]) == 6
 
-    def test_number_array(self, registry):
-        @registry("test")
-        def func(n: "tripy.types.NestedNumberSequence"):
-            return n
-
-        assert registry["test"](1) == 1
-        assert registry["test"](2.0) == 2.0
-        assert registry["test"]([1, 2, 3]) == [1, 2, 3]
-        assert registry["test"]([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]) == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
-
     def test_optional_can_be_none(self, registry):
         @registry("test")
         def func(n: Optional[int]):
@@ -479,59 +469,11 @@ class TestFunctionRegistry:
         ):
             registry["test"](["a", "b", "c"])
 
-    def test_error_number_array_not_sequence(self, registry):
-        @registry("test")
-        def func(n: "tripy.types.NestedNumberSequence"):
-            return n
-
-        with helper.raises(
-            TripyException,
-            match=dedent(
-                rf"""
-            Could not find an implementation for function: 'test'.
-                Candidate overloads were:
-
-                --> \x1b\[38;5;3m{__file__}\x1b\[0m:[0-9]+ in \x1b\[38;5;6mfunc\(\)\x1b\[0m
-                      \|
-                  [0-9]+ \|         def func\(n: \"tripy\.types\.NestedNumberSequence\"\):
-                  [0-9]+ \|     \.\.\.
-                      \|\s
-
-                Not a valid overload because: For parameter: 'n', expected an instance of type: 'Union\[numbers\.Number, Sequence\[tripy\.types\.NestedNumberSequence\]\]' but got argument of type: 'str'\.
-            """
-            ).strip(),
-        ):
-            registry["test"]("hi")
-
-    def test_error_number_array_not_sequence_of_numbers(self, registry):
-        @registry("test")
-        def func(n: "tripy.types.NestedNumberSequence"):
-            return n
-
-        with helper.raises(
-            TripyException,
-            match=dedent(
-                rf"""
-            Could not find an implementation for function: 'test'\.
-                Candidate overloads were:
-
-                --> \x1b\[38;5;3m{__file__}\x1b\[0m:[0-9]+ in \x1b\[38;5;6mfunc\(\)\x1b\[0m
-                      \|
-                  [0-9]+ \|         def func\(n: \"tripy\.types\.NestedNumberSequence\"\):
-                  [0-9]+ \|     \.\.\.
-                      \|\s
-
-                Not a valid overload because: For parameter: 'n', expected an instance of type: 'Union\[numbers\.Number, Sequence\[tripy\.types\.NestedNumberSequence\]\]' but got argument of type: 'List\[List\[str\]\]'
-            """
-            ).strip(),
-        ):
-            registry["test"]([["a"], ["b"], ["c"]])
-
 
 @pytest.mark.parametrize(
     "typ, expected",
     [
-        (tp.types.TensorLike, "Union[tripy.Tensor, tripy.types.NestedNumberSequence]"),
+        (tp.types.TensorLike, "Union[tripy.Tensor, numbers.Number]"),
         (tp.types.ShapeLike, "Union[tripy.Shape, Sequence[Union[int, tripy.ShapeScalar]]]"),
         (tp.Tensor, "Tensor"),
         (torch.Tensor, "torch.Tensor"),

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -108,10 +108,9 @@ def _get_function_file_and_lines(func):
 
 
 def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
+    from tripy.frontend.utils import convert_to_tensors, convert_shape_inputs
 
-    from tripy.frontend.utils import convert_inputs_to_tensors, convert_shape_inputs
-
-    EXCLUDE_FUNCTIONS = [convert_inputs_to_tensors, convert_shape_inputs]
+    EXCLUDE_FUNCTIONS = [convert_to_tensors, convert_shape_inputs]
 
     exclude_file_lines = {}  # Maps filenames to ranges of lines that should be ignored.
     for func in EXCLUDE_FUNCTIONS:

--- a/tripy/tripy/frontend/ops/allclose.py
+++ b/tripy/tripy/frontend/ops/allclose.py
@@ -22,7 +22,7 @@ from tripy.common.exception import raise_error
 @export.public_api(document_under="operations/functions")
 @constraints.dtypes(
     constraints={"a": "T1", "b": "T1"},
-    variables={"T1": ["float32", "float16", "bfloat16", "int32", "int8"]},
+    variables={"T1": ["float32", "float16", "bfloat16"]},
 )
 def allclose(a: "tripy.Tensor", b: "tripy.Tensor", rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -25,6 +25,7 @@ from tripy import constraints, export
 from tripy.common import datatype
 from tripy.frontend.ops.registry import TENSOR_METHOD_REGISTRY
 from tripy.frontend.trace.ops.base import BaseTraceOp
+from tripy.types import TensorLike
 
 
 @dataclass(repr=False)
@@ -66,8 +67,8 @@ class BinaryElementwise(BaseTraceOp):
                     [
                         "Binary elementwise operators do not accept combinations of Shape and Tensor arguments."
                         " Consider explicitly converting using tp.Shape or as_tensor."
-                        f" Indices of shape arguments: {', '.join(shape_arg_indices)}."
-                        f" Indices of tensor arguments: {', '.join(tensor_arg_indices)}.",
+                        f" Indices of shape arguments: {', '.join(map(str, shape_arg_indices))}."
+                        f" Indices of tensor arguments: {', '.join(map(str, tensor_arg_indices))}.",
                     ]
                 )
             return Result.ok([Shape])
@@ -227,16 +228,13 @@ class Comparison(BinaryElementwise):
 
 @TENSOR_METHOD_REGISTRY("__add__")
 @TENSOR_METHOD_REGISTRY("__radd__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64", "bool"]},
     aliases=["__radd__"],
 )
-def __add__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __add__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise sum.
 
@@ -262,15 +260,12 @@ def __add__(
 
 
 @TENSOR_METHOD_REGISTRY("__sub__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
 )
-def __sub__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __sub__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise subtraction.
 
@@ -296,12 +291,12 @@ def __sub__(
 
 
 @TENSOR_METHOD_REGISTRY("__rsub__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
-    constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
+    constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
 )
-def __rsub__(self: numbers.Number, other: "tripy.types.TensorLike") -> "tripy.Tensor":
+def __rsub__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise subtraction.
 
@@ -327,15 +322,12 @@ def __rsub__(self: numbers.Number, other: "tripy.types.TensorLike") -> "tripy.Te
 
 
 @TENSOR_METHOD_REGISTRY("__pow__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8"]},
 )
-def __pow__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __pow__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise exponentiation.
 
@@ -361,12 +353,12 @@ def __pow__(
 
 
 @TENSOR_METHOD_REGISTRY("__rpow__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
-    constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
+    constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8"]},
 )
-def __rpow__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __rpow__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise exponentiation.
 
@@ -393,16 +385,13 @@ def __rpow__(self: numbers.Number, other: Union["tripy.Tensor", Any]) -> "tripy.
 
 @TENSOR_METHOD_REGISTRY("__mul__")
 @TENSOR_METHOD_REGISTRY("__rmul__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64", "bool"]},
     aliases=["__rmul__"],
 )
-def __mul__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __mul__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise multiplication.
 
@@ -428,15 +417,12 @@ def __mul__(
 
 
 @TENSOR_METHOD_REGISTRY("__truediv__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
 )
-def __truediv__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __truediv__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise division.
 
@@ -462,12 +448,12 @@ def __truediv__(
 
 
 @TENSOR_METHOD_REGISTRY("__rtruediv__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
-    constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
+    constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
 )
-def __rtruediv__(self: numbers.Number, other: "tripy.types.TensorLike") -> "tripy.Tensor":
+def __rtruediv__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise division.
 
@@ -493,12 +479,12 @@ def __rtruediv__(self: numbers.Number, other: "tripy.types.TensorLike") -> "trip
 
 
 @TENSOR_METHOD_REGISTRY("__floordiv__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64"]},
 )
-def __floordiv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __floordiv__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise floor division.
 
@@ -529,12 +515,12 @@ def __floordiv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", 
 
 
 @TENSOR_METHOD_REGISTRY("__rfloordiv__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "int64"]},
 )
-def __rfloordiv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __rfloordiv__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an elementwise floor division.
 
@@ -565,12 +551,12 @@ def __rfloordiv__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor",
 
 
 @TENSOR_METHOD_REGISTRY("__mod__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "float8"]},
 )
-def __mod__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __mod__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a modulo operation.
 
@@ -596,12 +582,12 @@ def __mod__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any])
 
 
 @TENSOR_METHOD_REGISTRY("__rmod__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "float8"]},
 )
-def __rmod__(self: Union["tripy.Tensor", Any], other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __rmod__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a modulo operation.
 
@@ -686,7 +672,7 @@ def minimum(lhs: "tripy.Tensor", rhs: "tripy.Tensor") -> "tripy.Tensor":
 
 
 @TENSOR_METHOD_REGISTRY("__lt__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -694,10 +680,7 @@ def minimum(lhs: "tripy.Tensor", rhs: "tripy.Tensor") -> "tripy.Tensor":
         "T2": ["bool"],
     },
 )
-def __lt__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __lt__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a 'less than' comparison.
 
@@ -723,7 +706,7 @@ def __lt__(
 
 
 @TENSOR_METHOD_REGISTRY("__le__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -731,10 +714,7 @@ def __lt__(
         "T2": ["bool"],
     },
 )
-def __le__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __le__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a 'less than or equal' comparison.
 
@@ -760,7 +740,7 @@ def __le__(
 
 
 @TENSOR_METHOD_REGISTRY("__eq__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -768,10 +748,7 @@ def __le__(
         "T2": ["bool"],
     },
 )
-def __eq__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __eq__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs an 'equal' comparison.
 
@@ -797,7 +774,7 @@ def __eq__(
 
 
 @TENSOR_METHOD_REGISTRY("__ne__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -805,7 +782,7 @@ def __eq__(
         "T2": ["bool"],
     },
 )
-def __ne__(self: "tripy.types.TensorLike", other: Union["tripy.Tensor", Any]) -> "tripy.Tensor":
+def __ne__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a 'not equal' comparison.
 
@@ -831,7 +808,7 @@ def __ne__(self: "tripy.types.TensorLike", other: Union["tripy.Tensor", Any]) ->
 
 
 @TENSOR_METHOD_REGISTRY("__ge__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -839,10 +816,7 @@ def __ne__(self: "tripy.types.TensorLike", other: Union["tripy.Tensor", Any]) ->
         "T2": ["bool"],
     },
 )
-def __ge__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __ge__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a 'greater than or equal' comparison.
 
@@ -868,7 +842,7 @@ def __ge__(
 
 
 @TENSOR_METHOD_REGISTRY("__gt__")
-@frontend_utils.convert_inputs_to_tensors(["self", "other"], sync_arg_types=[("self", "other")])
+@frontend_utils.convert_to_tensors()
 @constraints.dtypes(
     constraints={"self": "T1", "other": "T1", constraints.RETURN_VALUE: "T2"},
     variables={
@@ -876,10 +850,7 @@ def __ge__(
         "T2": ["bool"],
     },
 )
-def __gt__(
-    self: "tripy.types.TensorLike",
-    other: "tripy.types.TensorLike",
-) -> "tripy.Tensor":
+def __gt__(self: "tripy.Tensor", other: TensorLike) -> "tripy.Tensor":
     """
     Performs a 'greater than' comparison.
 

--- a/tripy/tripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/tripy/frontend/trace/ops/binary_elementwise.py
@@ -301,7 +301,7 @@ def __sub__(
     constraints={"other": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64"]},
 )
-def __rsub__(self: "tripy.types.NestedNumberSequence", other: "tripy.types.TensorLike") -> "tripy.Tensor":
+def __rsub__(self: numbers.Number, other: "tripy.types.TensorLike") -> "tripy.Tensor":
     """
     Performs an elementwise subtraction.
 

--- a/tripy/tripy/frontend/trace/ops/dequantize.py
+++ b/tripy/tripy/frontend/trace/ops/dequantize.py
@@ -15,12 +15,12 @@
 # limitations under the License.
 #
 
+import numbers
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import Any, Union, Sequence
 
 from tripy import constraints, export
 from tripy.common import datatype
-from tripy.common.exception import raise_error
 from tripy.frontend import utils as frontend_utils
 from tripy.frontend.trace.ops import utils as op_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
@@ -38,15 +38,7 @@ class Dequantize(BaseTraceOp):
     @frontend_utils.make_function
     def to_flat_ir(self, inputs, outputs):
         from tripy.common.datatype import int32
-        from tripy.flat_ir.ops import (
-            ConcatenateOp,
-            ConstantOp,
-            ConvertOp,
-            DivideOp,
-            DynamicBroadcastOp,
-            DynamicReshapeOp,
-            MulOp,
-        )
+        from tripy.flat_ir.ops import ConcatenateOp, ConvertOp, DivideOp, DynamicBroadcastOp, DynamicReshapeOp, MulOp
         from tripy.flat_ir.tensor import FlatIRTensor
 
         # Represent quantize as convert(input, dtype) * scale
@@ -109,14 +101,14 @@ class Dequantize(BaseTraceOp):
 
 
 @export.public_api(document_under="operations/quantization")
-@frontend_utils.convert_inputs_to_tensors(["scale"])
+@frontend_utils.convert_to_tensors(targets={"scale"})
 @constraints.dtypes(
     constraints={"input": "T1", "scale": "T2", "dtype": "T2", constraints.RETURN_VALUE: "T2"},
     variables={"T1": ["int4", "int8", "float8"], "T2": ["float32", "float16", "bfloat16"]},
 )
 def dequantize(
     input: "tripy.Tensor",
-    scale: "tripy.types.TensorLike",
+    scale: Union["tripy.Tensor", numbers.Number, Sequence[numbers.Number], Sequence[Sequence[numbers.Number]]],
     dtype: datatype.dtype,
     dim: Union[int, Any] = None,
 ) -> "tripy.Tensor":

--- a/tripy/tripy/frontend/trace/ops/slice.py
+++ b/tripy/tripy/frontend/trace/ops/slice.py
@@ -25,6 +25,7 @@ from tripy.frontend.ops.registry import TENSOR_METHOD_REGISTRY
 from tripy.frontend.trace.ops import utils as op_utils
 from tripy.frontend.trace.ops.base import BaseTraceOp
 from tripy.utils import make_tuple
+from tripy.types import TensorLike
 
 
 @dataclass(repr=False)
@@ -303,9 +304,8 @@ def __getitem__(
     return ShapeScalar(out) if isinstance(self, Shape) and out.rank == 0 else out
 
 
-# Conveniently converts the inputs to tensors. The decorator also fills in column info for the converted tensors.
 # Because the helper is called inside another function, we need to skip one entry in the call stack to find
 # the original call to user code.
-@frontend_utils.convert_inputs_to_tensors(["slice_params"], skip_num_stack_entries=1)
-def slice_helper(tensor, *slice_params, shape_slice: Optional[slice] = None):
+@frontend_utils.convert_to_tensors(skip_num_stack_entries=1)
+def slice_helper(tensor, *slice_params: TensorLike, shape_slice: Optional[slice] = None):
     return Slice.build(inputs=[tensor, *slice_params], shape_slice=shape_slice)

--- a/tripy/tripy/types.py
+++ b/tripy/tripy/types.py
@@ -27,24 +27,15 @@ from tripy import export
 
 export.public_api(autodoc_options=[":no-members:", ":no-special-members:"])(sys.modules[__name__])
 
-NestedNumberSequence = export.public_api(
-    document_under="types.rst",
-    module=sys.modules[__name__],
-    symbol="NestedNumberSequence",
-    doc="""
-        Denotes the recursive type annotation for sequences of Python numbers, possibly nested to an arbitrary depth.
-        Tripy often automatically converts these sequences to :class:`Tensor`.
-        """,
-)(Union[numbers.Number, Sequence["tripy.types.NestedNumberSequence"]])
 
 TensorLike = export.public_api(
     document_under="types.rst",
     module=sys.modules[__name__],
     symbol="TensorLike",
     doc="""
-        Type annotation for a parameter that is either a Tripy :class:`Tensor` or a Python sequence that can be automatically converted into one.
+        Type annotation for a parameter that is either a Tripy :class:`Tensor` or a Python number that can be automatically converted into one.
         """,
-)(Union["tripy.Tensor", "tripy.types.NestedNumberSequence"])
+)(Union["tripy.Tensor", numbers.Number])
 
 ShapeLike = export.public_api(
     document_under="types.rst",

--- a/tripy/tripy/utils/result.py
+++ b/tripy/tripy/utils/result.py
@@ -50,7 +50,7 @@ class Result:
         return super().__getattribute__(name)
 
     def __class_getitem__(cls, item):
-        return f"{cls.__name__}[{item.__name__}]"
+        return f"{cls.__name__}[{item if isinstance(item, str) else item.__name__}]"
 
     def __str__(self):
         return repr(self)


### PR DESCRIPTION
- Replaces `convert_inputs_to_tensors` decorator with `convert_to_tensors`,
     which will convert any `TensorLike` arguments by default and sync data types
     according to any specified data type constraints. This means that information
     does not need to be duplicated in the decorator like it used to be.

- Disallows unsafe downcasting in the new `convert_to_tensors` decorator.
     Previously, you could have:
     ```py
     x = tp.Tensor([1], dtype=tp.int32)
     x * 3.99
     ```
     which would yield a result equal to:
     ```py
     tp.Tensor([3])
     ```
     due to truncation when casting.

- Fixes several type annotations for binary elementwise ops.

- Removes NestedNumberSequence
    We only want to convert Python numbers to Tensors automatically.
    It doesn't make sense to write, for example, `x + [3]`.