### PR TITLE
Pins versions for release pipeline dependencies

### DIFF
--- a/.github/workflows/tripy-release.yml
+++ b/.github/workflows/tripy-release.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/configure-pages@v5
-
     - name: build-package
       run: |
         cd /tripy/
@@ -51,6 +49,9 @@ jobs:
       with:
         generate_release_notes: true
         files: /tripy/dist/tripy-*.whl
+        fail_on_unmatched_files: true
+
+    - uses: actions/configure-pages@v5
 
     - uses: actions/upload-pages-artifact@v3
       with:

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -22,8 +22,8 @@ Documentation = "https://nvidia.github.io/TensorRT-Incubator/"
 
 [build-system]
 requires = [
-  "setuptools>=45",
-  "wheel",
+  "setuptools==75.3.0",
+  "wheel==0.44.0",
   # For stubgen:
   "mypy==1.11.0",
 ]
@@ -34,8 +34,8 @@ dev = [
   "pre-commit==3.6.0",
 ]
 build = [
-  "setuptools>=45",
-  "wheel",
+  "setuptools==75.3.0",
+  "wheel==0.44.0",
   # For stubgen:
   "mypy==1.11.0",
 ]


### PR DESCRIPTION
Pins versions for packages required to build wheels to the correct versions. Older versions do not build the package correctly (missing files and metadata).