### PR TITLE
Adds release packaging pipeline and updates version to 0.0.3

### DIFF
--- a/.github/workflows/tripy-l1.yml
+++ b/.github/workflows/tripy-l1.yml
@@ -1,4 +1,4 @@
-# Perform L1 test, build and deploy docs
+# Ensure that documentation builds and run L1 tests.
 name: Tripy L1
 
 on:
@@ -9,12 +9,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -24,9 +18,6 @@ concurrency:
 jobs:
   l1-test:
     runs-on: tripy-self-hosted
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     container:
       image: ghcr.io/nvidia/tensorrt-incubator/tripy:latest
       volumes:
@@ -34,21 +25,12 @@ jobs:
       options: --gpus all
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/configure-pages@v5
 
     - name: build-docs
       run: |
         cd /tripy/
         python3 docs/generate_rsts.py
         sphinx-build build/doc_sources build/docs -c docs/ -j 4 -W -n
-        cp docs/packages.html build/docs/
-
-    - uses: actions/upload-pages-artifact@v3
-      with:
-        path: "/tripy/build/docs"
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
 
     - name: l1-test
       run: |

--- a/.github/workflows/tripy-release.yml
+++ b/.github/workflows/tripy-release.yml
@@ -1,0 +1,59 @@
+# Builds Tripy wheels and documentation and deploys them to GitHub releases and pages respectively.
+name: Tripy Release Pipeline
+
+on:
+  push:
+    tags:
+      - "tripy-v*.*.*"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    runs-on: tripy-self-hosted
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    container:
+      image: ghcr.io/nvidia/tensorrt-incubator/tripy:latest
+      volumes:
+        - ${{ github.workspace }}/tripy:/tripy
+      options: --gpus all
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/configure-pages@v5
+
+    - name: build-docs
+      run: |
+        cd /tripy/
+        python3 docs/generate_rsts.py
+        sphinx-build build/doc_sources build/docs -c docs/ -j 4 -W -n
+        cp docs/packages.html build/docs/
+
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: "/tripy/build/docs"
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+
+    - name: build-package
+      run: |
+        cd /tripy/
+        python3 -m build .
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: /tripy/dist/tripy-*.whl

--- a/tripy/README.md
+++ b/tripy/README.md
@@ -20,13 +20,43 @@ user experience without compromising performance. Some of the features of Tripy 
 
 ## Installation
 
+<!-- Tripy: DOC: OMIT Start -->
+### Installing Prebuilt Wheels
+<!-- Tripy: DOC: OMIT End -->
+
 ```bash
 python3 -m pip install --no-index -f https://nvidia.github.io/TensorRT-Incubator/packages.html tripy --no-deps
 python3 -m pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html tripy
 ```
 
+***Important:** There is another package named `tripy` on PyPI.*
+*Note that it is **not** the package from this repository.*
+*Please use the instructions above to ensure you install the correct package.*
+
 <!-- Tripy: DOC: OMIT Start -->
-If you want to build from source, please follow the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md).
+### Building Wheels From Source
+
+To get the latest changes in the repository, you can build Tripy wheels from source.
+
+1. Make sure `build` is installed:
+
+    ```bash
+    python3 -m pip install build
+    ```
+
+2. From the [`tripy` root directory](.), run:
+
+    ```bash
+    python3 -m build .
+    ```
+
+3. Install the wheel, which should have been created in the `dist/` directory.
+    From the [`tripy` root directory](.), run:
+
+    ```bash
+    python3 -m pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html dist/tripy-*.whl
+    ```
+
 <!-- Tripy: DOC: OMIT End -->
 
 ## Quickstart

--- a/tripy/RELEASE.md
+++ b/tripy/RELEASE.md
@@ -1,0 +1,23 @@
+# Releasing Tripy
+
+This document explains how to release a new version of Tripy.
+
+1. Update version numbers in [`pyproject.toml`](./pyproject.toml) and
+    [`__init__.py`](./tripy/__init__.py) (make sure they match!).
+
+2. Add a new entry to [`packages.html`](./docs/packages.html).
+    This ensures that we will be able to `pip install` Tripy.
+
+3. If there were any other functional changes since the most recent
+    L1, make sure to run L1 testing locally.
+
+4. Create a PR with the above two changes.
+
+5. Once the PR created in (4) is merged, create a new tag with:
+    ```bash
+    git tag tripy-vX.Y.Z
+    ```
+    replacing `X.Y.Z` with the version number and push it to the repository.
+
+    This should trigger our release pipeline, which will build and deploy
+    the documentation and create a GitHub release with the wheel.

--- a/tripy/docs/packages.html
+++ b/tripy/docs/packages.html
@@ -10,6 +10,9 @@
 <body>
     <h1>Package Index</h1>
     <a
+        href="https://github.com/NVIDIA/TensorRT-Incubator/releases/download/tripy-v0.0.3/tripy-0.0.3-py3-none-any.whl">tripy-0.0.3-py3-none-any.whl</a><br>
+
+    <a
         href="https://github.com/NVIDIA/TensorRT-Incubator/releases/download/tripy-v0.0.2/tripy-0.0.2-py3-none-any.whl">tripy-0.0.2-py3-none-any.whl</a><br>
 
     <a
@@ -65,7 +68,7 @@
         href="https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.32/mlir_tensorrt_runtime-0.1.32+cuda12.trt102-cp312-cp312-linux_x86_64.whl">mlir_tensorrt_runtime-0.1.32+cuda12.trt102-cp312-cp312-linux_x86_64.whl</a><br>
     <a
         href="https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.32/mlir_tensorrt_runtime-0.1.32+cuda12.trt102-cp39-cp39-linux_x86_64.whl">mlir_tensorrt_runtime-0.1.32+cuda12.trt102-cp39-cp39-linux_x86_64.whl</a><br>
-    
+
     <a
         href="https://github.com/NVIDIA/TensorRT-Incubator/releases/download/mlir-tensorrt-v0.1.34/mlir_tensorrt_compiler-0.1.34+cuda12.trt102-cp310-cp310-linux_x86_64.whl">mlir_tensorrt_compiler-0.1.34+cuda12.trt102-cp310-cp310-linux_x86_64.whl</a><br>
     <a

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tripy"
-version = "0.0.2"
+version = "0.0.3"
 authors = [{name = "NVIDIA", email="svc_tensorrt@nvidia.com"}]
 description = "Tripy: A Python Programming Model For TensorRT"
 readme = "README.md"

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -311,8 +311,8 @@ class Marker:
     @staticmethod
     def from_name(name: str) -> "Marker":
         return Marker(
-            matches_start_func=lambda line: line == f"<!-- Tripy: {name} Start -->",
-            matches_end_func=lambda line: line == f"<!-- Tripy: {name} End -->",
+            matches_start_func=lambda line: f"Tripy: {name} Start" in line,
+            matches_end_func=lambda line: f"Tripy: {name} End" in line,
         )
 
 

--- a/tripy/tests/test_packaging.py
+++ b/tripy/tests/test_packaging.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tests import helper
+import tempfile
+import glob
+import os
+import tripy as tp
+import pytest
+
+
+@pytest.mark.l1
+def test_wheel_packaging_and_install(virtualenv):
+    with helper.raises(Exception, "returned non-zero exit status"):
+        virtualenv.run([virtualenv.python, "-c", "import tripy"])
+
+    virtualenv.install_package("build")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        virtualenv.run([virtualenv.python, "-m", "build", ".", "-o", tmp], cwd=helper.ROOT_DIR)
+
+        wheel_paths = glob.glob(os.path.join(tmp, "*.whl"))
+        assert len(wheel_paths) == 1, "Expected exactly one wheel file."
+
+        wheel_path = wheel_paths[0]
+        assert os.path.basename(wheel_path) == f"tripy-{tp.__version__}-py3-none-any.whl"
+
+        virtualenv.run(
+            [
+                virtualenv.python,
+                "-m",
+                "pip",
+                "install",
+                wheel_path,
+                # Needed to install MLIR-TRT:
+                "-f",
+                "https://nvidia.github.io/TensorRT-Incubator/packages.html",
+                # For some reason, using the cache causes pip not to correctly install TRT
+                # if this test is run multiple times in succession.
+                "--no-cache-dir",
+            ]
+        )
+
+        assert "tripy" in virtualenv.installed_packages()
+        tripy_pkg = virtualenv.installed_packages()["tripy"]
+        assert tripy_pkg.version == tp.__version__
+
+        # Check that we only package things we actually want.
+        # If tests are packaged, they'll end up in a higher-level directory.
+        assert not os.path.exists(os.path.join(tripy_pkg.source_path, "tests"))
+
+        # Lastly check we can actually import it and run a simple sanity test:
+        virtualenv.run(
+            [
+                virtualenv.python,
+                "-c",
+                "import tripy as tp; x = tp.ones((5,), dtype=tp.int32); assert x.tolist() == [1] * 5",
+            ]
+        )

--- a/tripy/tripy/__init__.py
+++ b/tripy/tripy/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 # Import TensorRT to make sure all dependent libraries are loaded first.
 import tensorrt


### PR DESCRIPTION
Adds a release packaging pipeline which will build and deploy the documentation
and push wheels to a GitHub release when a matching tag is pushed.

This change also updates L1 to no longer push documentation. This ensures that
the published documentation is always aligned with the latest wheel.