### PR TITLE
[tensorrt] Fix handling of dynamic shapes in `tensorrt-transpose-elimination`

### DIFF
--- a/mlir-tensorrt/tensorrt/lib/TensorRT/Transforms/TransposeElimination.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/Transforms/TransposeElimination.cpp
@@ -44,7 +44,10 @@ namespace tensorrt {
 using namespace mlir;
 using namespace mlir::tensorrt;
 
-static int64_t memoryCost(TensorType type) {
+static int64_t memoryCost(RankedTensorType type) {
+  // If the type is dynamic, then return max.
+  if (!type.hasStaticShape())
+    return std::numeric_limits<int64_t>::max();
   ArrayRef<int64_t> shape = type.getShape();
   return std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>());
 }


### PR DESCRIPTION
  Fixes an issue where the `tensorrt-transpose-elimination` pass did not correctly
    calculate cost for tensors that are dynamically shaped. After this change,
    the pass now considers any dynamically shaped tensor to have maximum cost;
    better heuristics would require that we move transpose elimination higher
    in the pipeline (e.g. to Plan dialect where we might have better information
    about shapes).

Fixes issue #368 

GitOrigin-RevId: 99e6260ee0c2679e1e6539e60b7840d9a90845b9