### PR TITLE
Fixes nanogpt, various other fixes

### DIFF
--- a/tripy/README.md
+++ b/tripy/README.md
@@ -1,10 +1,11 @@
+
+# Tripy: A Python Programming Model For TensorRT
+
 <!-- Tripy: DOC: OMIT Start -->
-[**Installation**](#installation) | [**Quickstart**](#quickstart) | [**Documentation**](#documentation) | [**Examples**](#examples)
+[**Installation**](#installation) | [**Quickstart**](#quickstart) | [**Documentation**](https://nvidia.github.io/TensorRT-Incubator/) | [**Examples**](./examples) | [**Contributing**](./CONTRIBUTING.md)
 
 [![Tripy L1](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml/badge.svg)](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml)
 <!-- Tripy: DOC: OMIT End -->
-
-# Tripy: A Python Programming Model For TensorRT
 
 Tripy is a Python programming model for [TensorRT](https://developer.nvidia.com/tensorrt) that aims to provide an excellent
 user experience without compromising performance. Some of the features of Tripy include:
@@ -101,22 +102,3 @@ print(compiled_add(tp.Tensor([1., 2., 3.]), tp.Tensor([3.])))
 For more details, see the
 [Introduction To Tripy](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/00-introduction-to-tripy.html)
 guide.
-
-
-<!-- Tripy: DOC: OMIT Start -->
-
-## Documentation
-
-The documentation is hosted [here](https://nvidia.github.io/TensorRT-Incubator/).
-
-
-## Examples
-
-The [examples](./examples/) directory includes end-to-end examples.
-
-
-## Contributing
-
-For information on how you can contribute to this project, see [CONTRIBUTING.md](./CONTRIBUTING.md)
-
-<!-- Tripy: DOC: OMIT End -->

--- a/tripy/README.md
+++ b/tripy/README.md
@@ -57,6 +57,12 @@ To get the latest changes in the repository, you can build Tripy wheels from sou
     python3 -m pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html dist/tripy-*.whl
     ```
 
+4. **[Optional]** To ensure that Tripy was installed correctly, you can run a sanity check:
+
+    ```bash
+    python3 -c "import tripy as tp; x = tp.ones((5,), dtype=tp.int32); assert x.tolist() == [1] * 5"
+    ```
+
 <!-- Tripy: DOC: OMIT End -->
 
 ## Quickstart

--- a/tripy/docs/post0_developer_guides/debugging.md
+++ b/tripy/docs/post0_developer_guides/debugging.md
@@ -1,9 +1,12 @@
 # Debugging MLIR-TensorRT backend
 
 1. Install new python bindings for compiler and runtime. Assuming `tripy/mlir-tensorrt` directory exists. No need to update `LD_LIBRARY_PATH`.
+
+<!-- Tripy: DOC: NO_EVAL Start -->
 	```bash
 	python3 -m pip install --force-reinstall mlir-tensorrt/build/wheels/trt100/**/*.whl
 	```
+<!-- Tripy: DOC: NO_EVAL End -->
 
 2. Set environment flags for debugging:
 
@@ -16,9 +19,11 @@
 3. Use LLDB for debugging MLIR-TensorRT backend.
 In order to use `lldb` in tripy container, launch the container with extra security options:
 
+<!-- Tripy: DOC: NO_EVAL Start -->
 ```bash
 docker run --gpus all --cap-add=SYS_PTRACE \
 	--security-opt seccomp=unconfined --security-opt apparmor=unconfined \
 	-p 8080:8080 -v $(pwd):/tripy/ -it --rm tripy:latest
 ```
+<!-- Tripy: DOC: NO_EVAL End -->
 See https://forums.swift.org/t/debugging-using-lldb/18046 for more details.

--- a/tripy/docs/post0_developer_guides/design-decisions.md
+++ b/tripy/docs/post0_developer_guides/design-decisions.md
@@ -129,6 +129,7 @@ Building our own stack has a few other advantages:
     exactly why the operation was inserted and which part of the user's Python code
     it originated from:
 
+<!-- Tripy: DOC: NO_EVAL Start -->
     ```bash
     --> example.py:11 in main()
         |
@@ -168,3 +169,4 @@ Building our own stack has a few other advantages:
         10  |     b = tp.ones((3, 3))
             |         ^^^^^^^^^^^^^^^
     ```
+<!-- Tripy: DOC: NO_EVAL End -->

--- a/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
+++ b/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
@@ -42,7 +42,7 @@ b = tp.arange(5)
 c = a + b + tp.tanh(a)
 end = time.time()
 
-print(f"Time to create 'c': {end - start:.3f} seconds.")
+print(f"Time to create 'c': {(end - start) * 1000:.3f} ms.")
 ```
 
 It looks like Tripy is very fast! While Tripy *execution* is very fast, compiling the program
@@ -57,7 +57,7 @@ start = time.time()
 print(c)
 end = time.time()
 
-print(f"Time to print 'c': {end - start:.3f} seconds.")
+print(f"Time to print 'c': {(end - start) * 1000:.3f} ms.")
 ```
 
 That is why the time to print `c` is so much higher than the time to create it.
@@ -127,8 +127,8 @@ out = mlp(inp)
 out.eval() # Recall that we need to evaluate in order to actually materialize `out`
 end = time.time()
 
-eager_time = (end - start)
-print(f"Eager mode time: {eager_time:.4f} seconds")
+eager_time = (end - start) * 1000
+print(f"Eager mode time: {eager_time:.4f} ms")
 
 ITERS = 10
 start = time.time()
@@ -137,8 +137,8 @@ for _ in range(ITERS):
     out.eval()
 end = time.time()
 
-compiled_time = (end - start) / ITERS
-print(f"Compiled mode average time: {(end - start) / ITERS:.4f} seconds")
+compiled_time = ((end - start) / ITERS) * 1000
+print(f"Compiled mode average time: {compiled_time:.4f} ms")
 # Make sure compiled mode is actually faster # doc: omit
 assert compiled_time < 0.01 * eager_time # doc: omit
 ```

--- a/tripy/docs/pre0_user_guides/01-quantization.md
+++ b/tripy/docs/pre0_user_guides/01-quantization.md
@@ -61,8 +61,8 @@ The quantization scales are not available unless the model was trained with QAT 
 We need to perform another step called calibration to compute the correct scales for each quantized layer.
 There are many ways to do calibration, one of which is using the `nvidia-modelopt` toolkit. To install it, run:
 
-```sh
-python3 -m pip install --extra-index-url https://pypi.nvidia.com nvidia-modelopt==0.11.0 transformers==4.44.2 datasets==2.21.0
+```bash
+python3 -m pip install --extra-index-url https://pypi.nvidia.com nvidia-modelopt==0.11.0 transformers==4.46.2 datasets==2.21.0
 ```
 
 First, let's get the pre-trained GPT model from hugging face:

--- a/tripy/examples/nanogpt/README.md
+++ b/tripy/examples/nanogpt/README.md
@@ -28,17 +28,17 @@ for expected accuracy.
     python3 example.py --input-text "What is the answer to life, the universe, and everything?"
     ```
 
-3. **[Optional]** You also use a fixed seed to ensure predictable outputs each time:
+3. **[Optional]** You can also use a fixed seed to ensure predictable outputs each time:
 
     ```bash
-    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=1
+    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0
     ```
 
     <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
     ```
     (?s).*?
-    What is the answer to life, the universe, and everything\? The answer to Aquinas, the most important thinker
+    What is the answer to life, the universe, and everything\? How can we get back at these questions\? And
     ```
      -->
     <!-- Tripy: TEST: EXPECTED_STDOUT End -->
@@ -47,34 +47,38 @@ for expected accuracy.
 
 This section shows how to run this example with different quantization modes.
 
-In `quantization.py`, we use `nvidia-modelopt` to quantize the pytorch GPT model, and then calibrate the quantization parameters. Then the quantization parameters are converted to scales and loaded into tripy model in function
-`load_quant_weights_from_hf` of `weight_loader.py`.
+In `quantization.py`, we use `nvidia-modelopt` to quantize the pytorch GPT model, and then calibrate the quantization parameters.
+Then the quantization parameters are converted to scales and loaded into the Tripy model by
+`load_quant_weights_from_hf` in [`weight_loader.py`](./weight_loader.py).
 
 To run with a quantization mode, pass `--quant-mode` to `example.py`. The supported modes are:
 
-1. weight only int8 quantization:
+1. Weight-only int8 quantization:
 
     ```bash
-    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=1 --quant-mode int8-weight-only
+    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0 --quant-mode int8-weight-only
     ```
     <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
     ```
     (?s).*?
-    What is the answer to life, the universe, and everything\? The answer to all of this is: I believe    ```
+    What is the answer to life, the universe, and everything\? How can one explain the existence of the universe to
+    ```
      -->
     <!-- Tripy: TEST: EXPECTED_STDOUT End -->
 
-2. weight only int4 quantization:
+2. Weight-only int4 quantization:
 
     ```bash
-    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=1 --quant-mode int4-weight-only
+    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0 --quant-mode int4-weight-only
     ```
-
-<!-- Tripy: TEST: XFAIL Start -->
-3. fp8 quantization:
-
-    ```bash
-    python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=1 --quant-mode fp8
+    <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
+    <!--
     ```
-<!-- Tripy: TEST: XFAIL End -->
+    (?s).*?
+    What is the answer to life, the universe, and everything\? What is what is what is what is what is
+    ```
+     -->
+    <!-- Tripy: TEST: EXPECTED_STDOUT End -->
+
+    *Note: `int4` quantization may result in poor accuracy. We include it here primarily to demonstrate the workflow.*

--- a/tripy/examples/nanogpt/example.py
+++ b/tripy/examples/nanogpt/example.py
@@ -72,7 +72,7 @@ def main():
         "--quant-mode",
         type=str,
         help="Quantization mode.",
-        choices=["int8-weight-only", "int4-weight-only", "fp8"],
+        choices=["int8-weight-only", "int4-weight-only"],
     )
 
     args = parser.parse_args()
@@ -97,6 +97,7 @@ def main():
     idx = tp.reshape(tp.Tensor(input_ids), shape=(1, len(input_ids)))
 
     # Compile the model before running inference.
+    print(f"Compiling the model (this may take a few seconds)...")
     compile_start_time = time.perf_counter()
     input_shape = (
         1,
@@ -137,7 +138,7 @@ def main():
     response = encoder.decode(torch.from_dlpack(idx[0, :]).tolist())
     end_time = time.perf_counter()
     print(f"Generating {args.max_new_tokens} tokens took {end_time - start_time} seconds.")
-    print(response)
+    print(f"\nResponse:\n{response}")
 
 
 if __name__ == "__main__":

--- a/tripy/examples/nanogpt/model.py
+++ b/tripy/examples/nanogpt/model.py
@@ -43,9 +43,6 @@ def linear_layer(config: GPTConfig, in_feat, out_feat, bias):
     elif config.quant_mode == "int4-weight-only":
         quant_kwargs["quant_dtype"] = tp.int4
         quant_kwargs["weight_quant_dim"] = None
-    elif config.quant_mode == "fp8":
-        quant_kwargs["quant_dtype"] = tp.float8
-        quant_kwargs["weight_quant_dim"] = None
 
     return tp.Linear(
         in_feat,
@@ -77,7 +74,7 @@ class CausalSelfAttention(tp.Module):
         qkv = self.c_attn(x)  # (batch_size, seq_len, 3 * embedding_size)
 
         # WAR for better accuracy and avoid TRT compilation error in fp16
-        if self.c_attn.quant_dtype in (tp.float8, tp.int4):
+        if self.c_attn.quant_dtype == tp.int4:
             qkv = tp.cast(qkv, tp.float32)
 
         q, k, v = tp.split(qkv, 3, dim=2)
@@ -164,11 +161,8 @@ class GPT(tp.Module):
         ), f"Cannot forward sequence of length {config.seq_len}, block size is only {config.block_size}"
 
         self.transformer = Transformer(config)
-        if config.quant_mode == "fp8":
-            self.lm_head = linear_layer(config, config.embedding_size, config.vocab_size, bias=False)
-        else:
-            # lm_head is disabled for int8 quantization
-            self.lm_head = tp.Linear(config.embedding_size, config.vocab_size, bias=False, dtype=config.dtype)
+        # Quantization is disabled for `lm_head`
+        self.lm_head = tp.Linear(config.embedding_size, config.vocab_size, bias=False, dtype=config.dtype)
 
     def __call__(self, idx):
         x = self.transformer(idx)

--- a/tripy/examples/nanogpt/quantization.py
+++ b/tripy/examples/nanogpt/quantization.py
@@ -38,8 +38,6 @@ def modelopt_quantize(model_hf, quant_mode):
         quant_cfg["quant_cfg"]["*input_quantizer"] = {
             "enable": False,
         }
-    elif quant_mode == "fp8":
-        quant_cfg = mtq.FP8_DEFAULT_CFG
     elif quant_mode == "int4-weight-only":
         quant_cfg = mtq.INT4_AWQ_CFG
     else:

--- a/tripy/examples/nanogpt/requirements.txt
+++ b/tripy/examples/nanogpt/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.40.1
+transformers==4.46.2
 tiktoken==0.5.2
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch==2.3.0

--- a/tripy/tests/frontend/module/test_linear.py
+++ b/tripy/tests/frontend/module/test_linear.py
@@ -15,19 +15,18 @@
 # limitations under the License.
 #
 
-import cupy as cp
 import pytest
+from tests import helper
 
 import tripy as tp
-from tests import helper
 
 
 class TestLinear:
     def test_linear_params(self):
         linear = tp.Linear(20, 30)
         assert isinstance(linear, tp.Linear)
-        assert cp.from_dlpack(linear.weight).get().shape == (30, 20)
-        assert cp.from_dlpack(linear.bias).get().shape == (30,)
+        assert linear.weight.shape == [30, 20]
+        assert linear.bias.shape == [30]
 
     def test_mismatched_input_shapes(self):
         a = tp.ones((2, 3))
@@ -51,11 +50,11 @@ class TestLinear:
         assert isinstance(qlinear, tp.Linear)
         assert qlinear.dtype == tp.float32
         assert qlinear.quant_dtype == quant_dtype
-        assert cp.from_dlpack(qlinear.weight).get().shape == (30, 20)
-        assert qlinear.weight_scale is None
-        assert qlinear.input_scale is None
-        assert cp.from_dlpack(qlinear.bias).get().shape == (30,)
+        assert qlinear.weight.shape == [30, 20]
+        assert qlinear.bias.shape == [30]
         assert qlinear.weight_quant_dim == weight_quant_dim
+        assert isinstance(qlinear.weight_scale, tp.Parameter)
+        assert isinstance(qlinear.input_scale, tp.Parameter)
 
     def test_load_quantized_params_from_state_dict(self):
         qlinear = tp.Linear(
@@ -66,6 +65,6 @@ class TestLinear:
         )
 
         qlinear.load_state_dict(
-            {"weight_scale": tp.Parameter(tp.ones((20,))), "input_scale": tp.Parameter(tp.ones((20,)))},
+            {"weight_scale": tp.Parameter(tp.ones((30,))), "input_scale": tp.Parameter(tp.ones((20,)))},
             strict=False,
         )

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -330,8 +330,10 @@ AVAILABLE_MARKERS = {
     "test: expected_stdout": Marker.from_name("TEST: EXPECTED_STDOUT"),
     # Marks that a block should be run under pytest.
     "test: use_pytest": Marker.from_name("TEST: USE_PYTEST"),
-    # Indicates that a block should be omitted from the rendered documentation.
+    # Indicates that a block should be omitted from the rendered documentation. Such blocks may still be evaluated.
     "doc: omit": Marker.from_name("DOC: OMIT"),
+    # Indicates that a block should not be evaluated for the documentation.
+    "doc: no_eval": Marker.from_name("DOC: NO_EVAL"),
 }
 
 

--- a/tripy/tests/integration/test_groupnorm.py
+++ b/tripy/tests/integration/test_groupnorm.py
@@ -15,19 +15,16 @@
 # limitations under the License.
 #
 
-import numpy as np
-import torch
 import pytest
+import torch
 
 import tripy as tp
-from tripy.common.exception import TripyException
 
 DTYPES = [(torch.float16, tp.float16), (torch.float32, tp.float32)]
 
 
 class TestGroupNorm:
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("torch_dtype, tp_dtype", DTYPES)
     @pytest.mark.parametrize("input_shape", [(1, 10, 2)])
     @pytest.mark.parametrize("num_groups", [2, 5])

--- a/tripy/tests/integration/test_layernorm.py
+++ b/tripy/tests/integration/test_layernorm.py
@@ -28,7 +28,6 @@ DTYPES = [(torch.float16, tp.float16), (torch.float32, tp.float32)]
 
 class TestLayerNorm:
 
-    @pytest.mark.l1
     @pytest.mark.parametrize("torch_dtype, tp_dtype", DTYPES)
     @pytest.mark.parametrize("input_shape", [(2, 2, 2)])
     @pytest.mark.parametrize("normalized_shape", [(2, 2), (2,)])

--- a/tripy/tests/test_packaging.py
+++ b/tripy/tests/test_packaging.py
@@ -66,22 +66,7 @@ def check_wheel(virtualenv, wheel_dir):
 
 
 @pytest.mark.l1
-def test_isolated_wheel_packaging_and_install(virtualenv):
-    # Tests wheel packaging and installation as an external user would do it.
-    with helper.raises(Exception, "returned non-zero exit status"):
-        virtualenv.run([virtualenv.python, "-c", "import tripy"])
-
-    virtualenv.install_package("build")
-
-    with tempfile.TemporaryDirectory() as tmp:
-        virtualenv.run([virtualenv.python, "-m", "build", ".", "-o", tmp], cwd=helper.ROOT_DIR)
-
-        check_wheel(virtualenv, tmp)
-
-
-@pytest.mark.l1
-def test_container_wheel_packaging_and_install(virtualenv):
-    # Tests wheel packaging as we do it in the development container.
+def test_wheel_packaging_and_install(virtualenv):
     with tempfile.TemporaryDirectory() as tmp:
         sp.run(["python3", "-m", "build", ".", "-n", "-o", tmp], cwd=helper.ROOT_DIR)
 

--- a/tripy/tripy/frontend/module/linear.py
+++ b/tripy/tripy/frontend/module/linear.py
@@ -53,7 +53,7 @@ class Linear(Module):
     r"""The quantization scale for input"""
 
     weight_quant_dim: Optional[int]
-    r"""The quantization dimension for weight"""
+    r"""The dimension along which to apply the weight quantization scale."""
 
     def __init__(
         self,
@@ -61,8 +61,8 @@ class Linear(Module):
         out_features: int,
         bias: bool = True,
         dtype: datatype.dtype = datatype.float32,
-        quant_dtype: datatype.dtype = None,
-        weight_quant_dim: int = None,
+        quant_dtype: Optional[datatype.dtype] = None,
+        weight_quant_dim: Optional[int] = None,
     ) -> None:
         """
         Args:
@@ -71,7 +71,7 @@ class Linear(Module):
             bias: Whether to include the bias term.
             dtype: The data type to use for the weight and bias parameters.
             quant_dtype: The data type for quantization.
-            weight_quant_dim: Quantization dimension of weights.
+            weight_quant_dim: The dimension along which to apply the weight quantization scale.
 
         .. code-block:: python
             :linenos:
@@ -100,6 +100,11 @@ class Linear(Module):
         self.weight_quant_dim = weight_quant_dim
         self.weight_scale = None
         self.input_scale = None
+        if quant_dtype is not None:
+            self.weight_scale = DefaultParameter(
+                shape=[self.weight._shape[weight_quant_dim]] if weight_quant_dim is not None else None, dtype=dtype
+            )
+            self.input_scale = DefaultParameter(shape=None, dtype=dtype)
 
     def __call__(self, x: "tripy.Tensor") -> "tripy.Tensor":
         r"""

--- a/tripy/tripy/frontend/module/module.py
+++ b/tripy/tripy/frontend/module/module.py
@@ -219,7 +219,7 @@ class Module:
             if missing_keys:
                 details.append(f"Missing keys: {missing_keys}\n")
             if unexpected_keys:
-                details.append(f"Unexpected keys: {unexpected_keys}")
+                details.append(f"Unexpected keys:\n{unexpected_keys}\n\nNote: Expected keys were:\n{expected_keys}")
             raise_error(
                 "state_dict is incompatible.",
                 details,


### PR DESCRIPTION
[Enables execution of shell blocks during documentation generation](https://github.com/NVIDIA/TensorRT-Incubator/commit/c7efe46185bcde15839b56c2b235ff075992b592)

Updates our documentation generation logic to allow execution of shell
blocks in guides and READMEs. This allows us to ensure that the content
of shell blocks is always functional.

Consequently, we also remove the packaging test that was previously used
as a proxy for running the packaging instructions in the README.

[Adds support for default parameters with unknown shapes, fixes linear](https://github.com/NVIDIA/TensorRT-Incubator/commit/e981b8bece25ed5d6d1966b61e94e64641cf22cf)

Updates `DefaultParameter` to allow unknown shapes. In such cases, we will
allow the member to be set to a parameter with any shape but a matching data type.

Also updates `Linear` to initialize scaling factors to default parameters when
quantization is enabled.

[Fixes nanoGPT](https://github.com/NVIDIA/TensorRT-Incubator/commit/81f1b093cc18ed3ef0161ac9ba5e2f8c1d5d195c)

- Removes `fp8` support since it wasn't working anyway.

- Updates the expected output blocks in the README to what the model actually generates.

- Updates `transfomers` dependency to get rid of a warning.