### PR TITLE
[CI] Add more configurations to mlir-tensorrt CI

### DIFF
--- a/.github/workflows/mlir-tensorrt-ci.yml
+++ b/.github/workflows/mlir-tensorrt-ci.yml
@@ -42,6 +42,40 @@ jobs:
         with:
           fetch-depth: 5
 
+      - name: Validate commit message
+        env:
+          PR_HEAD_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          cat > commit_message_checker.py <<EOF
+          #!/usr/bin/python3
+          import re
+          import sys
+          import subprocess
+
+          git_cmd = f"git show -s --format=%B {sys.argv[1]}"
+          try:
+            commit_message_cmd = subprocess.run(git_cmd.split(' '), capture_output=True, text=True, check=True)
+            commit_message = commit_message_cmd.stdout.strip()
+          except subprocess.CalledProcessError as e:
+            print(f"Failed to get PR HEAD commit message with error: {e.stderr.strip()}")
+
+          match = re.search(r"^(\[bot\].+|NFC: .+|(.+\n\n+.+\n+.+))$", commit_message, re.DOTALL)
+          if match:
+            print("Commit message is in canonical form :)")
+            sys.exit(0)
+          print("Commit message is not in the canonical form!")
+          print(commit_message)
+          print("")
+          print("Expected format is, ")
+          print("<title>")
+          print("<body>")
+          print("NOTE: Body should start on new line. `2 spaces + enter` for new line!")
+          print("NOTE: Body should be at least two lines.")
+          sys.exit(1)
+          EOF
+
+          python3 commit_message_checker.py ${PR_HEAD_COMMIT_SHA}
+
       # Run initial format check
       - name: Run python format and clang check
         uses: addnab/docker-run-action@v3
@@ -84,8 +118,8 @@ jobs:
             ${{ github.workspace }}/ccache
             ${{ github.workspace }}/.ccache.cpm
 
-      # Run LIT tests
-      - name: Run MLIR-TensorRT lit tests
+      # Run LIT tests with TensorRT 10
+      - name: Run MLIR-TensorRT lit tests with TensorRT 10
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEFAULT_IMAGE }}
@@ -113,6 +147,97 @@ jobs:
               -DMLIR_TRT_PACKAGE_CACHE_DIR=${PWD}/.cache.cpm \
               -DMLIR_TRT_ENABLE_ASSERTIONS=ON \
               -DMLIR_TRT_DOWNLOAD_TENSORRT_VERSION=10.2 \
+              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+              -DMLIR_TRT_USE_LINKER=lld \
+              -DMLIR_EXECUTOR_ENABLE_GPU_INTEGRATION_TESTS=OFF
+
+            ninja -C build all
+
+            ninja -C build check-mlir-executor
+            ninja -C build check-mlir-tensorrt-dialect
+            ninja -C build check-mlir-tensorrt
+
+            cd ..
+            ccache --show-stats || true
+            EOF
+
+            bash build_and_test.sh
+
+      # Run LIT tests with TensorRT 10 & ASAN
+      - name: Run MLIR-TensorRT lit tests with TensorRT 10, ASAN enabled
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.DEFAULT_IMAGE }}
+          options: -v ${{ github.workspace }}/mlir-tensorrt:/mlir-tensorrt -v ${{ github.workspace }}/ccache:/ccache -v ${{ github.workspace }}/.ccache.cpm:/.ccache.cpm
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            export CCACHE_BASEDIR="$PWD"
+            export CCACHE_DIR="$PWD/ccache"
+            export CCACHE_COMPILERCHECK=content
+            export CCACHE_MAXSIZE=10G
+            ccache --zero-stats || true
+            ccache --show-stats || true
+
+            cd mlir-tensorrt
+            cat > build_and_test.sh <<EOF
+            #!/bin/bash
+            set -e
+
+            python3 -m pip install -r python/requirements-dev.txt
+
+            cmake -B ./build -S . -G Ninja \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DMLIR_TRT_PACKAGE_CACHE_DIR=${PWD}/.cache.cpm \
+              -DMLIR_TRT_ENABLE_ASSERTIONS=ON \
+              -DMLIR_TRT_DOWNLOAD_TENSORRT_VERSION=10.2 \
+              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+              -DMLIR_TRT_USE_LINKER=lld \
+              -DMLIR_EXECUTOR_ENABLE_GPU_INTEGRATION_TESTS=OFF \
+              -DENABLE_ASAN=ON
+
+            ninja -C build all
+
+            ninja -C build check-mlir-executor
+            ninja -C build check-mlir-tensorrt-dialect
+            ninja -C build check-mlir-tensorrt
+
+            cd ..
+            ccache --show-stats || true
+            EOF
+
+            bash build_and_test.sh
+
+      # Run LIT tests with TensorRT 9
+      - name: Run MLIR-TensorRT lit tests with TensorRT 9
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.DEFAULT_IMAGE }}
+          options: -v ${{ github.workspace }}/mlir-tensorrt:/mlir-tensorrt -v ${{ github.workspace }}/ccache:/ccache -v ${{ github.workspace }}/.ccache.cpm:/.ccache.cpm
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            export CCACHE_BASEDIR="$PWD"
+            export CCACHE_DIR="$PWD/ccache"
+            export CCACHE_COMPILERCHECK=content
+            export CCACHE_MAXSIZE=10G
+            ccache --zero-stats || true
+            ccache --show-stats || true
+
+            cd mlir-tensorrt
+            cat > build_and_test.sh <<EOF
+            #!/bin/bash
+            set -e
+
+            python3 -m pip install -r python/requirements-dev.txt
+
+            cmake -B ./build -S . -G Ninja \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DMLIR_TRT_PACKAGE_CACHE_DIR=${PWD}/.cache.cpm \
+              -DMLIR_TRT_ENABLE_ASSERTIONS=ON \
+              -DMLIR_TRT_DOWNLOAD_TENSORRT_VERSION=9.2.0.5 \
               -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
               -DMLIR_TRT_USE_LINKER=lld \
               -DMLIR_EXECUTOR_ENABLE_GPU_INTEGRATION_TESTS=OFF

--- a/mlir-tensorrt/build_tools/cmake/Dependencies.cmake
+++ b/mlir-tensorrt/build_tools/cmake/Dependencies.cmake
@@ -255,4 +255,3 @@ function(mlir_tensorrt_find_dlpack)
     add_library(DLPack::Headers ALIAS DLPackHeaderOnly)
   endif()
 endfunction()
-


### PR DESCRIPTION
This PR makes the following changes in mlir-tensorrt CI,
- Add testing for TensorRT versions 8.6.1.6 and 9.2.
- Add testing with ASAN enabled