### PR TITLE
Improves docstrings for overloaded functions, updates README

### DIFF
--- a/tripy/README.md
+++ b/tripy/README.md
@@ -7,16 +7,19 @@
 [![Tripy L1](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml/badge.svg)](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml)
 <!-- Tripy: DOC: OMIT End -->
 
-Tripy is a Python programming model for [TensorRT](https://developer.nvidia.com/tensorrt) that aims to provide an excellent
-user experience without compromising performance. Some of the features of Tripy include:
+Tripy is a Python programming model for [TensorRT](https://developer.nvidia.com/tensorrt) that aims to provide
+an excellent user experience without compromising performance. Some of the goals of Tripy are:
 
 - **Intuitive API**: Tripy doesn't reinvent the wheel: If you have used NumPy or
     PyTorch before, Tripy APIs should feel familiar.
 
 - **Excellent Error Messages**: When something goes wrong, Tripy tries to provide
     informative and actionable error messages. Even in cases where the error comes
-    from deep within the software stack, Tripy is able to map it back to the Python code
-    that caused it.
+    from deep within the software stack, Tripy is usually able to map it back to the
+    related Python code.
+
+- **Friendly Documentation**: The documentation is meant to be accessible and comprehensive,
+    with plenty of examples to illustrate important points.
 
 
 ## Installation
@@ -72,6 +75,11 @@ We've included several guides in Tripy to make it easy to get started.
 We recommend starting with the
 [Introduction To Tripy](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/00-introduction-to-tripy.html)
 guide.
+
+Other features covered in our guides include:
+
+- [Compiling code (including dynamic shape support)](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/02-compiler.html)
+- [Quantization](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/01-quantization.html)
 
 To get an idea of the look and feel of Tripy, let's take a look at a short code example.
 All of the features used in this example are explained in more detail in the

--- a/tripy/docs/_static/style.css
+++ b/tripy/docs/_static/style.css
@@ -21,3 +21,14 @@ section {
     margin-top: 2rem;
     margin-bottom: 2rem;
 }
+
+.func-overload-sig {
+    padding-left: 3em !important;
+    color: var(--color-api-overall);
+    font-style: normal;
+}
+
+.func-overload-sig p {
+    margin-bottom: 0 !important;
+    margin-top: 0 !important;
+}

--- a/tripy/tripy/backend/api/executable.py
+++ b/tripy/tripy/backend/api/executable.py
@@ -23,7 +23,7 @@ from tripy.backend.mlir import Executor
 from tripy.backend.mlir import utils as mlir_utils
 from tripy.common.exception import raise_error
 from tripy.frontend import Tensor
-from tripy.function_registry import sanitize_name
+from tripy.function_registry import str_from_type_annotation
 from tripy.utils import json as json_utils
 from dataclasses import dataclass
 
@@ -73,8 +73,11 @@ class Executable:
         self._executor.stream = stream
 
     def __str__(self) -> str:
-        params = [f"{name}: {sanitize_name(param.annotation)}" for name, param in self.__signature__.parameters.items()]
-        return f"Executable({', '.join(params)}) -> {sanitize_name(self.__signature__.return_annotation)}"
+        params = [
+            f"{name}: {str_from_type_annotation(param.annotation)}"
+            for name, param in self.__signature__.parameters.items()
+        ]
+        return f"Executable({', '.join(params)}) -> {str_from_type_annotation(self.__signature__.return_annotation)}"
 
     @staticmethod
     def load(path: str) -> "tripy.Executable":

--- a/tripy/tripy/frontend/ops/tensor_initializers.py
+++ b/tripy/tripy/frontend/ops/tensor_initializers.py
@@ -292,7 +292,7 @@ def arange(
 ) -> "tripy.Tensor":
     r"""
     Returns a 1D tensor containing a sequence of numbers in the half-open interval
-    :math:`[0, \text{stop})` incrementing by :math:`\text{step}`.
+    :math:`[\text{start}, \text{stop})` incrementing by :math:`\text{step}`.
 
     Args:
         start: The inclusive lower bound of the values to generate. If a tensor is provided, it must be a scalar tensor.

--- a/tripy/tripy/function_registry.py
+++ b/tripy/tripy/function_registry.py
@@ -20,8 +20,8 @@ import inspect
 from collections import OrderedDict, defaultdict
 from collections.abc import Sequence as ABCSequence
 from dataclasses import dataclass
-from textwrap import dedent
-from typing import Any, Callable, Dict, ForwardRef, List, Sequence, Union, get_args, get_origin
+from textwrap import dedent, indent
+from typing import Any, Callable, Dict, ForwardRef, List, Sequence, Tuple, Union, get_args, get_origin
 
 
 def get_type_name(typ):
@@ -41,23 +41,31 @@ def get_type_name(typ):
     return module_name + typ.__qualname__
 
 
-def sanitize_name(annotation):
-    if get_origin(annotation) is Union and annotation._name == "Optional":
-        types = get_args(annotation)
-        return f"{annotation.__name__}[{sanitize_name(types[0])}]"
+def str_from_type_annotation(annotation, postprocess_annotation=None):
+    postprocess_annotation = postprocess_annotation or (lambda x: x)
 
-    if get_origin(annotation) in {Union, ABCSequence}:
+    if annotation is type(None):
+        return postprocess_annotation("None")
+
+    if isinstance(annotation, str):
+        return postprocess_annotation(annotation)
+
+    if get_origin(annotation) is Union:
+        types = list(get_args(annotation))
+        return " | ".join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)
+
+    if get_origin(annotation) in {ABCSequence, List, Tuple}:
         types = get_args(annotation)
-        return f"{annotation.__name__}[{', '.join(sanitize_name(typ) for typ in types)}]"
+        return f"{annotation.__name__}[{', '.join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)}]"
 
     if isinstance(annotation, ForwardRef):
-        return annotation.__forward_arg__
+        return postprocess_annotation(str(annotation.__forward_arg__))
 
     # typing module annotations are likely to be better when pretty-printed due to including subscripts
-    return annotation if annotation.__module__ == "typing" else get_type_name(annotation)
+    return postprocess_annotation(str(annotation) if annotation.__module__ == "typing" else get_type_name(annotation))
 
 
-def render_arg_type(arg: Any) -> str:
+def type_str_from_arg(arg: Any) -> str:
     # it is more useful to report more detailed types for sequences/tuples in error messages
     from typing import List, Tuple
 
@@ -65,12 +73,12 @@ def render_arg_type(arg: Any) -> str:
         if len(arg) == 0:
             return "List"
         # catch inconsistencies this way
-        arg_types = {render_arg_type(member) for member in arg}
+        arg_types = {type_str_from_arg(member) for member in arg}
         if len(arg_types) == 1:
             return f"List[{list(arg_types)[0]}]"
-        return f"List[Union[{', '.join(arg_types)}]]"
+        return f"List[{' | '.join(arg_types)}]"
     if isinstance(arg, Tuple):
-        return f"Tuple[{', '.join(map(render_arg_type, arg))}]"
+        return f"Tuple[{', '.join(map(type_str_from_arg, arg))}]"
 
     return get_type_name(type(arg))
 
@@ -89,7 +97,7 @@ class FuncOverload:
         # We *cannot* populate this at `__init__` time since that will be evaluated when the function
         # is first defined, at which point the required types in the annotations may not be accessible.
         # Instead, we populate this the first time the function is called.
-        self.annotations = None
+        self._annotations = None
 
     def __str__(self) -> str:
         from tripy.utils.utils import code_pretty_str
@@ -112,39 +120,41 @@ class FuncOverload:
         return pretty_code + "\n"
 
     def _get_annotations(self):
-        if self.annotations is None:
-            # Maps parameter names to their type annotations and a boolean indicating whether they are optional.
-            self.annotations: Dict[str, AnnotationInfo] = OrderedDict()
-            signature = inspect.signature(self.func)
-            for name, param in signature.parameters.items():
-                if name == "self":
-                    # Not likely to pass in the wrong `self` parameter, so we
-                    # don't require an annotation for it.
-                    annotation = Any
-                else:
-                    assert (param.annotation and param.annotation is not signature.empty) or param.kind in {
-                        inspect.Parameter.VAR_POSITIONAL,
-                        inspect.Parameter.VAR_KEYWORD,
-                    }, f"Non-variadic function parameters must have type annotations, but parameter: '{name}' of function: '{self.func.__name__}' has no type annotation!"
-                    annotation = param.annotation
-                    # In cases where a type is not available at the time of function definition, the type
-                    # annotation may be provided as a string. Since we need the actual type, we just
-                    # eval it here.
-                    if isinstance(annotation, str):
-                        try:
-                            # Import tripy so we can evaluate types from within tripy.
-                            import tripy
+        if self._annotations is not None:
+            return self._annotations
 
-                            annotation = eval(annotation)
-                        except Exception as e:
-                            raise NameError(
-                                f"Error while evaluating type annotation: '{annotation}' for parameter: '{name}' of function: '{self.func.__name__}'."
-                                f"\nNote: Error was: {e}"
-                            )
+        # Maps parameter names to their type annotations and a boolean indicating whether they are optional.
+        self._annotations: Dict[str, AnnotationInfo] = OrderedDict()
+        signature = inspect.signature(self.func)
+        for name, param in signature.parameters.items():
+            if name == "self":
+                # Not likely to pass in the wrong `self` parameter, so we
+                # don't require an annotation for it.
+                annotation = Any
+            else:
+                assert (param.annotation and param.annotation is not signature.empty) or param.kind in {
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD,
+                }, f"Non-variadic function parameters must have type annotations, but parameter: '{name}' of function: '{self.func.__name__}' has no type annotation!"
+                annotation = param.annotation
+                # In cases where a type is not available at the time of function definition, the type
+                # annotation may be provided as a string. Since we need the actual type, we just
+                # eval it here.
+                if isinstance(annotation, str):
+                    try:
+                        # Import tripy so we can evaluate types from within tripy.
+                        import tripy
 
-                self.annotations[name] = AnnotationInfo(annotation, param.default is not signature.empty, param.kind)
+                        annotation = eval(annotation)
+                    except Exception as e:
+                        raise NameError(
+                            f"Error while evaluating type annotation: '{annotation}' for parameter: '{name}' of function: '{self.func.__name__}'."
+                            f"\nNote: Error was: {e}"
+                        )
 
-        return self.annotations
+            self._annotations[name] = AnnotationInfo(annotation, param.default is not signature.empty, param.kind)
+
+        return self._annotations
 
     def matches_arg_types(self, args, kwargs) -> "Result":
         from itertools import chain
@@ -226,8 +236,8 @@ class FuncOverload:
             if not matches_type(name, annotation.type_info, arg):
                 return Result.err(
                     [
-                        f"For parameter: '{name}', expected an instance of type: '{sanitize_name(annotation.type_info)}' "
-                        f"but got argument of type: '{render_arg_type(arg)}'."
+                        f"For parameter: '{name}', expected an instance of type: '{str_from_type_annotation(annotation.type_info)}' "
+                        f"but got argument of type: '{type_str_from_arg(arg)}'."
                     ]
                 )
 
@@ -237,8 +247,8 @@ class FuncOverload:
                 if not matches_type(name, typ, arg):
                     return Result.err(
                         [
-                            f"For parameter: '{name}', expected an instance of type: '{sanitize_name(typ)}' "
-                            f"but got argument of type: '{render_arg_type(arg)}'."
+                            f"For parameter: '{name}', expected an instance of type: '{str_from_type_annotation(typ)}' "
+                            f"but got argument of type: '{type_str_from_arg(arg)}'."
                         ]
                     )
             elif not any(annotation.kind == inspect.Parameter.VAR_KEYWORD for annotation in annotations.values()):
@@ -387,30 +397,50 @@ class FunctionRegistry(dict):
                         if not f.__doc__:
                             return ""
 
+                        roles = ""
+
+                        def add_role(name, *additional_classes):
+                            nonlocal roles
+
+                            classes = [name] + list(additional_classes)
+                            roles += f".. role:: {name}\n    :class: {' '.join(classes)}\n"
+
+                        add_role("sig-prename", "descclassname")
+                        add_role("sig-name", "descname")
+
+                        # We cannot use `FuncOverload._get_annotations()` here because it is too early to be able
+                        # to import tripy to evaluate annotations.
                         signature = inspect.signature(f)
 
-                        def str_from_annotation(annotation):
-                            if isinstance(annotation, str):
-                                ret = annotation
-                            else:
-                                ret = annotation.__qualname__
-                            return f":class:`{ret}`"
+                        postprocess_annotation = lambda annotation: (
+                            f":class:`{annotation}`" if annotation.startswith("tripy.") else annotation
+                        )
 
                         def make_param_str(param):
-                            param_str = f"*{param.name}*: {str_from_annotation(param.annotation)}"
+                            param_str = (
+                                f"{param.name}: {str_from_type_annotation(param.annotation, postprocess_annotation)}"
+                            )
                             if param.default != signature.empty:
                                 param_str += f" = {param.default}"
                             return param_str
 
-                        sig_str = f"> **{key}** ({', '.join(make_param_str(param) for param in signature.parameters.values() if param.name != 'self')}) -> "
+                        sig_str = rf":sig-prename:`tripy`\ .\ :sig-name:`{key}`\ ({', '.join(make_param_str(param) for param in signature.parameters.values() if param.name != 'self')}) -> "
 
                         if signature.return_annotation != signature.empty:
-                            sig_str += f"{str_from_annotation(signature.return_annotation)}"
+                            sig_str += (
+                                f"{str_from_type_annotation(signature.return_annotation, postprocess_annotation)}"
+                            )
                         else:
                             sig_str += "None"
 
                         section_divider = "-" * 10
-                        return (f"""\n\n{section_divider}\n\n{sig_str}\n{dedent(f.__doc__)}""").strip()
+                        indent_prefix = " " * 4
+                        # We add a special `func-overload-sig` class here so we can correct the documentation
+                        # styling for signatures of overloaded functions.
+                        overload_doc = (
+                            f"""\n\n{section_divider}\n\n{dedent(roles).strip()}\n\n.. container:: func-overload-sig sig sig-object py\n\n{indent(sig_str, indent_prefix)}\n{dedent(f.__doc__)}"""
+                        ).strip()
+                        return overload_doc
 
                     # The first time we add an overload, we need to retroactively process the existing docstring
                     # to add signature information.


### PR DESCRIPTION
[Updates README to include links to common guides](https://github.com/NVIDIA/TensorRT-Incubator/commit/359f5089778edb476857cc017a036b6f891ec891)

[Improves docstrings for overloaded functions](https://github.com/NVIDIA/TensorRT-Incubator/commit/745f4586e60ee9967bab0cccf91b99cec84fb4f4)

Improves the docstrings for overloaded functions to be stylistically similar
to non-overloaded functions.

Also updates the helpers that generate strings from type annotations to be
more consistent with the style the documentation uses. For example, `Union[int, float]`
will now be rendered as `int | float`.