### PR TITLE
[compiler]  Fix CompilerClient CAPI destroy function

### DIFF
--- a/mlir-tensorrt/compiler/lib/CAPI/Compiler/Compiler.cpp
+++ b/mlir-tensorrt/compiler/lib/CAPI/Compiler/Compiler.cpp
@@ -90,12 +90,12 @@ MTRT_Status mtrtCompilerClientCreate(MlirContext context,
   if (!cppClient.isOk())
     return wrap(cppClient.getStatus());
 
-  *client = MTRT_CompilerClient{cppClient->release()};
+  *client = wrap(cppClient->release());
   return mtrtStatusGetOk();
 }
 
 MTRT_Status mtrtCompilerClientDestroy(MTRT_CompilerClient client) {
-  delete reinterpret_cast<MTRT_CompilerClient *>(client.ptr);
+  delete unwrap(client);
   return mtrtStatusGetOk();
 }
 


### PR DESCRIPTION
Fixes an issue where the `mtrtCompilerClientDestroy` function was not correctly
destroying the underlying C++ CompilerClient object.

GitOrigin-RevId: 39362fcb2fc2bf8233b4695fed5e6a3944cdf606