### PR TITLE
Move internal changes

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanInterfaces.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/IR/PlanInterfaces.td
@@ -39,14 +39,6 @@ def ClusterKindAttrInterface : AttrInterface<"ClusterKindAttrInterface"> {
     let cppNamespace = "::mlir::plan";
     let methods = [
         InterfaceMethod<
-            /*desc=*/"Return the name of the cluster",
-            /*retTy-*/"std::string",
-            "getClusterKindName",
-            /*args=*/(ins ),
-            /*body=*/"",
-            ""
-        >,
-        InterfaceMethod<
             /*desc=*/"Return the clustering options for the cluster",
             /*retTy-*/"::mlir::ClusteringOpts",
             "getClusterKindOptions",

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/IR/BuiltinClusterKinds.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/IR/BuiltinClusterKinds.cpp
@@ -51,8 +51,6 @@ using namespace mlir::plan;
 // HostClusterKindAttr
 //===----------------------------------------------------------------------===//
 
-std::string HostClusterKindAttr::getClusterKindName() const { return "host"; }
-
 int64_t HostClusterKindAttr::getClusterBenefit() const { return getBenefit(); }
 
 /// ClusteringOpts that identifies groups of `stablehlo` ops that can be
@@ -123,10 +121,6 @@ HostClusterKindAttr::getClusterFilter() const {
 //===----------------------------------------------------------------------===//
 // TensorRTClusterKindAttr
 //===----------------------------------------------------------------------===//
-
-std::string TensorRTClusterKindAttr::getClusterKindName() const {
-  return "tensorrt";
-}
 
 static ShapeInfoCallbacks getShapeInfoCallbacks() {
   ShapeInfoCallbacks shapeInfoCallbacks{};

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
@@ -91,7 +91,7 @@ applyClusteringToFunc(RewriterBase &rewriter, func::FuncOp func,
                       const StablehloClusteringPassOptions &opts) {
   ClusteringPatternSet<ClusteringRewriter> patterns;
   for (const auto &[idx, target] : llvm::enumerate(clusters)) {
-    if (target.getClusterKindName() == "tensorrt") {
+    if (isa<TensorRTClusterKindAttr>(target)) {
       patterns.add(target.getClusterKindOptions(solver, opts.trtMajorVersion),
                    createInlineGroupOp, isOpInClusterRegion,
                    target.getClusterFilter(),

--- a/mlir-tensorrt/test/Dialect/StableHloExt/canonicalize-scatter-nd.mlir
+++ b/mlir-tensorrt/test/Dialect/StableHloExt/canonicalize-scatter-nd.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-tensorrt-opt %s --stablehlo-ext-canonicalize-scatter --stablehlo-aggressive-simplification -split-input-file | FileCheck %s
+// RUN: mlir-tensorrt-opt %s --stablehlo-ext-canonicalize-scatter -split-input-file | FileCheck %s
 
 
 func.func @whisper_jax_scatter(%arg0: tensor<1x51865xf32>) -> tensor<1x51865xf32> {
@@ -22,22 +22,19 @@ func.func @whisper_jax_scatter(%arg0: tensor<1x51865xf32>) -> tensor<1x51865xf32
 }
 
 
-// CHECK-LABEL: @whisper_jax_scatter
-//  CHECK-SAME: (%[[arg0:.+]]: tensor<1x51865xf32>)
-//   CHECK-DAG:     %[[v0:.+]] = stablehlo.constant dense<0xFF800000> : tensor<1x1xf32>
+// CHECK-LABEL: func.func @whisper_jax_scatter
+//  CHECK-SAME: (%[[arg0:.+]]: tensor<1x51865xf32>) -> tensor<1x51865xf32> {
 //   CHECK-DAG:     %[[cst:.+]] = arith.constant dense<50257> : tensor<1x1xi32>
-//       CHECK:     %[[v1:.+]] = stablehlo.reshape %[[arg0]]
-//       CHECK:     %[[v2:.+]] = "stablehlo.scatter"(%[[v1]], %[[cst]], %[[v0]])
-//  CHECK-SAME:       indices_are_sorted = false
-//  CHECK-SAME:       #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>
-
-//  CHECK-SAME:       unique_indices = false
-//  CHECK-NEXT:     ^bb0(%[[arg1:.+]]: tensor<f32>, %[[arg2:.+]]: tensor<f32>):
-//  CHECK-NEXT:       stablehlo.return %[[arg2]] : tensor<f32>
-//  CHECK-NEXT:     }) {tensorrt.canonicalized_scatter}
-//  CHECK-SAME:        : (tensor<51865x1xf32>, tensor<1x1xi32>, tensor<1x1xf32>) -> tensor<51865x1xf32>
-
-//       CHECK:     %[[v3:.+]] = stablehlo.reshape
+//   CHECK-DAG:     %[[cst_0:.+]] = stablehlo.constant dense<0xFF800000> : tensor<1x1x1xf32>
+//   CHECK-DAG:     %[[v0:.+]] = stablehlo.transpose %[[arg0]], dims = [1, 0] : (tensor<1x51865xf32>) -> tensor<51865x1xf32>
+//   CHECK-DAG:     %[[v1:.+]] = stablehlo.reshape %[[cst_0]] : (tensor<1x1x1xf32>) -> tensor<1x1xf32>
+//       CHECK:     %[[v2:.+]] = "stablehlo.scatter"(%[[v0]], %[[cst]], %[[v1]])
+//  CHECK-SAME:        <{indices_are_sorted = false,
+//  CHECK-SAME:        scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1],
+//  CHECK-SAME:        inserted_window_dims = [0], scatter_dims_to_operand_dims = [0],
+//  CHECK-SAME:        index_vector_dim = 1>, unique_indices = false}> ({
+//       CHECK:     }) {tensorrt.canonicalized_scatter} : (tensor<51865x1xf32>, tensor<1x1xi32>, tensor<1x1xf32>) -> tensor<51865x1xf32>
+//       CHECK:     %[[v3:.+]] = stablehlo.transpose %[[v2]], dims = [1, 0] : (tensor<51865x1xf32>) -> tensor<1x51865xf32>
 //       CHECK:     return %[[v3]] : tensor<1x51865xf32>
 
 // -----
@@ -60,20 +57,21 @@ func.func @whisper_jax_scatter2(%arg0: tensor<1x51865xf32>, %arg1: tensor<88x1xi
   return %3 : tensor<1x51865xf32>
 }
 
-// CHECK-LABEL: @whisper_jax_scatter2
+// CHECK-LABEL: func.func @whisper_jax_scatter2
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<1x51865xf32>, %[[arg1:.+]]: tensor<88x1xi32>) -> tensor<1x51865xf32> {
-//       CHECK:     %[[v0:.+]] = stablehlo.constant dense<0xFF800000> : tensor<88x1xf32>
-//       CHECK:     %[[v1:.+]] = stablehlo.reshape
-//       CHECK:     %[[v2:.+]] = "stablehlo.scatter"(%[[v1]], %[[arg1]], %[[v0]])
-//  CHECK-SAME:      indices_are_sorted = false
-//  CHECK-SAME:      scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>
-//  CHECK-SAME:      unique_indices = false
-//  CHECK-NEXT:     ^bb0(%[[arg2:.+]]: tensor<f32>, %[[arg3:.+]]: tensor<f32>):
-//  CHECK-NEXT:       stablehlo.return %[[arg3]] : tensor<f32>
-//  CHECK-NEXT:     }) {tensorrt.canonicalized_scatter}
-//  CHECK-SAME:      (tensor<51865x1xf32>, tensor<88x1xi32>, tensor<88x1xf32>) -> tensor<51865x1xf32>
-//       CHECK:     %[[v3:.+]] = stablehlo.reshape
-//       CHECK:     return %[[v3]] : tensor<1x51865xf32>
+//       CHECK:   %[[cst:.+]] = stablehlo.constant dense<0xFF800000> : tensor<88x1x1xf32>
+//       CHECK:   %[[v0:.+]] = stablehlo.transpose %[[arg0]], dims = [1, 0] : (tensor<1x51865xf32>) -> tensor<51865x1xf32>
+//       CHECK:   %[[v1:.+]] = stablehlo.reshape %[[cst]] : (tensor<88x1x1xf32>) -> tensor<88x1xf32>
+//       CHECK:   %[[v2:.+]] = "stablehlo.scatter"(%[[v0]], %[[arg1]], %[[v1]])
+//  CHECK-SAME:     <{indices_are_sorted = false,
+//  CHECK-SAME:     scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1],
+//  CHECK-SAME:     inserted_window_dims = [0], scatter_dims_to_operand_dims = [0],
+//  CHECK-SAME:     index_vector_dim = 1>, unique_indices = false}>
+//       CHECK:   }) {tensorrt.canonicalized_scatter}
+//  CHECK-SAME:    : (tensor<51865x1xf32>, tensor<88x1xi32>, tensor<88x1xf32>) -> tensor<51865x1xf32>
+//       CHECK:   %[[v3:.+]] = stablehlo.transpose %[[v2]], dims = [1, 0] : (tensor<51865x1xf32>) -> tensor<1x51865xf32>
+//       CHECK:   return %[[v3]] : tensor<1x51865xf32>
+
 // -----
 
 func.func @stablehlo_scatter_canonicalize(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>, %arg2: tensor<2xi32>, %arg3: tensor<2x3xf32>, %arg4: tensor<2x3xf32>) -> tensor<3x3xf32> {
@@ -95,18 +93,22 @@ func.func @stablehlo_scatter_canonicalize(%arg0: tensor<3x3xf32>, %arg1: tensor<
   return %0#0 : tensor<3x3xf32>
 }
 
-// CHECK-LABEL: @stablehlo_scatter_canonicalize
+// CHECK-LABEL: func.func @stablehlo_scatter_canonicalize
 //  CHECK-SAME: (%[[arg0:.+]]: tensor<3x3xf32>, %[[arg1:.+]]: tensor<3x3xf32>, %[[arg2:.+]]: tensor<2xi32>, %[[arg3:.+]]: tensor<2x3xf32>, %[[arg4:.+]]: tensor<2x3xf32>) -> tensor<3x3xf32> {
-//       CHECK:     %[[v0:.+]] = stablehlo.reshape %[[arg2]] : (tensor<2xi32>) -> tensor<2x1xi32>
-//       CHECK:     %[[v2:.+]]:2 = "stablehlo.scatter"(%[[arg0]], %[[arg1]], %[[v0]], %[[arg3]], %[[arg4]])
-//  CHECK-SAME:       indices_are_sorted = false
-//  CHECK-SAME:       scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>
-//  CHECK-SAME:       unique_indices = false
-//  CHECK-NEXT:     ^bb0(%[[arg5:.+]]: tensor<f32>, %[[arg6:.+]]: tensor<f32>, %[[arg7:.+]]: tensor<f32>, %[[arg8:.+]]: tensor<f32>):
-//  CHECK-NEXT:       stablehlo.return %[[arg5]], %[[arg7]] : tensor<f32>, tensor<f32>
-//  CHECK-NEXT:     }) {tensorrt.canonicalized_scatter}
-//  CHECK-SAME:       : (tensor<3x3xf32>, tensor<3x3xf32>, tensor<2x1xi32>, tensor<2x3xf32>, tensor<2x3xf32>) -> (tensor<3x3xf32>, tensor<3x3xf32>)
-//       CHECK:     return %[[v2]]#0 : tensor<3x3xf32>
+//   CHECK-DAG:   %[[v0:.+]] = stablehlo.reshape %[[arg2]] : (tensor<2xi32>) -> tensor<2x1xi32>
+//   CHECK-DAG:   %[[v1:.+]] = stablehlo.reshape %[[arg3]] : (tensor<2x3xf32>) -> tensor<2x1x3xf32>
+//   CHECK-DAG:   %[[v2:.+]] = stablehlo.reshape %[[arg4]] : (tensor<2x3xf32>) -> tensor<2x1x3xf32>
+//   CHECK-DAG:   %[[v3:.+]] = stablehlo.reshape %[[v1]] : (tensor<2x1x3xf32>) -> tensor<2x3xf32>
+//   CHECK-DAG:   %[[v4:.+]] = stablehlo.reshape %[[v2]] : (tensor<2x1x3xf32>) -> tensor<2x3xf32>
+//       CHECK:   %[[v5:.+]]:2 = "stablehlo.scatter"(%[[arg0]], %[[arg1]], %[[v0]], %[[v3]], %[[v4]])
+//  CHECK-SAME:     <{indices_are_sorted = false,
+//  CHECK-SAME:     scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1],
+//  CHECK-SAME:     inserted_window_dims = [0],
+//  CHECK-SAME:     scatter_dims_to_operand_dims = [0],
+//  CHECK-SAME:     index_vector_dim = 1>, unique_indices = false}>
+//       CHECK:   }) {tensorrt.canonicalized_scatter}
+//  CHECK-SAME:     : (tensor<3x3xf32>, tensor<3x3xf32>, tensor<2x1xi32>, tensor<2x3xf32>, tensor<2x3xf32>) -> (tensor<3x3xf32>, tensor<3x3xf32>)
+//       CHECK:     return %[[v5]]#0 : tensor<3x3xf32>
 
 // -----
 

--- a/mlir-tensorrt/test/Dialect/StableHloExt/canonicalize-scatter.mlir
+++ b/mlir-tensorrt/test/Dialect/StableHloExt/canonicalize-scatter.mlir
@@ -1,4 +1,4 @@
-// RUN:  mlir-tensorrt-opt %s -split-input-file -stablehlo-ext-canonicalize-scatter -stablehlo-aggressive-simplification | FileCheck %s
+// RUN:  mlir-tensorrt-opt %s -split-input-file -stablehlo-ext-canonicalize-scatter | FileCheck %s
 
 func.func @insert_index_vector_and_window_dims(%dst1: tensor<3x3xf32>,
     %dst2: tensor<3x3xf32>, %indices: tensor<2xi32>, %update1: tensor<2x3xf32>,
@@ -19,19 +19,22 @@ func.func @insert_index_vector_and_window_dims(%dst1: tensor<3x3xf32>,
        tensor<2x3xf32>, tensor<2x3xf32>) -> (tensor<3x3xf32>, tensor<3x3xf32>)
   func.return %0 : tensor<3x3xf32>
 }
-// CHECK-LABEL: func.func @insert_index_vector_and_window_dims(
-// CHECK-SAME:      %[[DST1:.*]]: tensor<3x3xf32>, %[[DST2:.*]]: tensor<3x3xf32>,
-// CHECK-SAME:      %[[IND:.*]]: tensor<2xi32>,
-// CHECK-SAME:      %[[UPD1:.*]]: tensor<2x3xf32>, %[[UPD2:.*]]: tensor<2x3xf32>)
 
-// CHECK:         %[[IND_:.*]] = stablehlo.reshape %[[IND]]
-
-// CHECK:         "stablehlo.scatter"(%[[DST1]], %[[DST2]], %[[IND_]], %[[UPD1]], %[[UPD2]])
-// CHECK:           update_window_dims = [1],
-// CHECK-SAME:      inserted_window_dims = [0]
-// CHECK-SAME:      scatter_dims_to_operand_dims = [0]
-// CHECK-SAME:      index_vector_dim = 1
-// CHECK-SAME:      unique_indices = false
+// CHECK-LABEL: func.func @insert_index_vector_and_window_dims
+//  CHECK-SAME: (%[[arg0:.+]]: tensor<3x3xf32>, %[[arg1:.+]]: tensor<3x3xf32>, %[[arg2:.+]]: tensor<2xi32>, %[[arg3:.+]]: tensor<2x3xf32>, %[[arg4:.+]]: tensor<2x3xf32>)
+//   CHECK-DAG:     %[[v0:.+]] = stablehlo.reshape %[[arg2]] : (tensor<2xi32>) -> tensor<2x1xi32>
+//   CHECK-DAG:     %[[v1:.+]] = stablehlo.reshape %[[arg3]] : (tensor<2x3xf32>) -> tensor<2x1x3xf32>
+//   CHECK-DAG:     %[[v2:.+]] = stablehlo.reshape %[[arg4]] : (tensor<2x3xf32>) -> tensor<2x1x3xf32>
+//   CHECK-DAG:     %[[v3:.+]] = stablehlo.reshape %[[v1]] : (tensor<2x1x3xf32>) -> tensor<2x3xf32>
+//   CHECK-DAG:     %[[v4:.+]] = stablehlo.reshape %[[v2]] : (tensor<2x1x3xf32>) -> tensor<2x3xf32>
+//       CHECK:     %[[v5:.+]]:2 = "stablehlo.scatter"(%[[arg0]], %[[arg1]], %[[v0]], %[[v3]], %[[v4]])
+//  CHECK-SAME:       <{indices_are_sorted = false,
+//  CHECK-SAME:         scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1],
+//  CHECK-SAME:         inserted_window_dims = [0], scatter_dims_to_operand_dims = [0],
+//  CHECK-SAME:         index_vector_dim = 1>, unique_indices = false}>
+//       CHECK:     }) {tensorrt.canonicalized_scatter}
+//  CHECK-SAME:    : (tensor<3x3xf32>, tensor<3x3xf32>, tensor<2x1xi32>, tensor<2x3xf32>, tensor<2x3xf32>) -> (tensor<3x3xf32>, tensor<3x3xf32>)
+//       CHECK:     return %[[v5]]#0 : tensor<3x3xf32>
 
 // -----
 
@@ -89,7 +92,7 @@ func.func @move_index_vector_dim(%dst: tensor<3x3xf32>,
 // CHECK-SAME:      %[[IND:.*]]: tensor<2x1xi32>,
 // CHECK-SAME:      %[[UPD:.*]]: tensor<1x3x3xf32>
 
-// CHECK:         %[[IND_:.*]] = stablehlo.reshape %[[IND]] : (tensor<2x1xi32>) -> tensor<1x2xi32>
+// CHECK:         %[[IND_:.*]] = stablehlo.transpose %[[IND]], {{.*}} : (tensor<2x1xi32>) -> tensor<1x2xi32>
 // CHECK:         "stablehlo.scatter"(%[[DST]], %[[IND_]], %[[UPD]])
 // CHECK:         #stablehlo.scatter<
 // CHECK:           update_window_dims = [1, 2],
@@ -122,15 +125,13 @@ func.func @transform_updates_and_operands_using_scatter_dims(%dst: tensor<3x4x5x
 
 // CHECK:         %[[DST_:.*]] = stablehlo.transpose %[[DST]],
 // CHECK-SAME:      dims = [2, 0, 1] : (tensor<3x4x5xf32>) -> tensor<5x3x4xf32>
-// CHECK:         %[[UPD_:.*]] = stablehlo.reshape %[[UPD]]
+// CHECK:         %[[UPD_:.*]] = stablehlo.transpose %[[UPD]]
 // CHECK-SAME:      (tensor<2x1x1x3xf32>) -> tensor<2x3x1x1xf32>
-
 // CHECK:         %[[NEW_OP:.*]] = "stablehlo.scatter"(%[[DST_]], %[[IND]], %[[UPD_]])
 // CHECK:         #stablehlo.scatter<
 // CHECK-SAME:       update_window_dims = [1, 2, 3],
 // CHECK-SAME:      scatter_dims_to_operand_dims = [0, 1],
 // CHECK-SAME:      index_vector_dim = 1
-
 // CHECK:        stablehlo.transpose %[[NEW_OP:.*]], dims = [1, 2, 0] : (tensor<5x3x4xf32>) -> tensor<3x4x5xf32>
 
 // -----
@@ -160,7 +161,7 @@ func.func @dynamic_transform_updates_and_operands(%dst: tensor<3x?x5xf32>,
 
 // CHECK:         %[[DST_:.*]] = stablehlo.transpose %[[DST]],
 // CHECK-SAME:      dims = [2, 0, 1] : (tensor<3x?x5xf32>) -> tensor<5x3x?xf32>
-// CHECK:         %[[UPD_:.*]] = stablehlo.reshape %[[UPD]]
+// CHECK:         %[[UPD_:.*]] = stablehlo.transpose %[[UPD]]
 // CHECK-SAME:      (tensor<2x1x1x3xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[NEW_OP:.*]] = "stablehlo.scatter"(%[[DST_]], %[[IND]], %[[UPD_]])
 // CHECK:         #stablehlo.scatter<
@@ -192,10 +193,8 @@ func.func @make_scatter_dims_leading_in_updates(%dst: tensor<3xf32>,
 // CHECK-SAME:      %[[DST:.*]]: tensor<3xf32>,
 // CHECK-SAME:      %[[IND:.*]]: tensor<1x1xi32>,
 // CHECK-SAME:      %[[UPD:.*]]: tensor<2x1xf32>
-
-// CHECK:         %[[UPD_:.*]] = stablehlo.reshape %[[UPD]]
+// CHECK:         %[[UPD_:.*]] = stablehlo.transpose %[[UPD]]
 // CHECK-SAME:      (tensor<2x1xf32>) -> tensor<1x2xf32>
-
 // CHECK:         "stablehlo.scatter"(%[[DST]], %[[IND]], %[[UPD_]]
 // CHECK:         #stablehlo.scatter<
 // CHECK-SAME:      update_window_dims = [1],
@@ -288,14 +287,18 @@ func.func @multiple_window_and_scatter_dims(
   return %0 : tensor<1x2x3x4x5xf32>
 }
 
-// CHECK-LABEL: @multiple_window_and_scatter_dims(
-// CHECK-SAME:      %[[DST:.*]]: tensor<1x2x3x4x5xf32>,
-// CHECK-SAME:      %[[IND:.*]]: tensor<6x7x2xi32>,
-// CHECK-SAME:      %[[UPD:.*]]: tensor<2x6x4x7xf32>
-// CHECK:         %[[IND0:.*]] = stablehlo.reshape %[[IND]] : (tensor<6x7x2xi32>) -> tensor<42x2xi32>
-// CHECK:         %[[UPD0:.*]] = stablehlo.transpose %[[UPD]], dims = [1, 3, 0, 2] : (tensor<2x6x4x7xf32>) -> tensor<6x7x2x4xf32>
-// CHECK:         %[[UPD1:.*]] = stablehlo.reshape %[[UPD0]] : (tensor<6x7x2x4xf32>) -> tensor<42x1x2x1x4x1xf32>
-// CHECK:         "stablehlo.scatter"(%[[DST]], %[[IND0]], %[[UPD1]])
+// CHECK-LABEL: func.func @multiple_window_and_scatter_dims
+//  CHECK-SAME: (%[[arg0:.+]]: tensor<1x2x3x4x5xf32>, %[[arg1:.+]]: tensor<6x7x2xi32>, %[[arg2:.+]]: tensor<2x6x4x7xf32>) -> tensor<1x2x3x4x5xf32> {
+//       CHECK:     %[[v0:.+]] = stablehlo.reshape %[[arg1]] : (tensor<6x7x2xi32>) -> tensor<42x2xi32>
+//       CHECK:     %[[v1:.+]] = stablehlo.transpose %[[arg2]], dims = [1, 3, 0, 2] : (tensor<2x6x4x7xf32>) -> tensor<6x7x2x4xf32>
+//       CHECK:     %[[v2:.+]] = stablehlo.reshape %[[v1]] : (tensor<6x7x2x4xf32>) -> tensor<42x2x4xf32>
+//       CHECK:     %[[v3:.+]] = stablehlo.reshape %[[v2]] : (tensor<42x2x4xf32>) -> tensor<42x1x2x1x4x1xf32>
+//       CHECK:     %[[v4:.+]] = "stablehlo.scatter"(%[[arg0]], %[[v0]], %[[v3]])
+//  CHECK-SAME:      <{indices_are_sorted = false,
+//  CHECK-SAME:       scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2, 3, 4, 5],
+//  CHECK-SAME:       scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false}>
+//       CHECK:     : (tensor<1x2x3x4x5xf32>, tensor<42x2xi32>, tensor<42x1x2x1x4x1xf32>) -> tensor<1x2x3x4x5xf32>
+//       CHECK:     return %[[v4]] : tensor<1x2x3x4x5xf32>
 
 // -----
 
@@ -319,29 +322,42 @@ func.func @dynamic_window_size_multiple_window_and_scatter_dims(
 }
 
 // CHECK-LABEL: func.func @dynamic_window_size_multiple_window_and_scatter_dims
-//  CHECK-SAME: (%[[arg0:.+]]: tensor<1x2x3x4x5xf32>, %[[arg1:.+]]: tensor<?x?x2xi32>, %[[arg2:.+]]: tensor<2x?x4x?xf32>)
+//  CHECK-SAME: (%[[arg0:.+]]: tensor<1x2x3x4x5xf32>, %[[arg1:.+]]: tensor<?x?x2xi32>, %[[arg2:.+]]: tensor<2x?x4x?xf32>) -> tensor<1x2x3x4x5xf32> {
 //   CHECK-DAG:     %[[c:.+]] = stablehlo.constant dense<4> : tensor<1xi32>
 //   CHECK-DAG:     %[[c_0:.+]] = stablehlo.constant dense<2> : tensor<1xi32>
 //   CHECK-DAG:     %[[c_1:.+]] = stablehlo.constant dense<1> : tensor<1xi32>
-//   CHECK-DAG:     %[[v0:.+]] = stablehlo.get_dimension_size %[[arg1]], dim = 0 : (tensor<?x?x2xi32>) -> tensor<i32>
-//   CHECK-DAG:     %[[v1:.+]] = stablehlo.get_dimension_size %[[arg1]], dim = 1 : (tensor<?x?x2xi32>) -> tensor<i32>
-//   CHECK-DAG:     %[[v2:.+]] = stablehlo.multiply %[[v0]], %[[v1]] : tensor<i32>
-//   CHECK-DAG:     %[[v3:.+]] = stablehlo.reshape %[[v2]] : (tensor<i32>) -> tensor<1xi32>
-//   CHECK-DAG:     %[[v4:.+]] = stablehlo.concatenate %[[v3]], %[[c_0]], dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
-//   CHECK-DAG:     %[[v5:.+]] = stablehlo.dynamic_reshape %[[arg1]], %[[v4]] : (tensor<?x?x2xi32>, tensor<2xi32>) -> tensor<?x2xi32>
-//   CHECK-DAG:     %[[v6:.+]] = stablehlo.transpose %[[arg2]], dims = [1, 3, 0, 2] : (tensor<2x?x4x?xf32>) -> tensor<?x?x2x4xf32>
-//   CHECK-DAG:     %[[v7:.+]] = stablehlo.get_dimension_size %[[v6]], dim = 0 : (tensor<?x?x2x4xf32>) -> tensor<i32>
-//   CHECK-DAG:     %[[v8:.+]] = stablehlo.get_dimension_size %[[v6]], dim = 1 : (tensor<?x?x2x4xf32>) -> tensor<i32>
-//   CHECK-DAG:     %[[v9:.+]] = stablehlo.multiply %[[v7]], %[[v8]] : tensor<i32>
-//   CHECK-DAG:     %[[v10:.+]] = stablehlo.reshape %[[v9]] : (tensor<i32>) -> tensor<1xi32>
-//   CHECK-DAG:     %[[v11:.+]] = stablehlo.concatenate %[[v10]], %[[c_0]], %[[c]], dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xi32>
-//   CHECK-DAG:     %[[v12:.+]] = stablehlo.dynamic_reshape %[[v6]], %[[v11]] : (tensor<?x?x2x4xf32>, tensor<3xi32>) -> tensor<?x2x4xf32>
-//   CHECK-DAG:     %[[v13:.+]] = stablehlo.get_dimension_size %[[v12]], dim = 0 : (tensor<?x2x4xf32>) -> tensor<i32>
-//   CHECK-DAG:     %[[v14:.+]] = stablehlo.reshape %[[v13]] : (tensor<i32>) -> tensor<1xi32>
-//   CHECK-DAG:     %[[v15:.+]] = stablehlo.concatenate %[[v14]], %[[c_1]], %[[c_0]], %[[c_1]], %[[c]], %[[c_1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<6xi32>
-//   CHECK-DAG:     %[[v16:.+]] = stablehlo.dynamic_reshape %[[v12]], %[[v15]] : (tensor<?x2x4xf32>, tensor<6xi32>) -> tensor<?x1x2x1x4x1xf32>
-//   CHECK-DAG:     %[[v17:.+]] = "stablehlo.scatter"(%[[arg0]], %[[v5]], %[[v16]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2, 3, 4, 5], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false}> ({
-//   CHECK-DAG:     ^bb0(%[[arg3:.+]]: tensor<f32>, %[[arg4:.+]]: tensor<f32>):
-//   CHECK-DAG:       stablehlo.return %[[arg3]] : tensor<f32>
-//   CHECK-DAG:     }) : (tensor<1x2x3x4x5xf32>, tensor<?x2xi32>, tensor<?x1x2x1x4x1xf32>) -> tensor<1x2x3x4x5xf32>
-//   CHECK-DAG:     return %[[v17]] : tensor<1x2x3x4x5xf32>
+//   CHECK-DAG:     %[[c_2:.+]] = stablehlo.constant dense<1> : tensor<i32>
+//   CHECK-DAG:     %[[v0:.+]] = stablehlo.get_dimension_size %[[arg1]], dim = 0
+//   CHECK-DAG:     %[[v1:.+]] = stablehlo.multiply %[[c_2]], %[[v0]] : tensor<i32>
+//   CHECK-DAG:     %[[v2:.+]] = stablehlo.get_dimension_size %[[arg1]], dim = 1
+//   CHECK-DAG:     %[[v3:.+]] = stablehlo.multiply %[[v1]], %[[v2]] : tensor<i32>
+//   CHECK-DAG:     %[[v4:.+]] = stablehlo.reshape %[[v3]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v5:.+]] = stablehlo.get_dimension_size %[[arg1]], dim = 2
+//   CHECK-DAG:     %[[v6:.+]] = stablehlo.multiply %[[c_2]], %[[v5]] : tensor<i32>
+//   CHECK-DAG:     %[[v7:.+]] = stablehlo.reshape %[[v6]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v8:.+]] = stablehlo.concatenate %[[v4]], %[[v7]], dim = 0 :
+//   CHECK-DAG:     %[[v9:.+]] = stablehlo.dynamic_reshape %[[arg1]], %[[v8]] :
+//   CHECK-DAG:     %[[v10:.+]] = stablehlo.transpose %[[arg2]], dims = [1, 3, 0, 2] :
+//   CHECK-DAG:     %[[v11:.+]] = stablehlo.get_dimension_size %[[v10]], dim = 0 :
+//   CHECK-DAG:     %[[v12:.+]] = stablehlo.multiply %[[c_2]], %[[v11]] : tensor<i32>
+//   CHECK-DAG:     %[[v13:.+]] = stablehlo.get_dimension_size %[[v10]], dim = 1 :
+//   CHECK-DAG:     %[[v14:.+]] = stablehlo.multiply %[[v12]], %[[v13]] : tensor<i32>
+//   CHECK-DAG:     %[[v15:.+]] = stablehlo.reshape %[[v14]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v16:.+]] = stablehlo.get_dimension_size %[[v10]], dim = 2 :
+//   CHECK-DAG:     %[[v17:.+]] = stablehlo.multiply %[[c_2]], %[[v16]] : tensor<i32>
+//   CHECK-DAG:     %[[v18:.+]] = stablehlo.reshape %[[v17]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v19:.+]] = stablehlo.get_dimension_size %[[v10]], dim = 3 :
+//   CHECK-DAG:     %[[v20:.+]] = stablehlo.multiply %[[c_2]], %[[v19]] : tensor<i32>
+//   CHECK-DAG:     %[[v21:.+]] = stablehlo.reshape %[[v20]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v22:.+]] = stablehlo.concatenate %[[v15]], %[[v18]], %[[v21]], dim = 0 :
+//   CHECK-DAG:     %[[v23:.+]] = stablehlo.dynamic_reshape %[[v10]], %[[v22]] : (tensor<?x?x2x4xf32>, tensor<3xi32>) -> tensor<?x2x4xf32>
+//   CHECK-DAG:     %[[v24:.+]] = stablehlo.get_dimension_size %[[v23]], dim = 0 : (tensor<?x2x4xf32>) -> tensor<i32>
+//   CHECK-DAG:     %[[v25:.+]] = stablehlo.reshape %[[v24]] : (tensor<i32>) -> tensor<1xi32>
+//   CHECK-DAG:     %[[v26:.+]] = stablehlo.concatenate %[[v25]], %[[c_1]], %[[c_0]], %[[c_1]], %[[c]], %[[c_1]], dim = 0 :
+//       CHECK:     %[[v27:.+]] = stablehlo.dynamic_reshape %[[v23]], %[[v26]] :
+//       CHECK:     %[[v28:.+]] = "stablehlo.scatter"(%[[arg0]], %[[v9]], %[[v27]])
+//  CHECK-SAME:       <{indices_are_sorted = false,
+//  CHECK-SAME:         scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2, 3, 4, 5],
+//  CHECK-SAME:         scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false}>
+//       CHECK:     }) : (tensor<1x2x3x4x5xf32>, tensor<?x2xi32>, tensor<?x1x2x1x4x1xf32>) -> tensor<1x2x3x4x5xf32>
+//       CHECK:     return %[[v28]] : tensor<1x2x3x4x5xf32>


### PR DESCRIPTION
This is a combination of the following changes:

[compiler/Dialect/Plan] Drop `getClusterKindName` from `ClusterKindAttrInterface`

Removes the concept of having a cluster "name" from the `plan::ClusterKindAttrInterface`.
This concept is unnecessary since all concrete implementations of the interface
have their own mnemonic.

NFC: [compiler/StableHloExt] Update tests to avoid relying on other canonicalization patterns

Updates `stablehlo-ext-canonicalize-scatter` pass test cases to void relying
on other canonicalization patterns and just tests the effects of the 'stablehlo.scatter'
canonicalization patterns.
