### PR TITLE
Exposes base `OptionsContext` class in the API

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
@@ -52,6 +52,29 @@ static inline bool mtrtCompilerClientIsNull(MTRT_CompilerClient options) {
 }
 
 //===----------------------------------------------------------------------===//
+// MTRT_OptionsContext
+//===----------------------------------------------------------------------===//
+
+typedef struct MTRT_OptionsContext {
+  void *ptr;
+} MTRT_OptionsContext;
+
+MLIR_CAPI_EXPORTED MTRT_Status mtrtOptionsContextCreateFromArgs(
+    MTRT_CompilerClient client, MTRT_OptionsContext *options,
+    MlirStringRef optionsType, const MlirStringRef *argv, unsigned argc);
+
+MLIR_CAPI_EXPORTED void mtrtOptionsContextPrint(MTRT_OptionsContext options,
+                                                MlirStringCallback append,
+                                                void *userData);
+
+MLIR_CAPI_EXPORTED MTRT_Status
+mtrtOptionsContextDestroy(MTRT_OptionsContext options);
+
+static inline bool mtrtOptionsConextIsNull(MTRT_OptionsContext options) {
+  return !options.ptr;
+}
+
+//===----------------------------------------------------------------------===//
 // MTRT_StableHLOToExecutableOptions
 //===----------------------------------------------------------------------===//
 

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsRegistry.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsRegistry.h
@@ -1,0 +1,87 @@
+//===- OptionsRegistry.h -----------------------------------------*- C++-*-===//
+//
+// SPDX-FileCopyrightText: Copyright 2024 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+///
+/// This is the top-level C++ interface for clients that wish to compile
+/// MLIR programs from a supported input (e.g. StableHLO) into a supported
+/// target (e.g. TensorRT engine). This file contains just the declarations for
+/// the CompilerClient object, see below for details.
+///
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_TENSORRT_COMPILER_OPTIONS_REGISTRY
+#define MLIR_TENSORRT_COMPILER_OPTIONS_REGISTRY
+
+#include "mlir-tensorrt-dialect/Utils/Options.h"
+#include "mlir-tensorrt/Compiler/Client.h"
+#include "mlir-tensorrt/Dialect/Plan/IR/Plan.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include <functional>
+
+namespace mlirtrt::compiler {
+
+using OptionsConstructorFuncT =
+    std::function<StatusOr<std::unique_ptr<mlir::OptionsContext>>(
+        const CompilerClient &client, const llvm::ArrayRef<llvm::StringRef>)>;
+
+/// Registers an options creation function for a specific options type.
+void registerOption(const llvm::StringRef optionsType,
+                    OptionsConstructorFuncT func);
+
+/// Creates an options instance for the specified options type using a creation
+/// function that was previously registered.
+StatusOr<std::unique_ptr<mlir::OptionsContext>>
+createOptions(const CompilerClient &client, const llvm::StringRef optionsType,
+              const llvm::ArrayRef<llvm::StringRef> args);
+
+/// Helper to build callbacks that can create options.
+template <typename OptionsT, typename TaskT>
+StatusOr<std::unique_ptr<mlir::OptionsContext>>
+optionsCreateFromArgs(const CompilerClient &client,
+                      const llvm::ArrayRef<llvm::StringRef> args) {
+  // Load available extensions.
+  mlir::MLIRContext *context = client.getContext();
+  mlir::plan::PlanDialect *planDialect =
+      context->getLoadedDialect<mlir::plan::PlanDialect>();
+  compiler::TaskExtensionRegistry extensions =
+      planDialect->extensionConstructors.getExtensionRegistryForTask<TaskT>();
+
+  auto result = std::make_unique<OptionsT>(std::move(extensions));
+
+  std::string err;
+  if (failed(result->parse(args, err))) {
+    return getInternalErrorStatus(
+        "failed to parse options string \"{0:$[ ]}\" due to error {1}",
+        llvm::iterator_range(args), err);
+  }
+
+  // TODO: Figure out whether to add a method in the base class like
+  // "finalizeOptions" or a callback here, or something else if
+  // `inferDeviceOptionsFromHost` is unique to StableHLO.
+  //
+  // Populate device options from host information.
+  Status inferStatus = result->inferDeviceOptionsFromHost();
+  if (!inferStatus.isOk())
+    return inferStatus;
+
+  return std::unique_ptr<mlir::OptionsContext>(result.release());
+}
+} // namespace mlirtrt::compiler
+
+#endif

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
@@ -189,6 +189,9 @@ public:
                                const StableHLOToExecutableOptions &options);
 };
 
+/// Register the task/options with the client's registry.
+void registerStableHloToExecutableTask();
+
 //===----------------------------------------------------------------------===//
 // Pipeline Registrations
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Registration/RegisterMlirTensorRtPasses.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Registration/RegisterMlirTensorRtPasses.h
@@ -53,6 +53,7 @@ inline void registerAllMlirTensorRtPasses() {
   mlir::registerConvertPDLToPDLInterp();
 
 #ifdef MLIR_TRT_ENABLE_HLO
+  mlirtrt::compiler::registerStableHloToExecutableTask();
   mlirtrt::compiler::registerStablehloClusteringPipelines();
   registerStableHloInputPipelines();
   stablehlo_ext::registerStableHloExtPasses();

--- a/mlir-tensorrt/compiler/lib/Compiler/CMakeLists.txt
+++ b/mlir-tensorrt/compiler/lib/Compiler/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_tensorrt_library(MLIRTensorRTCompilerClient
     Client.cpp
     Extension.cpp
+    OptionsRegistry.cpp
     PARTIAL_SOURCES_INTENDED
 
     LINK_LIBS PUBLIC

--- a/mlir-tensorrt/compiler/lib/Compiler/OptionsRegistry.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/OptionsRegistry.cpp
@@ -1,0 +1,40 @@
+//===- OptionsRegistry.cpp-------------------------------------------------===//
+//
+// SPDX-FileCopyrightText: Copyright 2024 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "mlir-tensorrt/Compiler/OptionsRegistry.h"
+#include "llvm/Support/ManagedStatic.h"
+
+using namespace mlirtrt::compiler;
+
+static llvm::ManagedStatic<llvm::StringMap<OptionsConstructorFuncT>> registry{};
+
+void mlirtrt::compiler::registerOption(const llvm::StringRef optionsType,
+                                       OptionsConstructorFuncT func) {
+  (*registry)[optionsType] = std::move(func);
+}
+
+mlirtrt::StatusOr<std::unique_ptr<mlir::OptionsContext>>
+mlirtrt::compiler::createOptions(const CompilerClient &client,
+                                 const llvm::StringRef optionsType,
+                                 const llvm::ArrayRef<llvm::StringRef> args) {
+  if (!registry->contains(optionsType))
+    return getInvalidArgStatus(
+        "{0} is not a valid option type. Valid options were: {1:$[ ]}",
+        optionsType, llvm::iterator_range(registry->keys()));
+  return (*registry)[optionsType](client, args);
+}

--- a/mlir-tensorrt/compiler/lib/Compiler/StableHloToExecutable.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/StableHloToExecutable.cpp
@@ -31,6 +31,7 @@
 #include "mlir-tensorrt-dialect/TensorRT/Transforms/Passes.h"
 #include "mlir-tensorrt/Compiler/Extension.h"
 #include "mlir-tensorrt/Compiler/Options.h"
+#include "mlir-tensorrt/Compiler/OptionsRegistry.h"
 #include "mlir-tensorrt/Compiler/TensorRTExtension/TensorRTExtension.h"
 #include "mlir-tensorrt/Conversion/Passes.h"
 #include "mlir-tensorrt/Dialect/Plan/Transforms/Passes.h"
@@ -519,6 +520,12 @@ static StableHLOToExecutableOptions populateStablehloClusteringPipelineOpts(
   opts.shouldInferDeviceOptionsFromHost = cliOpts.inferDeviceOptionsFromHost;
   opts.entrypoint = cliOpts.entrypoint;
   return opts;
+}
+
+void mlirtrt::compiler::registerStableHloToExecutableTask() {
+  registerOption("stable-hlo-to-executable",
+                 optionsCreateFromArgs<StableHLOToExecutableOptions,
+                                       StableHloToExecutableTask>);
 }
 
 void mlirtrt::compiler::registerStablehloClusteringPipelines() {

--- a/mlir-tensorrt/python/bindings/Utils.h
+++ b/mlir-tensorrt/python/bindings/Utils.h
@@ -163,7 +163,7 @@ public:
 
   static py::object createFromCapsule(py::object capsule) {
     if constexpr (cFuncTable.capsuleToCApi == nullptr) {
-      throw py::value_error("boject cannot be converted from opaque capsule");
+      throw py::value_error("object cannot be converted from opaque capsule");
     } else {
       MTRT_StableHLOToExecutableOptions cObj =
           cFuncTable.capsuleToCApi(capsule.ptr());

--- a/mlir-tensorrt/test/python/mlir_tensorrt_compiler/compiler_api/test_options_context.py
+++ b/mlir-tensorrt/test/python/mlir_tensorrt_compiler/compiler_api/test_options_context.py
@@ -1,0 +1,30 @@
+# REQUIRES: host-has-at-least-1-gpus
+# RUN: %PYTHON %s 2>&1 | FileCheck %s
+
+import mlir_tensorrt.compiler.api as api
+from mlir_tensorrt.compiler.ir import *
+
+
+with Context() as context:
+    client = api.CompilerClient(context)
+    # Try to create a non-existent option type
+    try:
+        opts = api.OptionsContext(client, "non-existent-options-type", [])
+    except Exception as err:
+        print(err)
+
+    opts = api.OptionsContext(
+        client,
+        "stable-hlo-to-executable",
+        [
+            "--tensorrt-builder-opt-level=3",
+            "--tensorrt-strongly-typed=false",
+            "--tensorrt-workspace-memory-pool-limit=1gb",
+        ],
+    )
+
+    print(opts)
+
+
+# CHECK: InvalidArgument: InvalidArgument: non-existent-options-type is not a valid option type. Valid options were: stable-hlo-to-executable
+# CHECK: --tensorrt-timing-cache-path= --device-infer-from-host=true --debug-only= --executor-index-bitwidth=64 --entrypoint=main --plan-clustering-disallow-host-tensors-in-tensorrt-clusters=false --tensorrt-workspace-memory-pool-limit=1073741824 --device-max-registers-per-block=65536 --tensorrt-strongly-typed=false --tensorrt-layer-info-dir= --device-compute-capability=86 --debug=false --mlir-print-ir-tree-dir= --disable-tensorrt-extension=false --tensorrt-builder-opt-level=3 --tensorrt-engines-dir=


### PR DESCRIPTION
In order to support more than just the StableHloToExecutable pipeline, we need to be able to create different option types from the API. This commit exposes the base `OptionsContext` class in the Python API and includes a mechanism for child classes to register themselves with the client, allowing them to be created through a common API.