### PR TITLE
Update IOutputAllocator usage to be compatible with TensorRT 9.2 APIs

### DIFF
--- a/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/TensorRT/CMakeLists.txt
+++ b/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/TensorRT/CMakeLists.txt
@@ -15,3 +15,8 @@ add_mlir_executor_runtime_capability_library(MLIRTensorRTExecutorRuntimeTensorRT
   nvtx3-cpp
   TensorRTHeaderOnly
 )
+
+target_include_directories(MLIRTensorRTExecutorRuntimeTensorRTModule
+  PRIVATE
+  ${MLIR_TENSORRT_ROOT_DIR}/tensorrt/include
+)


### PR DESCRIPTION
`IOutputAllocator` needs to be supported for both TRT 9.2 and TRT 10.x release. Add support for using TRT 9.2 API.