### PR TITLE
Adds a warning if a tensor is evaluated while compiling

### DIFF
--- a/tripy/tests/common/test_exception.py
+++ b/tripy/tests/common/test_exception.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from tests import helper
 
 import tripy as tp
-from tripy.common.exception import TripyException, _get_function_file_and_lines, _make_stack_info_message, raise_error
+from tripy.common.exception import TripyException, _get_function_file_and_lines, str_from_stack_info, raise_error
 from tripy.frontend.utils import convert_to_tensors
 from tripy.utils import StackInfo, get_stack_info
 from tripy.utils.stack_info import SourceInfo
@@ -112,7 +112,7 @@ class TestRaiseError:
             ]
         )
 
-        error_msg = _make_stack_info_message(stack_info, enable_color=False)
+        error_msg = str_from_stack_info(stack_info, enable_color=False)
         assert (
             dedent(
                 """
@@ -156,5 +156,5 @@ class TestRaiseError:
                 """
         ).strip()
 
-        actual = _make_stack_info_message(stack_info, enable_color=False)
+        actual = str_from_stack_info(stack_info, enable_color=False)
         assert re.search(expected, actual) is not None

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -34,7 +34,7 @@ import torch
 
 import tripy as tp
 from tripy import utils
-from tripy.common.exception import _make_stack_info_message
+from tripy.common.exception import str_from_stack_info
 from tripy.frontend import Tensor
 from tripy.frontend.trace import Trace
 
@@ -74,7 +74,7 @@ def raises(ExcType: type, match: Optional[str] = None, has_stack_info_for: Seque
     has_stack_info_for = has_stack_info_for or []
     for tensor in has_stack_info_for:
         # Stack info is indented since it's part of the `details` block in `raise_error`
-        expected_stack_info = indent(_make_stack_info_message(tensor.stack_info).strip(), " " * 4)
+        expected_stack_info = indent(str_from_stack_info(tensor.stack_info).strip(), " " * 4)
         assert expected_stack_info in error_msg, f"Missing stack information for tensor:\n{expected_stack_info}"
 
 

--- a/tripy/tripy/common/exception.py
+++ b/tripy/tripy/common/exception.py
@@ -107,7 +107,7 @@ def _get_function_file_and_lines(func):
     return filename, start_line, start_line + len(lines)
 
 
-def _make_stack_info_message(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
+def str_from_stack_info(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
     from tripy.frontend.utils import convert_to_tensors
 
     EXCLUDE_FUNCTIONS = [convert_to_tensors]
@@ -187,9 +187,9 @@ def raise_error(summary: str, details: List[Any] = []):
     for detail in details:
         stack_info_message = None
         if hasattr(detail, "stack_info"):
-            stack_info_message = _make_stack_info_message(detail.stack_info)
+            stack_info_message = str_from_stack_info(detail.stack_info)
         elif isinstance(detail, utils.StackInfo):
-            stack_info_message = _make_stack_info_message(detail)
+            stack_info_message = str_from_stack_info(detail)
 
         if stack_info_message is not None:
             detail_msg += stack_info_message

--- a/tripy/tripy/frontend/module/module.py
+++ b/tripy/tripy/frontend/module/module.py
@@ -20,7 +20,7 @@ import operator
 from typing import Any, Dict, Iterator, List, Tuple, Union, Set, Sequence, TypeVar
 
 from tripy import export, utils
-from tripy.common.exception import raise_error, _make_stack_info_message
+from tripy.common.exception import raise_error, str_from_stack_info
 from tripy.frontend.module.parameter import Parameter
 from tripy.logging import logger
 
@@ -111,7 +111,7 @@ class Module:
             ):
                 stack_info = utils.get_stack_info()
                 stack_info.fetch_source_code()
-                stack_info_msg = _make_stack_info_message(stack_info)
+                stack_info_msg = str_from_stack_info(stack_info)
 
                 logger.warning(
                     "A container of mixed types will not be registered with this module's state_dict()."


### PR DESCRIPTION
In the case where a tensor is evaluated while compiling and then used in the computation graph, we throw an error. However, there are cases where the result of evaluation could make a round-trip through non-Tripy code, in which case we lose visibility. An example of this, assuming `a` and `b` are tensors, is:
```py
b = b + int(a.shape[0])
```

Here, `a.shape[0]` will be evaluated due to the `int` conversion and then used by the add operation with `b`. Because it was a Python integer in between, Tripy has no way to track that it actually came from an evaluated tensor.

Hence, this change prints warnings in these ambiguous cases when a tensor is evaluated while compiling. Here's an example of the warning messages:

```
[W] Tensor was evaluated while compiling which may cause unexpected behavior in the executable.
For example, this could cause values to be baked into the executable or dynamic shapes to become static.
If the result of the evaluation is not being used by other operations, you can safely ignore this warning.
[W] Note: Tensor was evaluated while compiling here:

--> /tripy/tests/backend/api/test_compile.py:174 in func()
      |
  174 |             print(a.shape)
      |             ^^^^^^^^^^^^^^

[2, 3]
[W] Note: Tensor was evaluated while compiling here:

--> /tripy/tests/backend/api/test_compile.py:176 in func()
      |
  176 |             c = a - int(a.shape[0])
      |                     ^^^^^^^^^^^^^^^

[W] Note: Tensor was evaluated while compiling here:

--> /tripy/tests/backend/api/test_compile.py:177 in func()
      |
  177 |             print(c)
      |             ^^^^^^^^
```