### PR TITLE
Formats code in documentation with black

### DIFF
--- a/tripy/RELEASE.md
+++ b/tripy/RELEASE.md
@@ -5,15 +5,21 @@ This document explains how to release a new version of Tripy.
 1. Update version numbers in [`pyproject.toml`](./pyproject.toml) and
     [`__init__.py`](./tripy/__init__.py) (make sure they match!).
 
+    Often, updates to Tripy will also require updates to dependencies,
+    like MLIR-TRT, so make sure to update those version numbers as well.
+
 2. Add a new entry to [`packages.html`](./docs/packages.html).
     This ensures that we will be able to `pip install` Tripy.
 
 3. If there were any other functional changes since the most recent
     L1, make sure to run L1 testing locally.
 
-4. Create a PR with the above two changes.
+4. Create a PR with the above changes.
 
-5. Once the PR created in (4) is merged, create a new tag with:
+5. Once the PR created in (4) is merged, **WAIT FOR THE POST-MERGE PIPELINES TO COMPLETE**.
+    This is a very important step as otherwise the release pipeline could fail.
+
+    Once the post-merge pipelines have succeeded, create a new tag with:
     ```bash
     git tag tripy-vX.Y.Z
     ```

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -286,10 +286,9 @@ def process_docstring_impl(app, what, name, obj, options, lines):
 
         code_block_lines, local_var_lines, output_lines, _ = helper.process_code_block_for_outputs_and_locals(
             block,
-            block.code(),
             format_contents=lambda title, contents, lang: f"\n\n.. code-block:: {lang}\n"
             + indent((f":caption: {title}" if title else "") + f"\n\n{contents}", prefix=" " * helper.TAB_SIZE),
-            err_msg=f"Failed while processing docstring for: {what}: {name} ({obj})",
+            err_msg=f"Failed while processing docstring for: {what}: {name} ({obj}): ",
             strip_assertions=True,
         )
 

--- a/tripy/docs/generate_rsts.py
+++ b/tripy/docs/generate_rsts.py
@@ -208,9 +208,8 @@ def process_guide(guide_path: str, processed_guide_path: str):
             code_block_lines, local_var_lines, output_lines, code_locals = (
                 helper.process_code_block_for_outputs_and_locals(
                     block.raw_str(),
-                    str(block),
                     format_contents=add_block,
-                    err_msg=f"Error while executing code block from {guide_path}.",
+                    err_msg=f"Error while executing code block {index} (line {block.line_number}) from {guide_path}. ",
                     local_vars=code_locals,
                 )
             )

--- a/tripy/docs/post0_developer_guides/architecture.md
+++ b/tripy/docs/post0_developer_guides/architecture.md
@@ -3,7 +3,6 @@
 This document explains the overall architecture of Tripy.
 
 
-
 ## Overview
 
 The main technical requirement of Tripy is twofold:

--- a/tripy/docs/post0_developer_guides/debugging.md
+++ b/tripy/docs/post0_developer_guides/debugging.md
@@ -1,29 +1,37 @@
-# Debugging MLIR-TensorRT backend
+# Debugging MLIR-TensorRT
 
-1. Install new python bindings for compiler and runtime. Assuming `tripy/mlir-tensorrt` directory exists. No need to update `LD_LIBRARY_PATH`.
-
-<!-- Tripy: DOC: NO_EVAL Start -->
-	```bash
-	python3 -m pip install --force-reinstall mlir-tensorrt/build/wheels/trt100/**/*.whl
-	```
-<!-- Tripy: DOC: NO_EVAL End -->
-
-2. Set environment flags for debugging:
-
-- `export TRIPY_MLIR_DEBUG_ENABLED=1` to enable MLIR-TRT debugging. It will enable debugging prints in MLIR-TRT as well as dump all intermediate IRs after each pass.
-- `export TRIPY_MLIR_DEBUG_PATH=<mlir-debug-path>` to set debug path for MLIR-TRT dumps. Default path is `mlir-dumps` under the repo directory. This will create one or more folders named like `module_ins_t1_outs_t2_1`.
-- `export TRIPY_TRT_DEBUG_ENABLED=1` to enable TensorRT debugging. It will dump TensorRT engines and their layer information (if there are any TensorRT built during compilation).
-- `export TRIPY_TRT_DEBUG_PATH=<trt-debug-path>` to set debug path for TensorRT dumps. Default path is `tensorrt-dumps` under the repo directory.
+While developing Tripy features, you may need to debug MLIR-TRT code.
+This guide outlines some methods of doing so.
 
 
-3. Use LLDB for debugging MLIR-TensorRT backend.
-In order to use `lldb` in tripy container, launch the container with extra security options:
+## Environment Variables
+
+We include some environment variables to enable extra debugging information from MLIR-TRT:
+
+- `export TRIPY_MLIR_DEBUG_ENABLED=1` will enable debug prints in MLIR-TRT and dump all intermediate IRs to a directory.
+- `export TRIPY_MLIR_DEBUG_PATH=<mlir-debug-path>` sets the directory for IR dumps. The default path is `mlir-dumps`.
+- `export TRIPY_TRT_DEBUG_ENABLED=1` will dump TensorRT engines and their layer information.
+- `export TRIPY_TRT_DEBUG_PATH=<trt-debug-path>` sets the directory for TensorRT dumps. Default path is `tensorrt-dumps`.
+
+
+## Using A Debugger
+
+For more involved bugs, it may be helpful to step into MLIR-TRT code.
+To do so, you will need a debug build of MLIR-TRT;
+see [CONTRIBUTING.md](source:/CONTRIBUTING.md)
+for details on using custom builds of MLIR-TRT.
+
+Once you've installed the debug build in the container, you should be able to use `gdb` as normal.
+
+Alternatively, you can use [LLDB](https://lldb.llvm.org/) if you launch the container with extra security options:
 
 <!-- Tripy: DOC: NO_EVAL Start -->
 ```bash
 docker run --gpus all --cap-add=SYS_PTRACE \
-	--security-opt seccomp=unconfined --security-opt apparmor=unconfined \
-	-p 8080:8080 -v $(pwd):/tripy/ -it --rm tripy:latest
+    --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
+    -p 8080:8080 -v $(pwd):/tripy/ -it --rm tripy:latest
 ```
 <!-- Tripy: DOC: NO_EVAL End -->
-See https://forums.swift.org/t/debugging-using-lldb/18046 for more details.
+
+See [this post](https://forums.swift.org/t/debugging-using-lldb/18046) for details on
+why these security options are required.

--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -47,9 +47,10 @@ from tripy.flat_ir.ops.base import BaseFlatIROp
 class ThetaOp(BaseFlatIROp):
     dim: int
 
-    # `to_mlir()` is the trickiest bit. As the name implies, the method is meant to lower the
-    # `FlatIR` operator into MLIR. To figure out which MLIR operators to use, refer to
-    # the 'MLIR Python API Guide' (linked below).
+    # `to_mlir()` is the trickiest bit. As the name implies, the method is
+    # meant to lower the `FlatIR` operator into MLIR. To figure out which
+    # MLIR operators to use, refer to the 'MLIR Python API Guide'
+    # (linked below).
     def to_mlir(self, operands):
         out_type = self.outputs[0].to_mlir()
         theta_dim = ir.IntegerAttr.get(type=ir.IntegerType.get_signless(64), value=self.dim)
@@ -116,29 +117,31 @@ from tripy.frontend.trace.ops.base import BaseTraceOp
 import tripy.frontend.trace.ops.utils as op_utils
 
 
-# Just like with `FlatIR` operators, all `Trace` operators are implemented as `dataclass`es.
-# As before, we want `repr=False` here.
+# Just like with `FlatIR` operators, all `Trace` operators are implemented
+# as `dataclass`es. As before, we want `repr=False` here.
 @dataclass(repr=False)
 class Theta(BaseTraceOp):
-    # Notice that we do *not* need to define a constructor and can rely on the default
-    # implementation provided by `dataclass`.
+    # Notice that we do *not* need to define a constructor and can rely on
+    # the default implementation provided by `dataclass`.
     dim: int
     dtype: datatype.dtype
 
     # `infer_rank()` populates the rank of the output `TraceTensor`s.
-    # Here we use one of the predefined policies to set the output rank to the same as the shape (i.e. the length)
-    # of the shape operand.
+    # Here we use one of the predefined policies to set the output rank
+    # to the same as the shape (i.e. the length) of the shape operand.
     infer_rank = op_utils.InferRankPolicies.same_as_shape_of_shape_input()
 
     # *Optional* `infer_dtypes()` populates the data types of the
     # output `TraceTensor`s. The default implementation copies the input
-    # data types if they are all the same, so you may not need to implement this.
+    # data types if they are all the same, so you may not need to implement
+    # this.
     def infer_dtypes(self):
         self.outputs[0].dtype = self.dtype
 
     # *Optional* `infer_devices()` populates the devices of the
     # output `TraceTensor`s. The default implementation copies the input
-    # devices if they are all the same, so you may not need to implement this either.
+    # devices if they are all the same, so you may not need to implement
+    # this either.
     def infer_devices(self):
         self.outputs[0].device = device("gpu")
 
@@ -177,30 +180,35 @@ from tripy import export
 import tripy.frontend.utils as frontend_utils
 from tripy.types import ShapeLike
 
-# We can use the `export.public_api()` decorator to automatically export this function into the
-# top-level module. This means it will be accessible as `tripy.theta`.
+# We can use the `export.public_api()` decorator to automatically export this
+# function into the top-level module. This means it will be accessible as
+# `tripy.theta`.
 #
-# This decorator also controls how the API is exposed in the documentation - the `document_under`
-# option determines where in the documentation hierarchy this API will show up.
+# This decorator also controls how the API is exposed in the documentation -
+# the `document_under` option determines where in the documentation hierarchy
+# this API will show up.
 #
-# If we needed to provide any special autodoc options, we could use the `autodoc_options` parameter.
+# If we needed to provide any special autodoc options, we could use the
+# `autodoc_options` parameter.
 @export.public_api(document_under="tensor_operations")
 
-# The `convert_to_tensors` decorator automatically converts compatible arguments,
-# like `TensorLike` or `ShapeLike`s, into tensors.
+# The `convert_to_tensors` decorator automatically converts compatible
+# arguments, like `TensorLike` or `ShapeLike`s, into tensors.
 @frontend_utils.convert_to_tensors()
 def theta(shape: ShapeLike, dim: int = 0, dtype: datatype.dtype = datatype.float32) -> "tripy.Tensor":
-    # For any public facing interfaces, we have documentation requirements which you can read
-    # about in the 'Docs README' (linked below). The docstring we've implemented here
-    # adheres to all of these requirements. Non-compliant docstrings will, in most cases,
-    # cause test failures; however, you should still manually ensure you're writing high-quality
-    # docstrings.
+    # For any public facing interfaces, we have documentation requirements which
+    # you can read about in the 'Docs README' (linked below). The docstring
+    # we've implemented here adheres to all of these requirements. Non-compliant
+    # docstrings will, in most cases, cause test failures; however, you should
+    # still manually ensure you're writing high-quality docstrings.
     #
-    # The examples in docstrings are run as part of our tests, so you should also add
-    # assertions to make sure things are functionally correct. In this case, we check
-    # that the `output` we create in the code example is what we expect.
+    # The examples in docstrings are run as part of our tests, so you should
+    # also add assertions to make sure things are functionally correct. In this
+    # case, we check that the `output` we create in the code example is what we
+    # expect.
     """
-    Fills an output tensor with consecutive values starting from zero along the given dimension.
+    Fills an output tensor with consecutive values starting from zero
+    along the given dimension.
 
     Args:
         shape: The desired shape.
@@ -217,12 +225,15 @@ def theta(shape: ShapeLike, dim: int = 0, dtype: datatype.dtype = datatype.float
 
         output = tp.theta([3])
 
-        assert np.array_equal(cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32))
+        assert np.array_equal(
+            cp.from_dlpack(output).get(), np.arange(0, 3, dtype=np.float32)
+        )
     """
 
-    # Next we build the trace operator. The `build()` function is also responsible for constructing
-    # the output frontend Tensors. All of the arguments that follow the inputs
-    # are forwarded directly to the constructor of the `Trace` operator.
+    # Next we build the trace operator. The `build()` function is also
+    # responsible for constructing the output frontend Tensors. All of the
+    # arguments that follow the inputs are forwarded directly to the
+    # constructor of the `Trace` operator.
     return Theta.build([shape], dim, dtype)
 
 ```

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -40,6 +40,7 @@ build = [
   "mypy==1.11.0",
 ]
 doc_test_common = [
+  "black==24.10.0",
   "torch==2.4.0+cu121",
   "numpy==1.25.0",
   # cupy requires NVRTC but does not specify it as a package dependency
@@ -96,5 +97,4 @@ testpaths = [
 addopts = "--strict-markers"
 markers = [
     "l1: Indicates that the test should only be run in nightlies.",
-    "manual: Disables tests in automation",
 ]

--- a/tripy/tests/README.md
+++ b/tripy/tests/README.md
@@ -18,13 +18,12 @@ You can also provide marker arguments to only run specific test cadences
 L0 tests, use:
 
 ```bash
-pytest tests/ -v -m "not l1 and not manual" -n 4 --dist worksteal --ignore tests/performance
-pytest tests/performance -v -m "not l1 and not manual"
+pytest tests/ -v -m "not l1" -n 4 --dist worksteal --ignore tests/performance
+pytest tests/performance -v -m "not l1"
 ```
 
-Note that the L0/L1 tests can be parallelized, which is not necessarily
-true of `manual` tests. In that case, performance tests are run separately
-because they must run serially to ensure accurate measurements.
+Note that the L0/L1 tests can be parallelized. In that case, performance tests
+are run separately because they must run serially to ensure accurate measurements.
 
 ## Profiling
 
@@ -36,7 +35,7 @@ tests together.
 For example, to profile L0 tests, run:
 
 ```bash
-pytest tests/ -v -m "not l1 and not manual" --ignore tests/performance --profile
+pytest tests/ -v -m "not l1" --ignore tests/performance --profile
 ```
 
 You can visualize the results using `snakeviz`.

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -27,6 +27,7 @@ import re
 from textwrap import dedent, indent
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 
+import black
 import cupy as cp
 import numpy as np
 import pytest
@@ -117,20 +118,25 @@ TORCH_DTYPES = {
 }
 
 
-class DocstringCodeBlock(str):
-    def code(self) -> str:
-        # Special directives can be used in the code blocks and they should be
-        # excluded from the actual code.
-        def is_directive(line):
-            if not line.strip().startswith(":"):
-                return False
-            tokens = line.strip().split(" ")
-            if not tokens:
-                return False
-            return tokens[0].endswith(":")
+def get_code_bounds(lines):
+    # Returns the start and end index of lines of pure code in a block. The block may contain backticks
+    # or RST markup indicating a code block.
+    code_start = len(lines)
+    code_end = 0
+    BLOCK_MARKUP = {"```", ".. code-block::", ":"}
+    for index, line in enumerate(lines):
+        line = line.strip()
+        if line and not any(line.startswith(markup) for markup in BLOCK_MARKUP):
+            code_start = min(index, code_start)
 
-        text = self.replace(".. code-block:: python", "", 1)
-        return "\n".join([line for line in text.splitlines() if not is_directive(line)])
+        if line != "```":
+            code_end = max(index, code_end)
+    code_end += 1
+    return code_start, code_end
+
+
+class DocstringCodeBlock(str):
+    pass
 
 
 def consolidate_code_blocks(doc):
@@ -241,45 +247,6 @@ def get_all_tripy_interfaces():
     return all_objects
 
 
-def get_all_docstrings_with_examples():
-    def get_qualname(obj):
-        if isinstance(obj, property):
-            return obj.fget.__qualname__
-        return obj.__qualname__
-
-    # Because of our complicated method registration logic, the free function and method
-    # might both be recognized as separate objects by `get_all_tripy_interfaces()`.
-    # In order to avoid redundant testing, we compare the docstrings directly instead.
-    seen_docstring_hashes = set()
-    docstrings = []
-    ids = []
-    tripy_interfaces = get_all_tripy_interfaces()
-    for obj in tripy_interfaces:
-        if not obj.__doc__:
-            print(f"Skipping {get_qualname(obj)} because no docstring was present")
-            continue
-
-        doc_hash = hash(obj.__doc__)
-        if doc_hash in seen_docstring_hashes:
-            print(f"Skipping {get_qualname(obj)} because it duplicates the docstring of another interface")
-            continue
-        seen_docstring_hashes.add(doc_hash)
-
-        blocks = [
-            dedent(block.code())
-            for block in consolidate_code_blocks(obj.__doc__)
-            if isinstance(block, DocstringCodeBlock)
-        ]
-        if blocks is None:
-            print(f"Skipping {get_qualname(obj)} because no example was present in the docstring")
-            continue
-
-        docstrings.extend(blocks)
-        ids.extend([f"{get_qualname(obj)}:{idx}" for idx in range(len(blocks))])
-
-    return docstrings, ids
-
-
 ##
 ## Working with READMEs
 ##
@@ -379,12 +346,11 @@ class MarkerTracker:
 
 
 class ReadmeCodeBlock:
-    def __init__(self, markers: Set[Marker], lang: str):
+    def __init__(self, markers: Set[Marker], lang: str, line_number: int):
         self.content: str = None
         self.markers = markers
         self.lang = lang
-        self.start_line = ""
-        self.end_line = ""
+        self.line_number = line_number
 
     def add(self, line: str):
         if self.content is None:
@@ -396,7 +362,10 @@ class ReadmeCodeBlock:
         return AVAILABLE_MARKERS[name] in self.markers
 
     def __str__(self):
-        return self.content or ""
+        content = self.content or ""
+        lines = content.splitlines()
+        start, end = get_code_bounds(lines)
+        return "\n".join(lines[start:end])
 
     def __bool__(self):
         return bool(self.content)
@@ -404,35 +373,36 @@ class ReadmeCodeBlock:
     # Returns the original raw contents of the block.
     # This will include the backticks that were stripped out by the consolidation function.
     def raw_str(self) -> str:
-        contents = str(self)
-        if self.lang == "text":
-            return contents
-        return f"{self.start_line}\n{contents}\n{self.end_line}"
+        return self.content or ""
 
 
 # Extract any ``` blocks from the README at the specified path
 def consolidate_code_blocks_from_readme(readme_path: str) -> List[ReadmeCodeBlock]:
     cmd_blocks = []
-    current_block = ReadmeCodeBlock(markers=set(), lang="text")
+    current_block = ReadmeCodeBlock(markers=set(), lang="text", line_number=0)
     with MarkerTracker(readme_path) as tracker:
         previous_markers = copy.copy(tracker.active_markers)
-        for line in tracker:
+        for index, line in enumerate(tracker):
             # We use copy here so we don't accidentally alias.
             if tracker.entering(AVAILABLE_MARKERS["command"]):
                 # Append previous text block before creating a new block for the command.
                 cmd_blocks.append(copy.copy(current_block))
                 lang = line.strip().partition("```")[-1]
-                current_block = ReadmeCodeBlock(markers=copy.copy(tracker.active_markers), lang=lang)
-                current_block.start_line = line
+                current_block = ReadmeCodeBlock(markers=copy.copy(tracker.active_markers), lang=lang, line_number=index)
+                current_block.add(line)
             elif tracker.exiting(AVAILABLE_MARKERS["command"]):
-                current_block.end_line = line
+                current_block.add(line)
                 cmd_blocks.append(copy.copy(current_block))
                 # Create new text block for contents between command blocks
-                current_block = ReadmeCodeBlock(markers=copy.copy(tracker.active_markers), lang="text")
+                current_block = ReadmeCodeBlock(
+                    markers=copy.copy(tracker.active_markers), lang="text", line_number=index
+                )
             elif tracker.active_markers != previous_markers:
                 cmd_blocks.append(copy.copy(current_block))
                 # When markers change, create a new text block
-                current_block = ReadmeCodeBlock(markers=copy.copy(tracker.active_markers), lang="text")
+                current_block = ReadmeCodeBlock(
+                    markers=copy.copy(tracker.active_markers), lang="text", line_number=index
+                )
             else:
                 current_block.add(line)
 
@@ -453,7 +423,6 @@ ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 def process_code_block_for_outputs_and_locals(
     block: str,
-    code: str,
     format_contents: Callable[[str, str, str], str],
     err_msg: str = "",
     local_vars: Dict[str, Any] = None,
@@ -483,7 +452,7 @@ def process_code_block_for_outputs_and_locals(
     # Set of variables *not* to print
     no_print_vars = set()
 
-    code_block_lines = []
+    stripped_code_block_lines = []  # All code except what was requested to be omitted.
     output_lines = []
     local_var_lines = []
 
@@ -510,12 +479,54 @@ def process_code_block_for_outputs_and_locals(
         if any(block_line.strip().startswith(tag) for tag in REMOVE_TAGS) or block_line.endswith(OMIT_COMMENT):
             continue
 
-        code_block_lines.append(block_line)
+        stripped_code_block_lines.append(block_line)
+
+    # Format the code portion of the block with black. We use a shorter
+    # line length so it doesn't overflow in the rendered docs:
+    MAX_LINE_LENGTH = 80
+    stripped_code_start, stripped_code_end = get_code_bounds(stripped_code_block_lines)
+    stripped_code_lines = stripped_code_block_lines[stripped_code_start:stripped_code_end]
+
+    indentation = len(stripped_code_lines[0]) - len(stripped_code_lines[0].lstrip())
+    try:
+        stripped_code_lines = indent(
+            black.format_file_contents(
+                dedent("\n".join(stripped_code_lines)), fast=False, mode=black.Mode(line_length=MAX_LINE_LENGTH)
+            )
+            + "\n",
+            prefix=" " * indentation,
+        ).splitlines()
+    except black.NothingChanged:
+        pass
+
+    # Check that comments don't exceed maximum line length. Note that `black` will not automatically split
+    # comments, so this needs to be done manually. Without this, each code block will become a scrollable
+    # element, making it very annoying to read. It is also annoying to fix this manually, but it is a one
+    # time cost and makes the reading experience so much better.
+    too_long_lines = []
+    for line in stripped_code_lines:
+        # The indentation of the code block doesn't show up in the rendered documentation
+        # (indentation *within* the block obviously will.)
+        if len(line) - indentation > MAX_LINE_LENGTH:
+            too_long_lines.append(f">| {line}")
+    too_long_lines = "\n".join(too_long_lines)
+    assert (
+        not too_long_lines
+    ), f"{err_msg}One or more lines exceed maximum line length ({MAX_LINE_LENGTH} characters). Note: lines were:\n{too_long_lines}\n"
+
+    stripped_code_block_lines = (
+        stripped_code_block_lines[:stripped_code_start]
+        + stripped_code_lines
+        + stripped_code_block_lines[stripped_code_end:]
+    )
 
     if not should_eval:
-        return code_block_lines, local_var_lines, output_lines, local_vars
+        return stripped_code_block_lines, local_var_lines, output_lines, local_vars
 
-    code = dedent(code)
+    # When we run the code, we need to get the original code, not the strpiped one.
+    block_lines = block.splitlines()
+    code_start, code_end = get_code_bounds(block_lines)
+    code = dedent("\n".join(block_lines[code_start:code_end]))
 
     with capture_output() as outfile:
         try:
@@ -604,4 +615,4 @@ def process_code_block_for_outputs_and_locals(
         stdout = ANSI_ESCAPE.sub("", stdout)
         output_lines = split_block_lines("Output:", stdout, lang="")
 
-    return code_block_lines, local_var_lines, output_lines, code_locals
+    return stripped_code_block_lines, local_var_lines, output_lines, code_locals

--- a/tripy/tests/test_examples.py
+++ b/tripy/tests/test_examples.py
@@ -99,18 +99,20 @@ def test_examples(example, sandboxed_install_run):
             if block.has_marker("test: ignore") or not block.has_marker("command"):
                 continue
 
-            block_text = str(block)
+            code = str(block)
             if block.has_marker("test: expected_stdout"):
                 print("Checking command output against expected output: ", end="")
                 out = statuses[-1].stdout.strip()
-                matched = re.match(dedent(block_text).strip(), out)
+                matched = re.match(dedent(code).strip(), out)
                 print("matched!" if matched else "did not match!")
                 print(f"==== STDOUT ====\n{out}")
                 assert matched
             else:
-                status = example.run(block_text, sandboxed_install_run)
+                status = example.run(code, sandboxed_install_run)
 
-                details = f"Note: Command was: {block_text}.\n==== STDOUT ====\n{status.stdout}\n==== STDERR ====\n{status.stderr}"
+                details = (
+                    f"Note: Command was: {code}.\n==== STDOUT ====\n{status.stdout}\n==== STDERR ====\n{status.stderr}"
+                )
                 if block.has_marker("test: xfail"):
                     assert not status.success, f"Command that was expected to fail did not fail. {details}"
                 else:

--- a/tripy/tests/test_helper.py
+++ b/tripy/tests/test_helper.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from tests import helper
 
 
@@ -13,7 +27,7 @@ class TestProcessCodeBlock:
         b = "42"
         """
 
-        _, local_var_lines, _, _ = helper.process_code_block_for_outputs_and_locals(block, block, format_contents)
+        _, local_var_lines, _, _ = helper.process_code_block_for_outputs_and_locals(block, format_contents)
 
         assert not local_var_lines
 
@@ -24,6 +38,6 @@ class TestProcessCodeBlock:
         cpu = tp.device("cpu")
         """
 
-        _, local_var_lines, _, _ = helper.process_code_block_for_outputs_and_locals(block, block, format_contents)
+        _, local_var_lines, _, _ = helper.process_code_block_for_outputs_and_locals(block, format_contents)
 
         assert not local_var_lines

--- a/tripy/tests/test_internal_docs.py
+++ b/tripy/tests/test_internal_docs.py
@@ -42,7 +42,6 @@ ALL_DOC_CODE_BLOCKS = {
 
 # Guides may use inline pytest tests or regular Python code snippets.
 INLINE_PYTESTS = {}
-CODE_BLOCKS = {}
 
 for readme, code_blocks in ALL_DOC_CODE_BLOCKS.items():
     if not code_blocks:
@@ -54,7 +53,6 @@ for readme, code_blocks in ALL_DOC_CODE_BLOCKS.items():
         assert not any(
             block.has_marker("test: use_pytest") for block in code_blocks
         ), "Guides must not mix Pytest code blocks with non-Pytest code blocks"
-        CODE_BLOCKS[readme] = code_blocks
 
 
 @pytest.mark.parametrize(
@@ -68,21 +66,3 @@ def test_inline_pytest(code_blocks):
     f.write(code)
     f.flush()
     assert pytest.main([f.name, "-vv", "-s"]) == 0
-
-
-@pytest.mark.manual  # Code snippets in guides are executed during doc generation.
-@pytest.mark.parametrize(
-    "code_blocks",
-    CODE_BLOCKS.values(),
-    ids=CODE_BLOCKS.keys(),
-)
-def test_python_code_snippets(code_blocks):
-    code_locals = {}
-    for block in code_blocks:
-        print(f"Checking code block:\n{str(block)}")
-        try:
-            new_locals = helper.exec_code(str(block), code_locals)
-            # Update code_locals with new variables
-            code_locals.update(new_locals)
-        except Exception as e:
-            raise AssertionError(f"Error while executing code block: {str(e)}") from e

--- a/tripy/tests/test_ux.py
+++ b/tripy/tests/test_ux.py
@@ -99,21 +99,7 @@ class TestReadme:
                 raise
 
 
-DOCSTRING_TEST_CASES, DOCSTRING_IDS = helper.get_all_docstrings_with_examples()
-
-
 class TestDocstrings:
-    @pytest.mark.manual  # This is already tested during doc generation.
-    @pytest.mark.parametrize("example_code", DOCSTRING_TEST_CASES, ids=DOCSTRING_IDS)
-    def test_examples_in_docstrings(self, example_code):
-        assert example_code, "Example code is empty! Is the formatting correct? Refer to `tests/README.md`."
-        for banned_module in ["numpy", "cupy", "tripy", "torch"]:
-            assert (
-                f"import {banned_module}" not in example_code
-            ), f"Avoid importing {banned_module} in example docstrings"
-            assert f"from {banned_module}" not in example_code, f"Avoid importing {banned_module} in example docstrings"
-
-        helper.exec_code(example_code)
 
     @pytest.mark.parametrize("api", PUBLIC_APIS, ids=lambda public_api: public_api.qualname)
     def test_all_public_apis_have_docstrings(self, api):

--- a/tripy/tripy/backend/api/compile.py
+++ b/tripy/tripy/backend/api/compile.py
@@ -78,7 +78,8 @@ def compile(
 
         # doc: no-print-locals compiled_add
 
-        # Support shapes in the range of (1, 2) to (3, 2), optimizing for a shape of (2, 2)
+        # Support shapes in the range of (1, 2) to (3, 2), optimizing for a
+        # shape of (2, 2)
         compiled_add = tp.compile(
             add,
             args=[
@@ -92,7 +93,8 @@ def compile(
 
         small_out = compiled_add(small_a, small_b)
 
-        # Now we can reuse the compiled function for any shapes within the range:
+        # Now we can reuse the compiled function for any shapes within the
+        # range:
         big_a = tp.ones((3, 2), dtype=tp.float32)
         big_b = tp.ones((3, 2), dtype=tp.float32)
 

--- a/tripy/tripy/frontend/trace/ops/plugin.py
+++ b/tripy/tripy/frontend/trace/ops/plugin.py
@@ -80,10 +80,11 @@ def plugin(
         out = tp.plugin(
             "CustomGeluPluginDynamic",
             [inp],
-            # GELU has a single output which always has the same rank and data type as the input.
+            # GELU has a single output which always has the same rank and data
+            # type as the input.
             output_info=[(inp.rank, inp.dtype)],
-            # The GELU plugin expects a `type_id` parameter indicating the precision to use.
-            # `0` indicates float32.
+            # The GELU plugin expects a `type_id` parameter indicating the precision
+            # to use. `0` indicates float32.
             type_id=0,
         )
 


### PR DESCRIPTION
This change updates our documentation generation to format all code blocks
with `black`. This helps ensure that lines do not overflow and create scrollable
elements in the rendered docs. For lines that `black` doesn't touch (e.g. comments),
we include our own assertions to ensure they don't exceed the length limits.

The logic to extract code from a code block (i.e. stripping out markup) has also
been consolidated.

Finally, this change removes the `manual` test cadence and related tests since
they were redundant (the same things are tested during doc generation) and didn't
add any value (the thought was they would make it easier to debug, but (1) they don't
and (2) it's rarely difficult to figure out what's wrong with the code blocks in documentation)