### PR TITLE
[mlir-tensorrt][tensorrt] Fix an issue in linspace op conversion

### DIFF
--- a/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
@@ -365,8 +365,13 @@ nvinfer1::ILayer *NvInferNetworkEncoder::addFillLayer(
     std::optional<double> alpha, std::optional<double> beta,
     nvinfer1::ITensor *dynamicAlpha, nvinfer1::ITensor *dynamicBeta) {
 #if MLIR_TRT_COMPILE_TIME_TENSORRT_VERSION_GTE(9, 1, 0)
-  nvinfer1::IFillLayer *layer =
-      network->addFill(staticShape, fillOperation, elementType);
+  nvinfer1::IFillLayer *layer{nullptr};
+  if (dynamicShape != nullptr) {
+    nvinfer1::Dims emptyDims{};
+    layer = network->addFill(emptyDims, fillOperation, elementType);
+  } else {
+    layer = network->addFill(staticShape, fillOperation, elementType);
+  }
   return populateFillLayerParameters(layer, staticShape, dynamicShape, alpha,
                                      beta, dynamicAlpha, dynamicBeta);
 #else

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/linspace.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/linspace.mlir
@@ -8,15 +8,12 @@ func.func @trt_fill_linspace() -> tensor<1024xf32> {
   return %0 : tensor<1024xf32>
 }
 
-
-
 // CHECK-LABEL: @trt_fill_linspace_i32
 //  CHECK-SAME: tensorrt.engine
 func.func @trt_fill_linspace_i32() -> tensor<1024xi32> {
   %0 = tensorrt.linspace [0.0][static][1.0] : tensor<1024xi32>
   return %0 : tensor<1024xi32>
 }
-
 
 // CHECK-LABEL: @trt_fill_linspace_dynamic
 //  CHECK-SAME: tensorrt.engine
@@ -27,3 +24,14 @@ func.func @trt_fill_linspace_dynamic() -> tensor<1024x1024xf32> {
   %0 = tensorrt.linspace [%start:tensor<f32>][%shape:tensor<2xi32>][%step:tensor<2xf32>] : tensor<1024x1024xf32>
   return %0 : tensor<1024x1024xf32>
 }
+
+func.func @trt_fill_linspace_dynamic_dim(%arg0: tensor<?x32xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [1, 32], opt = [64, 32], max = [64, 32]>}) -> tensor<?xf32> {
+    %cst_i32 = tensorrt.constant dense<0> : tensor<1xi32>
+    %0 = tensorrt.shape %arg0 : tensor<?x32xf32> -> tensor<2xi32>
+    %1 = tensorrt.gather {axis = 0 : i64} ins(%0, %cst_i32 : tensor<2xi32>, tensor<1xi32>) -> tensor<1xi32>
+    %2 = tensorrt.linspace[0.000000e+00] [%1 : tensor<1xi32>] [1.000000e+00] : tensor<?xi32>
+    %3 = tensorrt.cast %2 : tensor<?xi32> to tensor<?xf32>
+    return %3 : tensor<?xf32>
+}
+// CHECK-LABEL: @trt_fill_linspace_dynamic_dim
+//  CHECK-SAME: tensorrt.engine


### PR DESCRIPTION
This PR fixes an issue in linspace op conversion which was failing if output of linspace op is dynamic. With this change, if dynamic shape input is provided, IFillLayer is initialized with empty dims first and later dimensions are set to dynamic shape tensor.

Fixes https://github.com/NVIDIA/TensorRT-Incubator/issues/320