### PR TITLE
NFC: Add MLIR-TensorRT 'CMakePresets.json' and update build documentation

### DIFF
--- a/mlir-tensorrt/CMakeLists.txt
+++ b/mlir-tensorrt/CMakeLists.txt
@@ -17,9 +17,9 @@ endif()
 if(MLIR_TRT_PACKAGE_CACHE_DIR)
   set(CPM_SOURCE_CACHE "${MLIR_TRT_PACKAGE_CACHE_DIR}" CACHE STRING "" FORCE)
   set(CPM_USE_NAMED_CACHE_DIRECTORIES ON CACHE BOOL "" FORCE)
-else()
-  message(WARNING "MLIR_TRT_PACKAGE_CACHE_DIR is not set. Downloaded packages will be \
-  stored in your build directory. It is highly recommended to specify a package cache directory outside of \
+elseif(NOT CPM_SOURCE_CACHE)
+  message(WARNING "CPM_SOURCE_CACHE is not set. Source code for third party C++ packages will be \
+  stored in your build directory. It is highly recommended to specify a CPM source cache directory outside of \
   your build directory (for example '$PWD/.cache.cpm')")
 endif()
 
@@ -55,7 +55,7 @@ mtrt_option(MLIR_TRT_ENABLE_EXECUTOR "Build the Executor dialect and MLIR-Tensor
 mtrt_option(MLIR_TRT_ENABLE_NCCL "Enable the NCCL runtime module" ON)
 
 set(MLIR_TRT_TENSORRT_DIR "" CACHE STRING "Path to TensorRT install directory")
-set(MLIR_TRT_DOWNLOAD_TENSORRT_VERSION "10.0" CACHE STRING
+set(MLIR_TRT_DOWNLOAD_TENSORRT_VERSION "10.2" CACHE STRING
    "Version of TensorRT to download and use. It overrides MLIR_TRT_TENSORRT_DIR.")
 set(MLIR_TRT_PACKAGE_CACHE_DIR "" CACHE STRING "Directory where to cache downloaded C++ packages")
 set(MLIR_TRT_USE_LINKER "" CACHE STRING "Specify a linker to use (e.g. LLD); this is just an alias for LLVM_USE_LINKER")

--- a/mlir-tensorrt/CMakePresets.json
+++ b/mlir-tensorrt/CMakePresets.json
@@ -1,0 +1,56 @@
+{
+  "version": 6,
+  "include": [],
+  "configurePresets": [
+    {
+      "name": "base",
+      "generator": "Ninja",
+      "binaryDir": "build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "LLVM_ENABLE_ASSERTIONS": "ON",
+        "CPM_SOURCE_CACHE": "${sourceDir}/.cache.cpm",
+        "CPM_USE_NAMED_CACHE_DIRECTORIES": "ON"
+      }
+    },
+    {
+      "name": "ninja-llvm",
+      "displayName": "Ninja RelWithDebInfo LLVM",
+      "generator": "Ninja",
+      "binaryDir": "build",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "LLVM_USE_LINKER": "lld"
+      }
+    },
+    {
+      "name": "ninja-llvm-release",
+      "inherits": "ninja-llvm",
+      "displayName": "Ninja Release LLVM",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-llvm-debug",
+      "inherits": "ninja-llvm",
+      "displayName": "Ninja Release LLVM",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "ninja-gcc",
+      "displayName": "Ninja RelWithDebInfo GCC",
+      "generator": "Ninja",
+      "binaryDir": "build-gcc",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change adds a CMake presets file to MLIR-TensorRT, which helps to
simplify the initial CMake setup considerably.

The build documentation is updated to use this feature, and some additional
notes are added to describe how to control the TensorRT version that
is used for build & test.
