### PR TITLE
Fix stablehlo constant folding bugs through patch

### DIFF
--- a/mlir-tensorrt/CMakeLists.txt
+++ b/mlir-tensorrt/CMakeLists.txt
@@ -183,7 +183,9 @@ if(MLIR_TRT_ENABLE_HLO AND NOT TARGET StablehloOps)
     VERSION 1.6.4
     GIT_TAG 1456dfa1e1a83aab0cc717714ba3695886f60302
     GIT_REPOSITORY "https://github.com/openxla/stablehlo.git"
-    PATCHES "${MLIR_TENSORRT_ROOT_DIR}/build_tools/stablehlo.patch"
+    PATCHES 
+      "${MLIR_TENSORRT_ROOT_DIR}/build_tools/stablehlo.patch"
+      "${MLIR_TENSORRT_ROOT_DIR}/build_tools/stablehlo_aggressive_folder.patch"
     OPTIONS
       "STABLEHLO_ENABLE_BINDINGS_PYTHON ${MLIR_TRT_ENABLE_PYTHON}"
       "STABLEHLO_BUILD_EMBEDDED ON"

--- a/mlir-tensorrt/build_tools/stablehlo_aggressive_folder.patch
+++ b/mlir-tensorrt/build_tools/stablehlo_aggressive_folder.patch
@@ -1,0 +1,654 @@
+diff --git a/stablehlo/transforms/CMakeLists.txt b/stablehlo/transforms/CMakeLists.txt
+index 1cf6d6a3..9715bb1c 100644
+--- a/stablehlo/transforms/CMakeLists.txt
++++ b/stablehlo/transforms/CMakeLists.txt
+@@ -32,7 +32,6 @@ set(LLVM_TARGET_DEFINITIONS VhloToVersionPatterns.td)
+ mlir_tablegen(VhloToVersionPatterns.h.inc --gen-rewriters)
+ add_public_tablegen_target(VhloToVersionPatterns)
+ 
+-
+ add_mlir_dialect_library(StablehloPasses
+   PARTIAL_SOURCES_INTENDED
+   ChloLegalizeToStablehlo.cpp
+diff --git a/stablehlo/transforms/StablehloAggressiveFolder.cpp b/stablehlo/transforms/StablehloAggressiveFolder.cpp
+index 6c11c45c..b94d39e3 100644
+--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
++++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
+@@ -47,6 +47,7 @@ limitations under the License.
+ #include "stablehlo/dialect/Base.h"
+ #include "stablehlo/dialect/StablehloOps.h"
+ #include "stablehlo/transforms/Passes.h"
++#include "stablehlo/transforms/Utils.h"
+ 
+ namespace mlir {
+ namespace stablehlo {
+@@ -101,8 +102,8 @@ LogicalResult evalConvertHelper(PatternRewriter& rewriter, OpType op,
+            << " failed";
+     });
+ 
+-  rewriter.replaceOpWithNewOp<ConstantOp>(op, result);
+-  return success();
++  return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++      rewriter, op, result);
+ }
+ 
+ template <typename OpType>
+@@ -221,9 +222,8 @@ LogicalResult evalElementwise(PatternRewriter& rewriter, OpType op,
+     llvm::report_fatal_error("unsupported number of operands");
+   }
+ 
+-  rewriter.replaceOpWithNewOp<ConstantOp>(op,
+-                                          getTensorAttr(resultType, result));
+-  return success();
++  return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++      rewriter, op, getTensorAttr(resultType, result));
+ }
+ 
+ struct EvalAddOpPattern : public OpRewritePattern<AddOp> {
+@@ -266,9 +266,8 @@ struct EvalBroadcastInDimOpPattern : public OpRewritePattern<BroadcastInDimOp> {
+       return rewriter.notifyMatchFailure(op, "expected constant operands");
+     auto scalar = operand[0];
+ 
+-    rewriter.replaceOpWithNewOp<ConstantOp>(
+-        op, getTensorAttr(op.getType(), scalar));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, getTensorAttr(op.getType(), scalar));
+   }
+ };
+ 
+@@ -334,8 +333,8 @@ struct EvalConcatenateOpPattern : public OpRewritePattern<ConcatenateOp> {
+         return rewriter.notifyMatchFailure(op, "expected constant operands");
+     }
+ 
+-    rewriter.replaceOpWithNewOp<ConstantOp>(op,
+-                                            getTensorAttr(resultType, result));
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, getTensorAttr(resultType, result));
+     return success();
+   }
+ };
+@@ -400,9 +399,8 @@ struct EvalGetDimensionSizeOpPattern
+       return rewriter.notifyMatchFailure(op, "expected static dimension");
+ 
+     auto result = operandType.getDimSize(op.getDimension());
+-    rewriter.replaceOpWithNewOp<ConstantOp>(
+-        op, DenseIntElementsAttr::get<int32_t>(resultType, result));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, DenseIntElementsAttr::get<int32_t>(resultType, result));
+   }
+ };
+ 
+@@ -469,8 +467,8 @@ struct EvalReshapeOpPattern : public OpRewritePattern<ReshapeOp> {
+     DenseIntElementsAttr attr;
+     if (!matchPattern(op.getOperand(), m_Constant(&attr)))
+       return rewriter.notifyMatchFailure(op, "expected constant operand");
+-    rewriter.replaceOpWithNewOp<ConstantOp>(op, attr.reshape(resultType));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, attr.reshape(resultType));
+   }
+ };
+ 
+@@ -494,9 +492,8 @@ struct EvalSelectOpPattern : public OpRewritePattern<SelectOp> {
+       result.push_back(predEl != 0 ? onTrueEl : onFalseEl);
+     }
+ 
+-    rewriter.replaceOpWithNewOp<ConstantOp>(
+-        op, getTensorAttr(op.getType(), result));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, getTensorAttr(op.getType(), result));
+   }
+ };
+ 
+@@ -566,9 +563,8 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
+     for (auto i = start; i < limit; i += stride)
+       result.push_back(operandData[i]);
+ 
+-    rewriter.replaceOpWithNewOp<ConstantOp>(op,
+-                                            getTensorAttr(resultType, result));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, getTensorAttr(resultType, result));
+   }
+ };
+ 
+@@ -599,9 +595,8 @@ struct EvalIotaOpPattern : public OpRewritePattern<IotaOp> {
+     values.reserve(outputSize);
+ 
+     if (outputSize == 0) {
+-      rewriter.replaceOpWithNewOp<ConstantOp>(
+-          op, DenseIntElementsAttr::get(resultType, values));
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, DenseIntElementsAttr::get(resultType, values));
+     }
+ 
+     int64_t sequences = 1;
+@@ -620,9 +615,8 @@ struct EvalIotaOpPattern : public OpRewritePattern<IotaOp> {
+       }
+     }
+ 
+-    rewriter.replaceOpWithNewOp<ConstantOp>(
+-        op, DenseIntElementsAttr::get(resultType, values));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, DenseIntElementsAttr::get(resultType, values));
+   }
+ };
+ 
+diff --git a/stablehlo/transforms/StablehloAggressiveSimplification.cpp b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+index 6445f72d..e3f90448 100644
+--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
++++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+@@ -32,6 +32,7 @@
+ #include "mlir/IR/BuiltinTypeInterfaces.h"
+ #include "mlir/IR/BuiltinTypes.h"
+ #include "mlir/IR/Diagnostics.h"
++#include "mlir/IR/DialectResourceBlobManager.h"
+ #include "mlir/IR/IRMapping.h"
+ #include "mlir/IR/MLIRContext.h"
+ #include "mlir/IR/Matchers.h"
+@@ -48,6 +49,7 @@
+ #include "stablehlo/dialect/Base.h"
+ #include "stablehlo/dialect/StablehloOps.h"
+ #include "stablehlo/transforms/Passes.h"
++#include "stablehlo/transforms/Utils.h"
+ 
+ using llvm::SmallBitVector;
+ 
+@@ -112,13 +114,11 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
+     Value rhs = op.getRhs();
+ 
+     if (matchPattern(lhs, m_Zero())) {
+-      rewriter.replaceOp(op, rhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, rhs);
+     }
+ 
+     if (matchPattern(rhs, m_AnyOf(m_Zero(), m_NegZeroFloat()))) {
+-      rewriter.replaceOp(op, lhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, lhs);
+     }
+ 
+     TypedAttr lhsAttr;
+@@ -129,17 +129,16 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
+ 
+     // The canonical form has the constant operand as the RHS.
+     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
+-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
+-        op->setOperands(ValueRange{rhs, lhs});
+-      });
++      rewriter.modifyOpInPlace(
++          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
+       return success();
+     }
+ 
+     if (TypedAttr res;
+         lhsAttr && rhsAttr &&
+         (res = foldBinaryOpIntOrFloat(lhsAttr, rhsAttr, std::plus<>{}))) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(op, res);
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, res);
+     }
+ 
+     return failure();
+@@ -156,15 +155,13 @@ struct SubtractOpCanon final : OpRewritePattern<mlir::stablehlo::SubtractOp> {
+     Value rhs = op.getRhs();
+ 
+     if (isa<IntegerType>(elemType) && lhs == rhs) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-          op, rewriter.getZeroAttr(op.getType()));
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, rewriter.getZeroAttr(op.getType()));
+     }
+ 
+     // Subtraction of 0.
+     if (matchPattern(rhs, m_AnyOf(m_Zero(), m_PosZeroFloat()))) {
+-      rewriter.replaceOp(op, lhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, lhs);
+     }
+ 
+     TypedAttr lhsAttr;
+@@ -176,8 +173,8 @@ struct SubtractOpCanon final : OpRewritePattern<mlir::stablehlo::SubtractOp> {
+     if (TypedAttr res;
+         lhsAttr && rhsAttr &&
+         (res = foldBinaryOpIntOrFloat(lhsAttr, rhsAttr, std::minus<>{}))) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(op, res);
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, res);
+     }
+ 
+     return failure();
+@@ -192,22 +189,18 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
+     auto elemType = op.getType().getElementType();
+     Value lhs = op.getLhs();
+     Value rhs = op.getRhs();
+-
+     // Multiplication by 0. This fold is not trivial for floats in presence of
+     // NaN values.
+     if (matchPattern(lhs, m_Zero())) {
+-      rewriter.replaceOp(op, lhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, lhs);
+     }
+     if (matchPattern(rhs, m_Zero())) {
+-      rewriter.replaceOp(op, rhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, rhs);
+     }
+ 
+     // Multiplication by 1.
+     if (matchPattern(rhs, m_One())) {
+-      rewriter.replaceOp(op, lhs);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, lhs);
+     }
+ 
+     TypedAttr lhsAttr;
+@@ -218,17 +211,16 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
+ 
+     // The canonical form has the constant operand as the RHS.
+     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
+-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
+-        op->setOperands(ValueRange{rhs, lhs});
+-      });
++      rewriter.modifyOpInPlace(
++          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
+       return success();
+     }
+ 
+     if (TypedAttr res;
+         lhsAttr && rhsAttr &&
+         (res = foldBinaryOpIntOrFloat(lhsAttr, rhsAttr, std::multiplies<>{}))) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(op, res);
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, res);
+     }
+ 
+     return failure();
+@@ -318,16 +310,15 @@ struct CompareOpCanon final : OpRewritePattern<mlir::stablehlo::CompareOp> {
+         case ComparisonDirection::EQ:
+         case ComparisonDirection::GE:
+         case ComparisonDirection::LE: {
+-          rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-              op, SplatElementsAttr::get(type, rewriter.getBoolAttr(true)));
+-          return success();
++          return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++              rewriter, op,
++              SplatElementsAttr::get(type, rewriter.getBoolAttr(true)));
+         }
+         case ComparisonDirection::GT:
+         case ComparisonDirection::LT:
+         case ComparisonDirection::NE: {
+-          rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-              op, rewriter.getZeroAttr(type));
+-          return success();
++          return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++              rewriter, op, rewriter.getZeroAttr(type));
+         }
+       }
+       llvm_unreachable("Unhandled case");
+@@ -355,8 +346,8 @@ struct CompareOpCanon final : OpRewritePattern<mlir::stablehlo::CompareOp> {
+              [direction, kind = *compType](const APInt &a, const APInt &b) {
+                return calculateComp(kind, direction, a, b);
+              }))) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(op, res);
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, res);
+     }
+ 
+     return failure();
+@@ -375,8 +366,7 @@ struct SelectOpCanon final : OpRewritePattern<mlir::stablehlo::SelectOp> {
+ 
+     // Eliminate select with two identical outcomes.
+     if (trueVal == falseVal) {
+-      rewriter.replaceOp(op, trueVal);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, trueVal);
+     }
+ 
+     // Simplify when the condition is a constant.
+@@ -386,8 +376,8 @@ struct SelectOpCanon final : OpRewritePattern<mlir::stablehlo::SelectOp> {
+ 
+     // Handle splat predicate and select either `trueVal` or `falseVal`.
+     if (cond.isSplat()) {
+-      rewriter.replaceOp(op, cond.getSplatValue<bool>() ? trueVal : falseVal);
+-      return success();
++      return maybeCastAndReplace(
++          rewriter, op, cond.getSplatValue<bool>() ? trueVal : falseVal);
+     }
+ 
+     // Handle elementwise selection when both outcomes are also constants. This
+@@ -408,9 +398,8 @@ struct SelectOpCanon final : OpRewritePattern<mlir::stablehlo::SelectOp> {
+       newValues.push_back(condElem ? trueElem : falseElem);
+     }
+ 
+-    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-        op, DenseElementsAttr::get(type, newValues));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, DenseElementsAttr::get(type, newValues));
+   }
+ };
+ 
+@@ -477,17 +466,16 @@ struct BroadcastInDimOpCanon final
+     // Fold when broadcast is a noop.
+     auto dims = op.getBroadcastDimensions();
+     if (type == operandTy && isIotaRange(dims)) {
+-      rewriter.replaceOp(op, operand);
+-      return success();
++      return maybeCastAndReplace(rewriter, op, operand);
+     }
+ 
+     // Handle splat broadcasts.
+     if (SplatElementsAttr cstAttr;
+         matchPattern(operand, m_Constant(&cstAttr))) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-          op, SplatElementsAttr::get(op.getType(),
+-                                     cstAttr.getSplatValue<Attribute>()));
+-      return success();
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op,
++          SplatElementsAttr::get(op.getType(),
++                                 cstAttr.getSplatValue<Attribute>()));
+     }
+ 
+     if (operandTy.hasStaticShape() && type.hasStaticShape() &&
+@@ -557,9 +545,8 @@ struct ConcatenateOpCanon final
+     }
+ 
+     assert(newElems.size() == numElems);
+-    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-        op, DenseElementsAttr::get(op.getType(), newElems));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, DenseElementsAttr::get(op.getType(), newElems));
+   }
+ };
+ 
+@@ -571,8 +558,7 @@ struct ConvertOpCanon final : OpRewritePattern<mlir::stablehlo::ConvertOp> {
+     // Check if this convert is a noop.
+     if (op.getOperand().getType() != op.getType()) return failure();
+ 
+-    rewriter.replaceOp(op, op.getOperand());
+-    return success();
++    return maybeCastAndReplace(rewriter, op, op.getOperand());
+   }
+ };
+ 
+@@ -699,8 +685,7 @@ struct NoopReduceOpCanon final : OpRewritePattern<mlir::stablehlo::ReduceOp> {
+                                 PatternRewriter &rewriter) const override {
+     // No dimensions to reduce.
+     if (op.getDimensions().empty()) {
+-      rewriter.replaceOp(op, op.getInputs());
+-      return success();
++      return maybeCastAndReplace(rewriter, op, op.getInputs());
+     }
+ 
+     // If all returned values in the ReduceOp region exists outside the
+@@ -943,9 +928,8 @@ struct GetDimensionSizeOpCanon final
+ 
+     auto elemTy = cast<IntegerType>(op.getType().getElementType());
+     IntegerAttr elemVal = rewriter.getIntegerAttr(elemTy, dimSize);
+-    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-        op, DenseElementsAttr::get(op.getType(), elemVal));
+-    return success();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, DenseElementsAttr::get(op.getType(), elemVal));
+   }
+ };
+ 
+@@ -1027,26 +1011,34 @@ struct ReshapeOpCanon final : OpRewritePattern<mlir::stablehlo::ReshapeOp> {
+                                 PatternRewriter &rewriter) const override {
+     // Fold noop reshape.
+     if (op.getType() == op.getOperand().getType()) {
+-      rewriter.replaceOp(op, op.getOperand());
+-      return success();
++      return maybeCastAndReplace(rewriter, op, op.getOperand());
+     }
+ 
+-    // Fold reshape of a constant.
+-    ElementsAttr cstAttr;
+-    if (!matchPattern(op.getOperand(), m_Constant(&cstAttr))) return failure();
++    auto constOp = op.getOperand().getDefiningOp<stablehlo::ConstantOp>();
++    if (!constOp) return failure();
++
++    ElementsAttr cstAttr = constOp.getValueAttr();
++    // If constant is dense resource elements attribute, we just pass
++    // resource handle to attribute with new shape.
++    auto getElidedResourceElementsAttrHandle =
++        [&]() -> std::optional<DenseResourceElementsHandle> {
++      auto denseResourceAttr = dyn_cast<DenseResourceElementsAttr>(cstAttr);
++      if (!denseResourceAttr) return std::nullopt;
++      DenseResourceElementsHandle handle = denseResourceAttr.getRawHandle();
++      if (handle.getKey() != "__elided__") return std::nullopt;
++      return handle;
++    };
+ 
+-    if (auto splat = dyn_cast<SplatElementsAttr>(cstAttr)) {
+-      rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-          op, SplatElementsAttr::get(op.getType(),
+-                                     splat.getSplatValue<Attribute>()));
+-      return success();
+-    }
++    if (auto handle = getElidedResourceElementsAttrHandle())
++      return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++          rewriter, op, DenseResourceElementsAttr::get(op.getType(), *handle));
+ 
+-    auto elements =
+-        llvm::to_vector_of<Attribute>(cstAttr.getValues<Attribute>());
+-    rewriter.replaceOpWithNewOp<mlir::stablehlo::ConstantOp>(
+-        op, DenseElementsAttr::get(op.getType(), elements));
+-    return success();
++    // We can access and reshape `DenseElementsAttr`
++    auto els = dyn_cast<DenseElementsAttr>(cstAttr);
++    if (!els) return failure();
++    if (els.getNumElements() != op.getType().getNumElements()) return failure();
++    return replaceOpWithNewOpAndMaybeCast<mlir::stablehlo::ConstantOp>(
++        rewriter, op, els.reshape(op.getType()));
+   }
+ };
+ 
+@@ -1059,8 +1051,7 @@ struct MergeConsecutiveReshapes final
+     // Fold noop reshape.
+     auto operand = op.getOperand();
+     if (op.getType() == operand.getType()) {
+-      rewriter.replaceOp(op, op.getOperand());
+-      return success();
++      return maybeCastAndReplace(rewriter, op, op.getOperand());
+     }
+ 
+     // Fold reshape(reshape(x)).
+@@ -1084,8 +1075,7 @@ struct TransposeIsReshape final
+     auto permutation = op.getPermutation();
+ 
+     if (isIotaRange(permutation)) {
+-      rewriter.replaceOp(op, op.getOperand());
+-      return success();
++      return maybeCastAndReplace(rewriter, op, op.getOperand());
+     }
+ 
+     RankedTensorType inputTy = input.getType();
+diff --git a/stablehlo/transforms/Utils.h b/stablehlo/transforms/Utils.h
+new file mode 100644
+index 00000000..7851453f
+--- /dev/null
++++ b/stablehlo/transforms/Utils.h
+@@ -0,0 +1,167 @@
++/* Copyright 2024 The StableHLO Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++==============================================================================*/
++
++#ifndef STABLEHLO_TRANSFORMS_UTILS_H
++#define STABLEHLO_TRANSFORMS_UTILS_H
++
++#include "mlir/Dialect/Tensor/IR/Tensor.h"
++#include "mlir/IR/PatternMatch.h"
++#include "mlir/IR/TypeUtilities.h"
++#include "mlir/IR/Value.h"
++#include "stablehlo/dialect/StablehloOps.h"
++
++namespace mlir {
++namespace stablehlo {
++
++/// Returns true if the type of `result` can be updated and replaced (assuming
++/// replacement type is compatible with respect to dynamic dim refinement)
++/// without inserting a cast. This is true if:
++/// 1. All users are StableHLO operations, since the StableHLO dialect was
++///    designed with this in mind, or
++/// 2. The operation passes a custom check defined by the `otherCases` lambda.
++/// For operations that don't meet these criteria, we conservatively require
++/// a cast to be inserted.
++inline bool canUpdateTypeWithoutCast(
++    OpOperand &use, const std::function<bool(OpOperand &)> &otherCases = {}) {
++  Operation *consumer = use.getOwner();
++  Value value = use.get();
++  // There is one limitation to StableHlo ops being updated in place:
++  // all operations that accept shape tensor argument should have shape tensor
++  // with known rank.
++  if (isa<stablehlo::CompositeOp>(consumer)) return false;
++
++  if (auto iotaOp = dyn_cast<stablehlo::DynamicIotaOp>(consumer))
++    return false;  // shape tensor is the only argument for iotaOp, always
++                   // insert a cast op.
++
++  if (auto sliceOp = dyn_cast<stablehlo::DynamicSliceOp>(consumer))
++    return sliceOp.getOperand() == value;
++
++  if (auto dynamicUpdateSliceOp =
++          dyn_cast<stablehlo::DynamicUpdateSliceOp>(consumer))
++    return dynamicUpdateSliceOp.getOperand() == value;
++
++  if (auto dynamicBroadcastInDimOp =
++          dyn_cast<stablehlo::DynamicBroadcastInDimOp>(consumer))
++    return dynamicBroadcastInDimOp.getOperand() == value;
++
++  if (auto reshapeOp = dyn_cast<stablehlo::DynamicReshapeOp>(consumer))
++    return reshapeOp.getOperand() == value;
++
++  if (auto sliceOp = dyn_cast<stablehlo::RealDynamicSliceOp>(consumer))
++    return sliceOp.getOperand().getType() == value.getType();
++
++  if (auto padOp = dyn_cast<stablehlo::DynamicPadOp>(consumer))
++    return padOp.getOperand() == value;
++
++  if (auto gatherOp = dyn_cast<stablehlo::DynamicGatherOp>(consumer))
++    return gatherOp.getOperand() == value;
++
++  if (auto convOp = dyn_cast<stablehlo::DynamicConvOp>(consumer))
++    return convOp.getOperand(0) == value;
++
++  return isa<stablehlo::StablehloDialect>(consumer->getDialect()) ||
++         (otherCases && otherCases(use));
++}
++
++inline bool canUpdateTypeWithoutCast(
++    Value result, const std::function<bool(Operation *)> &otherCases = {}) {
++  return llvm::all_of(result.getUses(), [&](OpOperand &use) {
++    return canUpdateTypeWithoutCast(use) ||
++           (otherCases && otherCases(use.getOwner()));
++  });
++}
++/// Returns true if `target` shape is refinement of `source` shape.
++/// This is true only, if source dim is dynamic because in that case
++/// corresponding target dim can be static or dynamic.
++inline bool isTargetRefinementOfSource(ArrayRef<int64_t> source,
++                                       ArrayRef<int64_t> target) {
++  if (source.size() != target.size()) return false;
++  for (auto [srcDim, tgtDim] : llvm::zip_equal(source, target)) {
++    // If the source dimension is dynamic, then the target dimension can be
++    // dynamic or static.
++    if (ShapedType::isDynamic(srcDim)) continue;
++    // Static source dim and dynamic result dim -> not a refinement.
++    if (ShapedType::isDynamic(tgtDim)) return false;
++    // Static source dim != static result dim -> not a refinement.
++    if (srcDim != tgtDim) return false;
++  }
++  return true;
++}
++
++/// Replace `originalOp` with `v` if the types match. Otherwise, insert a
++/// `tensor.cast` of `v` if the types are "cast compatible", meaning that one
++/// type is a generalization of the other. Otherwise, return failure.
++inline LogicalResult maybeCastAndReplace(RewriterBase &rewriter,
++                                         Operation *originalOp,
++                                         ValueRange replacements) {
++  TypeRange originalTypes = originalOp->getResultTypes();
++  TypeRange newTypes(replacements);
++  if (originalTypes == newTypes) {
++    rewriter.replaceOp(originalOp, replacements);
++    return success();
++  }
++
++  // We should not be handling element type differences here. If this occurs,
++  // something has gone wrong. Types should have matching ranks and one shape
++  // should be a generalization of the other.
++  if (originalTypes.size() != newTypes.size() ||
++      llvm::any_of(llvm::zip(originalTypes, newTypes),
++                   [](const std::tuple<Type, Type> &types) {
++                     RankedTensorType originalType =
++                         cast<RankedTensorType>(std::get<0>(types));
++                     RankedTensorType newType =
++                         cast<RankedTensorType>(std::get<1>(types));
++                     return mlir::getElementTypeOrSelf(originalType) !=
++                                mlir::getElementTypeOrSelf(newType) ||
++                            (!isTargetRefinementOfSource(
++                                 originalType.getShape(), newType.getShape()) &&
++                             !isTargetRefinementOfSource(
++                                 newType.getShape(), originalType.getShape()));
++                   }))
++    return failure();
++  SmallVector<Value> finalReplacements;
++  finalReplacements.reserve(originalTypes.size());
++  for (auto [v, originalType, originalValue] :
++       llvm::zip_equal(replacements, originalTypes, originalOp->getResults())) {
++    if (v.getType() == originalType ||
++        canUpdateTypeWithoutCast(originalValue)) {
++      finalReplacements.push_back(v);
++      continue;
++    }
++    finalReplacements.push_back(
++        rewriter.create<tensor::CastOp>(originalOp->getLoc(), originalType, v));
++  }
++  rewriter.replaceOp(originalOp, finalReplacements);
++  return success();
++}
++
++/// Logic borrowed from
++/// https://github.com/NVIDIA/TensorRT-Incubator/blob/main/mlir-tensorrt/compiler/lib/Dialect/StableHloExt/Transforms/ConstantFolding.cpp#L121
++///
++/// Like `rewriter.replaceOpWithNewOp`, except that casts are inserted if it
++/// makes sense to match the original result types (see `maybeCastAndReplace`
++/// above).
++template <typename T, typename... Args>
++inline LogicalResult replaceOpWithNewOpAndMaybeCast(RewriterBase &rewriter,
++                                                    Operation *originalOp,
++                                                    Args &&...args) {
++  auto newOp =
++      rewriter.create<T>(originalOp->getLoc(), std::forward<Args>(args)...);
++  return maybeCastAndReplace(rewriter, originalOp, newOp->getResults());
++}
++}  // namespace stablehlo
++}  // namespace mlir
++#endif  // STABLEHLO_TRANSFORMS_UTILS_H


### PR DESCRIPTION
This PR provides a patch to fix two issues in StableHlo
upstream,
- If some op is constant folded and op users are certain
stablehlo ops (which don't allow different type for operand
and result) OR ops with different dialect, `tensor.cast`
should be inserted.
MLIR-TensorRT constant folding pass does this but upstream
stablehlo pass doesn't do this, causing error. Some
logic from MLIR-TRT is patched into upstream.
- Upstream `ReshapeOpCanon` pattern to simplify
`stablehlo.reshape` op failed if input to reshape
is `DenseResourceElementsAttr`. This is fixed.
- Many patterns where replacing op with a new op,
without giving consideration to casting. This is 
fixed.

Solves: https://github.com/NVIDIA/TensorRT-Incubator/issues/378