### PR TITLE
[tripy] Sequential module

### DIFF
--- a/tripy/tests/frontend/module/conftest.py
+++ b/tripy/tests/frontend/module/conftest.py
@@ -139,3 +139,12 @@ def mixed_network():
 @pytest.fixture
 def complex_network():
     yield ComplexNetwork()
+
+@pytest.fixture
+def sequential_network():
+    yield tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+
+
+@pytest.fixture
+def nested_sequential_network():
+    yield tp.Sequential(tp.Linear(2, 4), tp.Sequential(tp.Linear(4, 3), tp.Linear(3, 1)))

--- a/tripy/tests/frontend/module/test_sequential.py
+++ b/tripy/tests/frontend/module/test_sequential.py
@@ -1,0 +1,145 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# SPDX-LicenseCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import cupy as cp
+import numpy as np
+
+import tripy as tp
+from tests import helper
+from textwrap import dedent
+
+class TestSequential:
+    def test_basic_structure(self, sequential_network):
+        assert len(sequential_network) == 2
+
+        assert isinstance(sequential_network[0], tp.Linear)
+        assert  np.array_equal(cp.from_dlpack(sequential_network[0].weight),  cp.from_dlpack(sequential_network[0].weight))
+        assert  np.array_equal(cp.from_dlpack(sequential_network[0].bias),  cp.from_dlpack(sequential_network[0].bias))
+
+    def test_named_children(self, sequential_network):
+        expected_names = [("0", sequential_network[0]), ("1", sequential_network[1])]
+        assert list(sequential_network.named_children()) == expected_names
+
+    # not valid test since sequential_network.named_parameters() is empty
+    # def test_named_parameters(self, sequential_network):
+    #     param_names = [f"{i}.{name}" for i in range(len(sequential_network)) for name, _ in sequential_network[i].named_parameters()]
+    #     for name, _ in sequential_network.named_parameters(): # 
+    #         assert name in param_names
+
+    def test_forward_pass(self, sequential_network):
+        input_data = tp.Tensor([1.0])
+        output = sequential_network(input_data)
+        assert output.shape == tp.Shape([1,2])
+
+    def test_state_dict(self, sequential_network):
+        state_dict = sequential_network.state_dict()
+        param_count = sum(len(dict(m.named_parameters())) for m in sequential_network)
+        assert len(state_dict) == param_count
+
+        expected_state_dict_keys = ["0.weight", "0.bias", "1.weight", "1.bias"]
+        assert list(state_dict.keys()) == expected_state_dict_keys
+
+    def test_load_state_dict(self, sequential_network):
+        new_state_dict = {
+            "0.weight": tp.Parameter(tp.ones((3, 1)))
+        }
+        sequential_network.load_state_dict(new_state_dict)
+        assert np.array_equal(cp.from_dlpack(sequential_network[0].weight),  cp.from_dlpack(new_state_dict["0.weight"]))
+
+    def test_modify_parameters(self, sequential_network):
+        new_param = tp.Parameter(tp.ones((2, 3)))
+        sequential_network[1].weight = new_param
+        assert sequential_network[1].weight is new_param
+
+    def test_invalid_index_access(self, sequential_network):
+        with helper.raises(ValueError, match="Key 2 not found in modules"):
+            _ = sequential_network[2]
+
+    def test_str_representation(self, sequential_network):
+        expected_str = dedent(
+            """\
+            Sequential(
+              0=
+                Linear(
+                 weight=shape(3, 1),
+                 bias=shape(3),
+                ),
+              1=
+                Linear(
+                 weight=shape(2, 3),
+                 bias=shape(2),
+                ),
+            )"""
+        )
+        assert str(sequential_network) == expected_str
+
+class TestNestedSequential:
+    def test_basic_structure(self, nested_sequential_network):
+        # Check that the top-level Sequential has two layers and that one of them is a nested Sequential
+        assert len(nested_sequential_network) == 2
+        assert isinstance(nested_sequential_network[1], tp.Sequential)
+
+    def test_named_children_top_level(self, nested_sequential_network):
+        expected_names = [
+            ("0", nested_sequential_network[0]),
+            ("1", nested_sequential_network[1]),
+        ]
+        assert list(nested_sequential_network.named_children()) == expected_names
+
+    def test_named_children_nested(self, nested_sequential_network):
+        expected_names = [
+            ("0", nested_sequential_network[1][0]),
+            ("1", nested_sequential_network[1][1]),
+        ]
+        assert list(nested_sequential_network[1].named_children()) == expected_names
+
+    def test_load_state_dict_nested(self, nested_sequential_network):
+        # Loading state dict with parameters for both top-level and nested modules
+        new_state_dict = {
+            "1.1.weight": tp.Parameter(tp.ones((1, 3))),
+        }
+        nested_sequential_network.load_state_dict(new_state_dict)
+        assert np.array_equal(cp.from_dlpack(nested_sequential_network[1][1].weight),  cp.from_dlpack(new_state_dict["1.1.weight"]))
+
+    def test_str_representation(self, nested_sequential_network):
+        expected_str = dedent(
+            """\
+            Sequential(
+              0=
+                Linear(
+                 weight=shape(4, 2),
+                 bias=shape(4),
+                ),
+              1=
+                Sequential(
+                  0=
+                    Linear(
+                     weight=shape(3, 4),
+                     bias=shape(3),
+                    ),
+                  1=
+                    Linear(
+                     weight=shape(1, 3),
+                     bias=shape(1),
+                    ),
+                ),
+            )"""
+        )
+        assert str(nested_sequential_network) == expected_str

--- a/tripy/tests/frontend/module/test_sequential.py
+++ b/tripy/tests/frontend/module/test_sequential.py
@@ -25,28 +25,25 @@ import tripy as tp
 from tests import helper
 from textwrap import dedent
 
+
 class TestSequential:
     def test_basic_structure(self, sequential_network):
         assert len(sequential_network) == 2
 
         assert isinstance(sequential_network[0], tp.Linear)
-        assert  np.array_equal(cp.from_dlpack(sequential_network[0].weight),  cp.from_dlpack(sequential_network[0].weight))
-        assert  np.array_equal(cp.from_dlpack(sequential_network[0].bias),  cp.from_dlpack(sequential_network[0].bias))
+        assert np.array_equal(
+            cp.from_dlpack(sequential_network[0].weight), cp.from_dlpack(sequential_network[0].weight)
+        )
+        assert np.array_equal(cp.from_dlpack(sequential_network[0].bias), cp.from_dlpack(sequential_network[0].bias))
 
     def test_named_children(self, sequential_network):
         expected_names = [("0", sequential_network[0]), ("1", sequential_network[1])]
         assert list(sequential_network.named_children()) == expected_names
 
-    # not valid test since sequential_network.named_parameters() is empty
-    # def test_named_parameters(self, sequential_network):
-    #     param_names = [f"{i}.{name}" for i in range(len(sequential_network)) for name, _ in sequential_network[i].named_parameters()]
-    #     for name, _ in sequential_network.named_parameters(): # 
-    #         assert name in param_names
-
     def test_forward_pass(self, sequential_network):
         input_data = tp.Tensor([1.0])
         output = sequential_network(input_data)
-        assert output.shape == tp.Shape([1,2])
+        assert output.shape == tp.Shape([1, 2])
 
     def test_state_dict(self, sequential_network):
         state_dict = sequential_network.state_dict()
@@ -57,11 +54,9 @@ class TestSequential:
         assert list(state_dict.keys()) == expected_state_dict_keys
 
     def test_load_state_dict(self, sequential_network):
-        new_state_dict = {
-            "0.weight": tp.Parameter(tp.ones((3, 1)))
-        }
+        new_state_dict = {"0.weight": tp.Parameter(tp.ones((3, 1)))}
         sequential_network.load_state_dict(new_state_dict)
-        assert np.array_equal(cp.from_dlpack(sequential_network[0].weight),  cp.from_dlpack(new_state_dict["0.weight"]))
+        assert np.array_equal(cp.from_dlpack(sequential_network[0].weight), cp.from_dlpack(new_state_dict["0.weight"]))
 
     def test_modify_parameters(self, sequential_network):
         new_param = tp.Parameter(tp.ones((2, 3)))
@@ -90,6 +85,7 @@ class TestSequential:
         )
         assert str(sequential_network) == expected_str
 
+
 class TestNestedSequential:
     def test_basic_structure(self, nested_sequential_network):
         # Check that the top-level Sequential has two layers and that one of them is a nested Sequential
@@ -116,7 +112,9 @@ class TestNestedSequential:
             "1.1.weight": tp.Parameter(tp.ones((1, 3))),
         }
         nested_sequential_network.load_state_dict(new_state_dict)
-        assert np.array_equal(cp.from_dlpack(nested_sequential_network[1][1].weight),  cp.from_dlpack(new_state_dict["1.1.weight"]))
+        assert np.array_equal(
+            cp.from_dlpack(nested_sequential_network[1][1].weight), cp.from_dlpack(new_state_dict["1.1.weight"])
+        )
 
     def test_str_representation(self, nested_sequential_network):
         expected_str = dedent(

--- a/tripy/tests/integration/test_sequential.py
+++ b/tripy/tests/integration/test_sequential.py
@@ -16,14 +16,10 @@
 #
 
 import torch
-
 import tripy as tp
 
-
 class TestSequential:
-
     def test_forward_pass_accuracy(self):
-        # Initialize Sequential with two Linear layers in both PyTorch and Tripy
         torch_model = torch.nn.Sequential(
             torch.nn.Linear(1, 3, dtype=torch.float32), torch.nn.Linear(3, 2, dtype=torch.float32)
         )
@@ -34,16 +30,16 @@ class TestSequential:
         tp_model[1].weight = tp.Parameter(torch_model[1].weight.detach())
         tp_model[1].bias = tp.Parameter(torch_model[1].bias.detach())
 
-        input_tensor = torch.tensor([[1.0]], dtype=torch.float32)
+        input_tensor = torch.tensor([[1.0]], dtype=torch.float32).to('cuda')
         tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
 
-        tp_output = tp.copy(tp_model(tp_input), tp.device("cpu"))
+        tp_output = tp_model(tp_input)
 
-        torch_model.eval()
+        torch_model.to('cuda').eval()
         with torch.no_grad():
             torch_output = torch_model(input_tensor)
 
-        rtol_ = 2e-7
+        rtol_ = 2e-6
         assert torch.allclose(torch.from_dlpack(tp_output), torch_output, rtol=rtol_)
 
     def test_nested_sequential_accuracy(self):
@@ -63,16 +59,16 @@ class TestSequential:
         tp_model[1][1].weight = tp.Parameter(torch_model[1][1].weight.detach())
         tp_model[1][1].bias = tp.Parameter(torch_model[1][1].bias.detach())
 
-        input_tensor = torch.tensor([[1.0]], dtype=torch.float32)
+        input_tensor = torch.tensor([[1.0]], dtype=torch.float32).to('cuda')
         tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
 
-        tp_output = tp.copy(tp_model(tp_input), tp.device("cpu"))
+        tp_output = tp_model(tp_input)
 
-        torch_model.eval()
+        torch_model.to('cuda').eval()
         with torch.no_grad():
             torch_output = torch_model(input_tensor)
 
-        rtol_ = 2e-7
+        rtol_ = 2e-6
         assert torch.allclose(torch.from_dlpack(tp_output), torch_output, rtol=rtol_)
 
     def test_state_dict_comparison(self):

--- a/tripy/tests/integration/test_sequential.py
+++ b/tripy/tests/integration/test_sequential.py
@@ -1,0 +1,76 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+
+import tripy as tp
+
+
+class TestSequential:
+
+    def test_forward_pass_accuracy(self):
+        # Initialize Sequential with two Linear layers in both PyTorch and Tripy
+        torch_model = torch.nn.Sequential(
+            torch.nn.Linear(1, 3, dtype=torch.float32), torch.nn.Linear(3, 2, dtype=torch.float32)
+        )
+        tp_model = tp.Sequential(tp.Linear(1, 3, dtype=tp.float32), tp.Linear(3, 2, dtype=tp.float32))
+
+        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
+        tp_model[1].weight = tp.Parameter(torch_model[1].weight.detach())
+        tp_model[1].bias = tp.Parameter(torch_model[1].bias.detach())
+
+        input_tensor = torch.tensor([[1.0]], dtype=torch.float32)
+        tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
+
+        tp_output = tp.copy(tp_model(tp_input), tp.device("cpu"))
+
+        torch_model.eval()
+        with torch.no_grad():
+            torch_output = torch_model(input_tensor)
+
+        rtol_ = 2e-7
+        assert torch.allclose(torch.from_dlpack(tp_output), torch_output, rtol=rtol_)
+
+    def test_nested_sequential_accuracy(self):
+        torch_model = torch.nn.Sequential(
+            torch.nn.Linear(1, 3, dtype=torch.float32),
+            torch.nn.Sequential(torch.nn.Linear(3, 4, dtype=torch.float32), torch.nn.Linear(4, 2, dtype=torch.float32)),
+        )
+        tp_model = tp.Sequential(
+            tp.Linear(1, 3, dtype=tp.float32),
+            tp.Sequential(tp.Linear(3, 4, dtype=tp.float32), tp.Linear(4, 2, dtype=tp.float32)),
+        )
+
+        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
+        tp_model[1][0].weight = tp.Parameter(torch_model[1][0].weight.detach())
+        tp_model[1][0].bias = tp.Parameter(torch_model[1][0].bias.detach())
+        tp_model[1][1].weight = tp.Parameter(torch_model[1][1].weight.detach())
+        tp_model[1][1].bias = tp.Parameter(torch_model[1][1].bias.detach())
+
+        input_tensor = torch.tensor([[1.0]], dtype=torch.float32)
+        tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
+
+        tp_output = tp.copy(tp_model(tp_input), tp.device("cpu"))
+
+        torch_model.eval()
+        with torch.no_grad():
+            torch_output = torch_model(input_tensor)
+
+        rtol_ = 2e-7
+        assert torch.allclose(torch.from_dlpack(tp_output), torch_output, rtol=rtol_)

--- a/tripy/tripy/frontend/module/sequential.py
+++ b/tripy/tripy/frontend/module/sequential.py
@@ -5,6 +5,7 @@ from tripy import export
 from tripy.frontend.module.parameter import Parameter
 from tripy.frontend.module import Module
 
+
 @export.public_api(document_under="modules/sequential.rst")
 @dataclass
 class Sequential(Module):
@@ -13,6 +14,7 @@ class Sequential(Module):
     container can accept either a list of modules or a dictionary of named modules. Modules are
     added in the order they are passed, and each is called sequentially during the forward pass.
     """
+
     modules: Union[Module, Dict[str, Module]]
     r"""The modules to include in the sequence"""
 
@@ -34,7 +36,6 @@ class Sequential(Module):
             # Sequential with named dictionary of layers
             model_named = tp.Sequential({'layer1': tp.Linear(1, 3), 'layer2': tp.Linear(3, 2)})
 
-            # Forward pass
             x = tp.Tensor([1.0])
             output = model(x)
         """
@@ -43,10 +44,10 @@ class Sequential(Module):
 
         if len(modules) == 1 and isinstance(modules[0], dict):
             for name, module in modules[0].items():
-                self.modules[name]= module
+                self.modules[name] = module
         else:
             for idx, module in enumerate(modules):
-                self.modules[str(idx)]= module
+                self.modules[str(idx)] = module
 
     def __call__(self, x: "tripy.Tensor") -> "tripy.Tensor":
         r"""
@@ -61,22 +62,21 @@ class Sequential(Module):
         for module in self.modules.values():
             x = module(x)
         return x
-    
+
     def __getattr__(self, name) -> Any:
         """
-        Custom __getattr__ to search both in `modules` dictionary and in other attributes. This is for handling 
+        Custom __getattr__ to search both in `modules` dictionary and in other attributes. This is for handling
         `module = operator.attrgetter(child_name)(module)` calls in tripy/frontend/module/module.py:load_state_dict
         """
         # Check if `name` is a key in the modules dictionary
         if "modules" in self.__dict__ and name in self.modules:
             return self.modules[name]
-        
+
         # Fallback to regular attribute access if not found in modules
         try:
             return super().__getattr__(name)
         except AttributeError:
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute or module named '{name}'")
-
 
     def __len__(self) -> int:
         r"""
@@ -84,7 +84,7 @@ class Sequential(Module):
 
         Returns:
             int: The number of modules in the sequence.
-        
+
         .. code-block:: python
             :linenos:
             :caption: Example
@@ -100,7 +100,7 @@ class Sequential(Module):
 
         Returns:
             Iterator[Module]: An iterator over the modules.
-        
+
         .. code-block:: python
             :linenos:
             :caption: Example
@@ -114,16 +114,16 @@ class Sequential(Module):
     def __getitem__(self, idx: Union[int, str]) -> Module:
         r"""
         Accesses a module by index (int) or name (str).
-        
+
         Args:
             idx (Union[int, str]): The index or name of the module to retrieve.
-        
+
         Returns:
             Module: The module at the specified index or name.
-        
+
         Raises:
             TypeError: If `idx` is not an int or str.
-        
+
         .. code-block:: python
             :linenos:
             :caption: Example
@@ -143,11 +143,11 @@ class Sequential(Module):
 
     def named_children(self) -> Iterator[Tuple[str, "Module"]]:
         r"""
-        Returns an iterator over all child modules in this `Sequential` container. 
+        Returns an iterator over all child modules in this `Sequential` container.
         Each child module is represented by its name and the module object itself.
-        
+
         Returns:
-            Iterator[Tuple[str, Module]]: An iterator over tuples containing 
+            Iterator[Tuple[str, Module]]: An iterator over tuples containing
             the name and module of each child.
 
         .. code-block:: python
@@ -155,15 +155,11 @@ class Sequential(Module):
             :caption: Example
 
             model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
-            
+
             for name, child in model.named_children():
                 print(f"{name}: {type(child).__name__}")
 
         """
-       # Avoid accessing `modules` during `__init__`
-        if not getattr(self, "modules", None):
-            return
-
         for name, module in self.modules.items():
             if isinstance(module, Module):
                 yield name, module
@@ -171,5 +167,3 @@ class Sequential(Module):
                 # Traverse deeper into Sequential containers within Sequential
                 for child_name, child in module.named_children():
                     yield f"{name}.{child_name}", child
-
-    # maybe handle named_parameters since currently just empty?

--- a/tripy/tripy/frontend/module/sequential.py
+++ b/tripy/tripy/frontend/module/sequential.py
@@ -1,0 +1,284 @@
+from typing import Union, List, Dict, Iterator
+from dataclasses import dataclass
+
+from tripy import export
+from tripy.frontend.module import Module
+
+@export.public_api(document_under="modules/sequential.rst")
+@dataclass
+class Sequential(Module):
+    r"""
+    A module to stack multiple layers or modules in a sequential order. The `Sequential`
+    container can accept either a list of modules or a dictionary of named modules. Modules are
+    added in the order they are passed, and each is called sequentially during the forward pass.
+    """
+    modules: Union[Module, Dict[str, Module]]
+    r"""The modules to include in the sequence"""
+
+    def __init__(self, *modules: Union[Module, Dict[str, Module]]) -> None:
+        r"""
+        Args:
+            *modules (Union[Module, Dict[str, Module]]): The modules to include in the sequence.
+                Can be passed as individual positional arguments or as a single dictionary of named modules.
+
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            import tripy as tp
+
+            # Sequential with layers passed as arguments
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+
+            # Sequential with named dictionary of layers
+            model_named = tp.Sequential({'layer1': tp.Linear(1, 3), 'layer2': tp.Linear(3, 2)})
+
+            # Forward pass
+            x = tp.Tensor([1.0])
+            output = model(x)
+        """
+        super().__init__()
+        self._modules = {}
+
+        if len(modules) == 1 and isinstance(modules[0], dict):
+            for name, module in modules[0].items():
+                self.add_module(name, module)
+        else:
+            for idx, module in enumerate(modules):
+                self.add_module(str(idx), module)
+
+    def __call__(self, x: "tripy.Tensor") -> "tripy.Tensor":
+        r"""
+        Defines the forward pass by applying each module in the container sequentially to input `x`.
+
+        Args:
+            x (Tensor): The input tensor to pass through the sequence of modules.
+
+        Returns:
+            Tensor: The output tensor after passing through each module in sequence.
+        """
+        for module in self._modules.values():
+            x = module(x)
+        return x
+    
+    def __len__(self) -> int:
+        r"""
+        Returns the total number of modules in the sequence.
+
+        Returns:
+            int: The number of modules in the sequence.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 64), tp.Linear(64, 128))
+            assert len(model) == 2
+        """
+        return len(self._modules)
+
+
+    def __iter__(self) -> Iterator[Module]:
+        r"""
+        Returns an iterator over the modules in the sequence.
+
+        Returns:
+            Iterator[Module]: An iterator over the modules.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+            for layer in model:
+                print(layer)
+        """
+        return iter(self._modules.values())
+
+    def __getitem__(self, idx: Union[int, str]) -> Module:
+        r"""
+        Accesses a module by index (int) or name (str).
+        
+        Args:
+            idx (Union[int, str]): The index or name of the module to retrieve.
+        
+        Returns:
+            Module: The module at the specified index or name.
+        
+        Raises:
+            TypeError: If `idx` is not an int or str.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+            layer = model[1]
+            assert isinstance(layer, tp.Linear)
+        """
+        if isinstance(idx, int):
+            return list(self._modules.values())[idx]
+        elif isinstance(idx, str):
+            return self._modules[idx]
+        else:
+            raise TypeError("Index must be an int or str")
+
+    def __setitem__(self, idx: Union[int, str], module: Module) -> None:
+        r"""
+        Replaces a module at a specific index or name.
+
+        Args:
+            idx (Union[int, str]): The index or name of the module to replace.
+            module (Module): The new module to set at the specified position.
+
+        Raises:
+            TypeError: If `idx` is not an int or str, or if `module` is not an instance of `Module`.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+            model[1] = tp.Linear(3, 1)
+            assert isinstance(model[1], tp.Linear)
+        """
+        if not isinstance(module, Module):
+            raise TypeError(f"{module} is not of type Module")
+
+        if isinstance(idx, int):
+            name = list(self._modules.keys())[idx]
+        elif isinstance(idx, str):
+            name = idx
+        else:
+            raise TypeError("Index must be an int or str")
+
+        self._modules[name] = module
+        setattr(self, name, module)
+
+    def __delitem__(self, idx: Union[int, str]) -> None:
+        r"""
+        Deletes a module by index or name.
+        
+        Args:
+            idx (Union[int, str]): The index or name of the module to delete.
+
+        Raises:
+            TypeError: If `idx` is not an int or str.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+            del model[1]
+            assert len(model) == 1
+        """
+        if isinstance(idx, int):
+            name = list(self._modules.keys())[idx]
+        elif isinstance(idx, str):
+            name = idx
+        else:
+            raise TypeError("Index must be an int or str")
+
+        del self._modules[name]
+        delattr(self, name)
+
+    def add_module(self, name: str, module: Module) -> None:
+        """
+        Adds a module with a specified name to the sequence.
+        
+        Args:
+            name (str): The name of the module to be added.
+            module (Module): The module to be added to the sequence.
+        
+        Returns:
+            None
+
+        Raises:
+            TypeError: If `module` is not an instance of `Module`.
+
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential()
+            model.add_module("layer1", tp.Linear(1, 3))
+            model.add_module("layer2", tp.Linear(3, 2))
+
+            assert len(model) == 2
+        """
+        if not isinstance(module, Module):
+            raise TypeError(f"{module} is not of type Module")
+        
+        self._modules[name] = module
+        setattr(self, name, module)
+
+    def append(self, module: Module) -> "Sequential":
+        """
+        Appends a module to the end of the sequence using an auto-generated name.
+
+        Args:
+            module (Module): The module to append to the sequence.
+
+        Returns:
+            Sequential: The instance of `Sequential` with the added module, allowing for chaining.
+        
+        Raises:
+            TypeError: If `module` is not an instance of `Module`.
+
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential()
+            model.append(tp.Linear(1, 3))
+            model.append(tp.Linear(3, 2))
+
+            assert len(model) == 2
+        """
+        self.add_module(str(len(self)), module)
+        return self
+   
+    def extend(self, *modules: Union[Module, Dict[str, Module]]) -> "Sequential":
+        r"""
+        Appends modules to the sequence, accepting either a dictionary of named modules
+        or individual modules as arguments.
+
+        Args:
+            *modules (Union[Module, Dict[str, Module]]): Additional modules to append to the sequence.
+                Can be individual modules as positional arguments or a single dictionary of named modules.
+        
+        Returns:
+            Sequential: The instance of `Sequential` with the added module, allowing for chaining.
+    
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 64))
+            model.extend(tp.Linear(64, 128), tp.Linear(128, 256))
+            assert len(model) == 3
+        """
+        if len(modules) == 1 and isinstance(modules[0], dict):
+            for name, module in modules[0].items():
+                self.add_module(name, module)
+        else:
+            for layer in modules:
+                self.append(layer)
+
+    def __str__(self) -> str:
+        r"""
+        Returns a string representation of the Sequential container, showing each module's name and type.
+
+        Returns:
+            str: The string representation of the Sequential container.
+        
+        .. code-block:: python
+            :linenos:
+            :caption: Example
+
+            model = tp.Sequential(tp.Linear(1, 3), tp.Linear(3, 2))
+            print(model)
+        """
+        module_str = "\n".join(f"({name}): {module}" for name, module in self._modules.items())
+        return f"{self.__class__.__name__}(\n{module_str}\n)"


### PR DESCRIPTION
Sequential similar to [torch.nn.sequential ](https://pytorch.org/docs/stable/generated/torch.nn.Sequential.html)

Things done

- [x] new frontend module called `tp.Sequential`
- [x] Unit tests under `tests/frontend/module/test_sequential.py`
- [x] integration tests and comparison with torch under

Supports nested tp.Sequential and most list operations other than modifications. `tp.Sequential` can not be modified after creation.