### PR TITLE
Miscellaneous fixes

### DIFF
--- a/tripy/tests/README.md
+++ b/tripy/tests/README.md
@@ -36,7 +36,7 @@ tests together.
 For example, to profile L0 tests, run:
 
 ```bash
-pytest tests/ -v -m "not l1 and not manual" --profile
+pytest tests/ -v -m "not l1 and not manual" --ignore tests/performance --profile
 ```
 
 You can visualize the results using `snakeviz`.

--- a/tripy/tests/README.md
+++ b/tripy/tests/README.md
@@ -74,13 +74,13 @@ detect dead code. *This **will** include false positives for our code, so be car
 You can run it with:
 
 ```bash
-vulture tripy tests --sort-by-size
+vulture . --sort-by-size
 ```
 
 To exclude false positives, use:
 
 ```bash
-vulture tripy tests --sort-by-size --min-confidence=100
+vulture . --sort-by-size --min-confidence=100
 ```
 
 

--- a/tripy/tests/backend/api/test_stream.py
+++ b/tripy/tests/backend/api/test_stream.py
@@ -12,10 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
-import gc, sys
-import tripy as tp
 import cupy as cp
+
+import tripy as tp
 
 
 def test_default_stream_creation():

--- a/tripy/tests/common/test_utils.py
+++ b/tripy/tests/common/test_utils.py
@@ -16,21 +16,11 @@
 #
 
 import pytest
-import struct
-from collections import ChainMap
-from textwrap import dedent
-
-import cupy as cp
-import torch
+from tests import helper
 
 import tripy.common.datatype
-
-from tests import helper
 from tripy.common.exception import TripyException
-from tripy.common.utils import (
-    convert_list_to_array,
-    get_element_type,
-)
+from tripy.common.utils import convert_list_to_array, get_element_type
 
 
 def test_get_element_type():

--- a/tripy/tests/constraints/test_dtypes.py
+++ b/tripy/tests/constraints/test_dtypes.py
@@ -36,7 +36,6 @@ from tripy.export import PUBLIC_APIS
 PUBLIC_API_TENSOR_FUNCTIONS = []
 PUBLIC_API_TENSOR_FUNCTION_NAMES = []
 for api in PUBLIC_APIS:
-    is_module = False
     if inspect.isfunction(api.obj):
         funcs = [api.obj]
     elif inspect.isclass(api.obj):

--- a/tripy/tests/frontend/trace/ops/test_iota.py
+++ b/tripy/tests/frontend/trace/ops/test_iota.py
@@ -34,9 +34,8 @@ class TestIota:
         assert isinstance(a.trace_tensor.producer, Iota)
 
     def test_invalid_dim(self):
-        a = tp.iota([2, 3], dim=3)
-        with helper.raises(tp.TripyException, match="iota dimension cannot go beyond the output rank"):
-            a.eval()
+        with helper.raises(tp.TripyException, match="Dimension argument is out of bounds."):
+            tp.iota([2, 3], dim=3)
 
     def test_infer_rank(self):
         a = tp.iota((2, 3, 4))

--- a/tripy/tests/integration/test_plugin.py
+++ b/tripy/tests/integration/test_plugin.py
@@ -34,6 +34,7 @@ class TestPlugin:
 
         ref_out = tp.gelu(inp)
 
+        assert out.shape == ref_out.shape == inp.shape
         assert cp.allclose(cp.from_dlpack(out), cp.from_dlpack(ref_out))
 
     def test_dynamic_shape_gelu(self):
@@ -43,7 +44,11 @@ class TestPlugin:
         compiled_gelu = tp.compile(gelu, args=[tp.InputInfo((2, (1, 2, 3), 4), dtype=tp.float32)])
 
         inp = tp.iota((2, 1, 4))
-        assert tp.allclose(compiled_gelu(inp), tp.gelu(inp))
+        out = compiled_gelu(inp)
+        assert out.shape == inp.shape
+        assert tp.allclose(out, tp.gelu(inp))
 
         new_inp = tp.ones((2, 2, 4), dtype=tp.float32)
-        assert tp.allclose(compiled_gelu(new_inp), tp.gelu(new_inp))
+        out = compiled_gelu(new_inp)
+        assert out.shape == new_inp.shape
+        assert tp.allclose(out, tp.gelu(new_inp))

--- a/tripy/tripy/backend/mlir/utils.py
+++ b/tripy/tripy/backend/mlir/utils.py
@@ -107,41 +107,6 @@ def list_to_dense_attr(data: List, mlir_dtype):
     return attrs
 
 
-def get_mlir_quant_dtype(
-    origin_dtype: "tripy.dtype",
-    quant_dtype: "tripy.dtype",
-    scale: float,
-    zero_point: int,
-    storage_type_min: int,
-    storage_type_max: int,
-):
-    """
-    Converts a tripy data type to an MLIR quantized data type.
-
-    Args:
-        origin_dtype: original data type to be quantized
-        quant_dtype: target data type to quantize
-        dtype: One of int4, int8, float8
-        scale: scale value of quantized tensor
-        zero_point: zero point of quantized tensor
-        storage_type_min: min value of quantized dtype
-        storage_type_max: max value of quantized dtype
-    """
-    from mlir_tensorrt.compiler.dialects import quant
-
-    storage_type = get_mlir_dtype(quant_dtype)
-    expressed_type = get_mlir_dtype(origin_dtype)
-    return quant.UniformQuantizedType.get(
-        quant.UniformQuantizedType.FLAG_SIGNED,
-        storage_type,
-        expressed_type,
-        scale,
-        zero_point,
-        storage_type_min,
-        storage_type_max,
-    )
-
-
 def make_mlir_tensor(
     dtype: "tripy.common.dtype", shape: Optional[Sequence[int]] = None, rank: Optional[int] = None
 ) -> ir.RankedTensorType:

--- a/tripy/tripy/flat_ir/flat_ir.py
+++ b/tripy/tripy/flat_ir/flat_ir.py
@@ -177,10 +177,6 @@ class FlatIR:
         def _get_function_input_types(func: FlatIRFunction, mlir_tensor_map: Dict[str, ir.Value]) -> List[ir.Type]:
             """Get the input types for a function, converting to dynamic tensors if necessary."""
 
-            def convert_to_dynamic_tensor(rtt: ir.RankedTensorType) -> ir.RankedTensorType:
-                dynamic_shape = [ir.ShapedType.get_dynamic_size()] * rtt.rank
-                return ir.RankedTensorType.get(dynamic_shape, rtt.element_type)
-
             # Skip converting to dynamic tensor for Quantize/Dequantize scale operation.
             if "Quantize" in func.name or "Dequantize" in func.name:
                 return [

--- a/tripy/tripy/frontend/ops/cumsum.py
+++ b/tripy/tripy/frontend/ops/cumsum.py
@@ -24,7 +24,6 @@ from tripy.frontend import utils as frontend_utils
         "T1": ["float32", "float16", "bfloat16", "int32"],
     },
 )
-@frontend_utils.process_dim()
 def cumsum(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":
     """
     Computes the cumulative sum of elements in the input along the dimension ``dim``.
@@ -73,6 +72,8 @@ def cumsum(input: "tripy.Tensor", dim: int) -> "tripy.Tensor":
     # GEMM described above, then tranpose the output back.
     from tripy.frontend.trace.ops.permute import permute
     from tripy.frontend.ops.tensor_initializers import triu, ones
+
+    dim = frontend_utils.process_dim(dim, input.rank)
 
     # For the examples in the comments that follow, assume the input shape is (3, 5, 7) and
     # we are applying cumsum over dim=1 (the dimension of length 5).

--- a/tripy/tripy/frontend/ops/repeat.py
+++ b/tripy/tripy/frontend/ops/repeat.py
@@ -27,7 +27,6 @@ from tripy.frontend import utils as frontend_utils
         "T1": ["float32", "float16", "bfloat16", "int4", "float8", "int8", "int32", "int64", "bool"],
     },
 )
-@frontend_utils.process_dim()
 def repeat(input: "tripy.Tensor", repeats: Union[int, "tripy.DimensionSize"], dim: int) -> "tripy.Tensor":
     """
     Repeats each element of a tensor after itself along the specified dimension.
@@ -71,6 +70,8 @@ def repeat(input: "tripy.Tensor", repeats: Union[int, "tripy.DimensionSize"], di
     from tripy.frontend.ops.unsqueeze import unsqueeze
     from tripy.frontend.trace.ops.expand import expand
     from tripy.frontend.trace.ops.reshape import reshape
+
+    dim = frontend_utils.process_dim(dim, input.rank)
 
     if isinstance(repeats, int):
         if repeats < 0:

--- a/tripy/tripy/frontend/trace/ops/convolution.py
+++ b/tripy/tripy/frontend/trace/ops/convolution.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import tripy.frontend.trace.ops.utils as op_utils
-from tripy import constraints, utils
+from tripy import constraints
 from tripy.frontend.trace.ops.base import BaseTraceOp
 
 
@@ -30,35 +30,6 @@ class Convolution(BaseTraceOp):
     groups: int
     lhs_dilation: Sequence[int]
     rhs_dilation: Sequence[int]
-
-    def verify_spatial_rank(self, attr, rank, string):
-        spatial_rank = rank - 2
-        if attr and len(attr) != spatial_rank:
-            utils.raise_error_io_info(
-                self,
-                f"Number of {string} values does not match number of spatial dimensions in the input.",
-                details=[
-                    f"Got {len(attr)} {string} value pairs but the number of spatial dimensions is: {spatial_rank}.",
-                ],
-            )
-
-    def validate_inputs(self, tensor_shape, kernel_shape):
-        if len(tensor_shape) != len(kernel_shape):
-            utils.raise_error_io_info(
-                self,
-                "Input tensor and kernel must have the same rank.",
-                details=[
-                    f"Input tensor for operation: 'convolution' has shape: {tensor_shape} [rank = {len(tensor_shape)}], "
-                    f"but should have the same rank as the kernel of shape: {kernel_shape} [rank = {len(kernel_shape)}]."
-                ],
-            )
-
-        rank = len(tensor_shape)
-
-        self.verify_spatial_rank(self.padding, rank, "padding")
-        self.verify_spatial_rank(self.stride, rank, "stride")
-        self.verify_spatial_rank(self.lhs_dilation, rank, "lhs_dilation")
-        self.verify_spatial_rank(self.rhs_dilation, rank, "rhs_dilation")
 
     infer_rank = op_utils.InferRankPolicies.same_as_input()
 

--- a/tripy/tripy/frontend/trace/ops/iota.py
+++ b/tripy/tripy/frontend/trace/ops/iota.py
@@ -63,7 +63,7 @@ def iota_impl(shape: "tripy.Tensor", dim: int, dtype: datatype.dtype, output_ran
 @export.public_api(document_under="operations/initializers")
 @frontend_utils.convert_to_tensors(
     preprocess_args=lambda shape, dim=None, dtype=None: (
-        {"dim": dim if dim >= 0 else dim + len(shape)} if dim is not None else {}
+        {"dim": frontend_utils.process_dim(dim, len(shape))} if dim is not None else {}
     )
 )
 @constraints.dtypes(
@@ -104,7 +104,6 @@ def iota(shape: ShapeLike, dim: int = 0, dtype: datatype.dtype = datatype.float3
         "T2": ["float32", "float16", "bfloat16", "float8", "int4", "int8", "int32", "bool"],
     },
 )
-@frontend_utils.process_dim()
 def iota_like(input: "tripy.Tensor", dim: int = 0, dtype: Optional[datatype.dtype] = None) -> "tripy.Tensor":
     """
     Returns a tensor of the same shape and data type as the input tensor, with consecutive values
@@ -128,6 +127,8 @@ def iota_like(input: "tripy.Tensor", dim: int = 0, dtype: Optional[datatype.dtyp
 
         assert np.array_equal(cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32))
     """
+    dim = frontend_utils.process_dim(dim, input.rank)
+
     return iota_impl(
         frontend_utils.tensor_from_shape_like(input.shape),
         dim,

--- a/tripy/tripy/frontend/utils.py
+++ b/tripy/tripy/frontend/utils.py
@@ -315,37 +315,20 @@ def topological_sort(ops: List[Union["BaseTraceOp", BaseFlatIROp]]) -> List[Unio
 
 # Processes a `dim` (i.e. axis) argument related to a tensor.
 # If the dimension is negative, this will convert it to the corresponding positive index.
-#
-# NOTE: This is currently an extremely specialized decorator that expects an `input` tensor
-# argument and a `dim` argument for the axis.
-# In the future, we can generalize this and use it more broadly.
-def process_dim():
-    def process_dim_impl(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            input = utils.get_arg_by_name("input", func, *args, **kwargs)
+def process_dim(dim: int, input_rank: int) -> int:
+    new_dim = dim
+    if dim < 0:
+        new_dim = input_rank + dim
 
-            def process_dim(dim: int) -> int:
-                new_dim = dim
-                if dim < 0:
-                    new_dim = input.rank + dim
-
-                if new_dim < 0 or new_dim >= input.rank:
-                    raise_error(
-                        "Dimension argument is out of bounds.",
-                        [
-                            f"Note: provided dimension was: {dim}, while the tensor has a rank of: {input.rank}.\n"
-                            f"Dimension should be in the half-open interval: [{-input.rank}, {input.rank})."
-                        ],
-                    )
-                return new_dim
-
-            args, kwargs = utils.modify_arg("dim", process_dim, func, *args, **kwargs)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return process_dim_impl
+    if new_dim < 0 or new_dim >= input_rank:
+        raise_error(
+            "Dimension argument is out of bounds.",
+            [
+                f"Note: provided dimension was: {dim}, while the tensor has a rank of: {input_rank}.\n"
+                f"Dimension should be in the half-open interval: [{-input_rank}, {input_rank})."
+            ],
+        )
+    return new_dim
 
 
 def pretty_print(data_list, shape, threshold=1000, linewidth=10, edgeitems=3):

--- a/tripy/tripy/utils/ast.py
+++ b/tripy/tripy/utils/ast.py
@@ -16,9 +16,7 @@
 #
 
 import ast
-import inspect
-import textwrap
-from typing import Callable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from tripy.utils.result import Result
 from tripy.utils.stack_info import SourceInfo
@@ -181,25 +179,3 @@ def get_candidate_column_offsets(cur_frame: SourceInfo, callee: SourceInfo) -> L
             candidate_column_offsets.append((indentation + node.col_offset, indentation + node.end_col_offset))
 
     return candidate_column_offsets
-
-
-def find_node_in_method(method, node_finder: Callable) -> List[str]:
-    """
-    Returns a list of source line of code where node is found.
-
-    Args:
-        method: Source function where node is searched.
-        node_finder (Callable): User function that takes (node, source) and returns a bool whether node is found in ast or not.
-
-    Returns:
-        List[str]: List of source line of code
-    """
-    source = textwrap.dedent(inspect.getsource(method))
-    tree = ast.parse(source)
-    source = source.splitlines()
-    nodes_found = []
-    for node in ast.walk(tree):
-        if node_finder(node, source):
-            nodes_found.append(source[node.lineno - 1].strip())
-
-    return nodes_found

--- a/tripy/tripy/utils/utils.py
+++ b/tripy/tripy/utils/utils.py
@@ -254,21 +254,6 @@ def constant_fields(field_names: Sequence[str]):
 ##
 
 
-def find_file_in_dir(file_name: str, search_directory: str) -> List:
-    """
-    Search for file_name recursively in the root_directory.
-
-    Args:
-        file_name: The file name or pattern with wildcards.
-        search_directory: The root directory from where to search for file_name.
-    Returns:
-        List of absolute path for matching files.
-    """
-    search_pattern = os.path.join(search_directory, "**", file_name)
-    matching_files = glob.glob(search_pattern, recursive=True)
-    return matching_files
-
-
 def warn_if_wrong_mode(file_like: typing.IO, mode: str):
     def binary(mode):
         return "b" in mode
@@ -456,31 +441,3 @@ def merge_function_arguments(func, *args, **kwargs):
     all_args = get_positional_arg_names(func, *args)
     all_args.extend(kwargs.items())
     return all_args
-
-
-def get_arg_by_name(name, func, *args, **kwargs):
-    if name in kwargs:
-        return kwargs[name]
-
-    args = dict(get_positional_arg_names(func, *args))
-    if name in args:
-        return args[name]
-
-    assert False, f"No such argument: {name}"
-
-
-def modify_arg(name, modify_func, func, *args, **kwargs):
-    """
-    Modifies an argument corresponding to the provided name if it is present.
-    `modify_func` should be a function that accepts the argument and returns the modified argument.
-    """
-    if name in kwargs:
-        kwargs[name] = modify_func(kwargs[name])
-
-    all_args = get_positional_arg_names(func, *args)
-    args = list(args)
-    for index, (arg_name, _) in enumerate(all_args):
-        if name == arg_name:
-            args[index] = modify_func(args[index])
-
-    return args, kwargs


### PR DESCRIPTION
- Updates plugin test to check for shapes

- Makes process_dim a regular function instead of a decorator. Making `process_dim` a decorator is overkill and complicates the stack infomation unnecessarily. This change makes it a regular function so that it can be used more broadly.

- Removes dead code

- Fixes a typo in the profiling section of the README

- Makes datatype constraints tests significantly faster by not evaluating inputs.