### PR TITLE
Move internal changes

### DIFF
--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/MaterializeShapeCalculations.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/MaterializeShapeCalculations.cpp
@@ -361,6 +361,9 @@ struct SimplifyExtractOfReshape : public OpRewritePattern<tensor::ExtractOp> {
     if (!reshapeOp)
       return failure();
 
+    if (!reshapeOp.getOperand().getType().hasStaticShape())
+      return failure();
+
     std::optional<SmallVector<int64_t>> coords =
         getConstantIntValues(getAsOpFoldResult(op.getIndices()));
     if (!coords)

--- a/mlir-tensorrt/test/models/bert.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/bert.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit__unnamed_wrapped_function_ attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @bert attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<32x8xi32> {mhlo.layout_mode = "default"}) -> (tensor<32x8x768xf16> {mhlo.layout_mode = "default"}, tensor<32x768xf16> {mhlo.layout_mode = "default"}) {
     %0 = stablehlo.constant dense_resource<__elided__> : tensor<30522x768xf32>
     %1 = stablehlo.constant dense_resource<__elided__> : tensor<512x768xf32>

--- a/mlir-tensorrt/test/models/gpt2.stablehlo.bs2.elided.mlir
+++ b/mlir-tensorrt/test/models/gpt2.stablehlo.bs2.elided.mlir
@@ -1,4 +1,4 @@
-module @jit_generate attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @gpt2_bs2 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<2x6xi32> {mhlo.sharding = "{replicated}"}, %arg1: tensor<2x6xi32> {mhlo.sharding = "{replicated}"}) -> (tensor<2x20xi32> {jax.result_info = ""}) {
     %0 = stablehlo.constant dense<0> : tensor<1xi32>
     %1 = stablehlo.constant dense<768> : tensor<i32>

--- a/mlir-tensorrt/test/models/gpt2.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/gpt2.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit_generate attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @gpt_bs1 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x7xi32> {jax.arg_info = "inputs['attention_mask']", mhlo.sharding = "{replicated}"}, %arg1: tensor<1x7xi32> {jax.arg_info = "inputs['input_ids']", mhlo.sharding = "{replicated}"}) -> (tensor<1x20xi32> {jax.result_info = ""}) {
     %0 = stablehlo.constant dense_resource<__elided__> : tensor<50257x768xf16>
     %1 = stablehlo.constant dense_resource<__elided__> : tensor<1024x768xf16>

--- a/mlir-tensorrt/test/models/llama-68m.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/llama-68m.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit_generate attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32, mhlo.use_auto_spmd_partitioning = false} {
+module @llama_68m attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32, mhlo.use_auto_spmd_partitioning = false} {
   func.func @main(%arg0: tensor<1x9xi32> {mhlo.sharding = "{replicated}"}, %arg1: tensor<1x9xi32> {mhlo.sharding = "{replicated}"}) -> tensor<1x20xi32> {
     %0 = stablehlo.constant dense<1.000000e+00> : tensor<1x1x3072xf32>
     %1 = stablehlo.constant dense<-3.40282347E+38> : tensor<1x1x1x20xf32>

--- a/mlir-tensorrt/test/models/llama-v2.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/llama-v2.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit__unnamed_wrapped_function_ attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @llama_v2 attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x27xf32> {mhlo.layout_mode = "default"}) -> (tensor<1x27x32000xf32> {mhlo.layout_mode = "default"}) {
     %0 = stablehlo.constant dense_resource<__elided__> : tensor<32000x4096xf16>
     %1 = stablehlo.constant dense_resource<__elided__> : tensor<4096xf16>

--- a/mlir-tensorrt/test/models/resnet50.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/resnet50.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit__unnamed_wrapped_function_ attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @resnet50 attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<16x3x224x224xf16> {mhlo.layout_mode = "default"}) -> (tensor<16x1000xf16> {mhlo.layout_mode = "default"}) {
     %0 = stablehlo.constant dense_resource<__elided__> : tensor<7x7x3x64xf32>
     %1 = stablehlo.constant dense_resource<__elided__> : tensor<64xf32>

--- a/mlir-tensorrt/test/models/swin.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/swin.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit_run attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32, mhlo.use_auto_spmd_partitioning = false} {
+module @swin attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32, mhlo.use_auto_spmd_partitioning = false} {
   func.func @main(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %cst = stablehlo.constant dense_resource<__elided__> : tensor<1x1000xf32>
     %cst_0 = stablehlo.constant dense_resource<__elided__> : tensor<1024x1000xf32>

--- a/mlir-tensorrt/test/models/whisper-jax.stablehlo.elided.mlir
+++ b/mlir-tensorrt/test/models/whisper-jax.stablehlo.elided.mlir
@@ -1,4 +1,4 @@
-module @jit_generate_fn attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+module @whisper_jax attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x80x3000xf32> {jax.arg_info = "input_features", mhlo.sharding = "{replicated}"}) -> (tensor<1x448xi32> {jax.result_info = ""}) {
     %0 = stablehlo.constant dense_resource<__elided__> : tensor<3x80x384xf32>
     %1 = stablehlo.constant dense_resource<__elided__> : tensor<384xf32>


### PR DESCRIPTION
This PR moves the following internal changes to OSS
repo.

## [plan][transforms] Fix an issue in shape materialization pass 

This MR fixes an issue in `SimplifyExtractOfReshape` pattern
of shape materialization pass. This patten was being
applied even when reshape op operand is dynamic. However,
with dynamic operand, mapping extract index into
reshape operand doesn't work.
With this change, we return failure if reshape op
operand is dynamic. MLIR test is added for scenario
when pattern should return failure.

## [tensorrt] Fix incorrect handling of dynamic shape in `tensorrt-broadcast-elimination`

Fixes an issue where a `tensorrt-broadcast-elimination` would improperly handle
dynamically shaped tensors when attempting to reshape them. In certain cases (when
more than 1 dynamic dimension is present), to perform a reshape, the target shape
must be explicitly calculated in the IR and a dynamic reshape must be created.