### PR TITLE
Removes Parameter API

### DIFF
--- a/tripy/docs/README.md
+++ b/tripy/docs/README.md
@@ -85,7 +85,7 @@ This means we need to make some special considerations:
     For example:
 
     ```md
-    {class}`tripy.Parameter`
+    {class}`tripy.Tensor`
     ```
 
     `<api_kind>` can take on any value that is a valid role provided by

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -292,7 +292,8 @@ def process_docstring_impl(app, what, name, obj, options, lines):
             strip_assertions=True,
         )
 
-        code_block_lines += local_var_lines + output_lines
+        # Sphinx requires a new line after markup
+        code_block_lines += ["\n"] + local_var_lines + output_lines
 
         # Grab the caption from the example code block.
         for line in code_block_lines:

--- a/tripy/docs/pre0_user_guides/01-quantization.md
+++ b/tripy/docs/pre0_user_guides/01-quantization.md
@@ -19,7 +19,7 @@ quant_linear = tp.Linear(
 ```
 
 As described in {class}`tripy.Linear`, the quantized linear module has
-2 additional {class}`tripy.Parameter`s compared to a normal linear layer:
+2 additional parameters compared to a normal linear layer:
 
 1. `weight_scale`: The quantization scale for `weight`.
 
@@ -33,8 +33,8 @@ Let's fill the scale parameters with dummy data:
 
 ```py
 # doc: print-locals quant_linear
-quant_linear.weight_scale = tp.Parameter(1.0)
-quant_linear.input_scale = tp.Parameter(1.0)
+quant_linear.weight_scale = tp.Tensor(1.0)
+quant_linear.input_scale = tp.Tensor(1.0)
 ```
 
 and run a forward pass to see the result:
@@ -42,6 +42,7 @@ and run a forward pass to see the result:
 ```py
 x = tp.iota((3, 4), dtype=tp.float32)
 out = quant_linear(x)
+assert tp.equal(out, tp.Tensor([[0.0000, 1.0000], [6.0000, 23.0000], [12.0000, 45.0000]])) # doc: omit
 ```
 
 The result still has a data type of {class}`tripy.float32`, but internally, TensorRT quantized the
@@ -144,7 +145,7 @@ weight_only_qlinear = tp.Linear(
 quantizer = model.transformer.h[0].attn.c_attn.weight_quantizer
 scale = convert_to_scale(quantizer.export_amax(), quantizer.maxbound)
 scale = scale.squeeze().contiguous()
-weight_only_qlinear.weight_scale = tp.Parameter(scale)
+weight_only_qlinear.weight_scale = tp.Tensor(scale)
 ```
 
 For an example of how to load weights from a quantized model, refer to

--- a/tripy/examples/nanogpt/weight_loader.py
+++ b/tripy/examples/nanogpt/weight_loader.py
@@ -49,7 +49,7 @@ def load_weights_from_hf(model, model_type, dtype):
                 weight = hf_state_dict[key].t().contiguous()
         if "ln" not in key:
             weight = weight.to(torch_dtype)
-        param = tp.Parameter(weight)
+        param = tp.Tensor(weight)
         tripy_state_dict[key] = param
 
     model.load_state_dict(tripy_state_dict)
@@ -109,7 +109,7 @@ def load_quant_weights_from_hf(model, model_type, dtype, quant_mode):
 
         if "ln" not in key:
             weight = weight.to(torch_dtype)
-        param = tp.Parameter(weight.contiguous())
+        param = tp.Tensor(weight.contiguous())
         tripy_state_dict[key] = param
 
     model.load_state_dict(tripy_state_dict)

--- a/tripy/tests/frontend/module/conftest.py
+++ b/tripy/tests/frontend/module/conftest.py
@@ -25,7 +25,7 @@ import tripy as tp
 class DummyNestedOp(tp.Module):
     def __init__(self, tensor):
         super().__init__()
-        self.param = tp.Parameter(tensor)
+        self.param = tensor
 
     def __call__(self):
         return self.param
@@ -43,7 +43,7 @@ class DummyOp(tp.Module):
 class Network(tp.Module):
     def __init__(self):
         super().__init__()
-        self.param = tp.Parameter(tp.ones((2,), dtype=tp.float32))
+        self.param = tp.ones((2,), dtype=tp.float32)
         self.dummy1 = DummyOp(tp.zeros((2,), dtype=tp.float32))
         self.dummy2 = DummyOp(tp.arange(2, dtype=tp.float32))
 
@@ -54,7 +54,7 @@ class Network(tp.Module):
 class ListNetwork(tp.Module):
     def __init__(self):
         super().__init__()
-        self.params = [tp.Parameter(tp.ones((2,), dtype=tp.float32))]
+        self.params = [tp.ones((2,), dtype=tp.float32)]
         self.dummy_list = [DummyOp(tp.zeros((2,), dtype=tp.float32)), DummyOp(tp.arange(2, dtype=tp.float32))]
 
     def __call__(self):
@@ -67,7 +67,7 @@ class ListNetwork(tp.Module):
 class DictNetwork(tp.Module):
     def __init__(self):
         super().__init__()
-        self.params = {"param": tp.Parameter(tp.ones((2,), dtype=tp.float32))}
+        self.params = {"param": tp.ones((2,), dtype=tp.float32)}
         self.dummy_dict = {
             "op0": DummyOp(tp.zeros((2,), dtype=tp.float32)),
             "op1": DummyOp(tp.arange(2, dtype=tp.float32)),
@@ -112,7 +112,7 @@ class ComplexNetwork(tp.Module):
 class MixedContainerNetwork(tp.Module):
     def __init__(self):
         super().__init__()
-        self.param = tp.Parameter(tp.ones((2,), dtype=tp.float32))
+        self.param = tp.ones((2,), dtype=tp.float32)
 
         # Define a mixed list with both modules and lambda functions
         self.mixed_list = [

--- a/tripy/tests/frontend/module/test_linear.py
+++ b/tripy/tests/frontend/module/test_linear.py
@@ -53,8 +53,8 @@ class TestLinear:
         assert qlinear.weight.shape == [30, 20]
         assert qlinear.bias.shape == [30]
         assert qlinear.weight_quant_dim == weight_quant_dim
-        assert isinstance(qlinear.weight_scale, tp.Parameter)
-        assert isinstance(qlinear.input_scale, tp.Parameter)
+        assert isinstance(qlinear.weight_scale, tp.Tensor)
+        assert isinstance(qlinear.input_scale, tp.Tensor)
 
     def test_load_quantized_params_from_state_dict(self):
         qlinear = tp.Linear(
@@ -65,6 +65,6 @@ class TestLinear:
         )
 
         qlinear.load_state_dict(
-            {"weight_scale": tp.Parameter(tp.ones((30,))), "input_scale": tp.Parameter(tp.ones((20,)))},
+            {"weight_scale": tp.ones((30,)), "input_scale": tp.ones((20,))},
             strict=False,
         )

--- a/tripy/tests/frontend/module/test_parameter.py
+++ b/tripy/tests/frontend/module/test_parameter.py
@@ -21,64 +21,15 @@ import numpy as np
 import tripy as tp
 from tripy.frontend.module.parameter import DefaultParameter
 from tripy.frontend.trace.ops import Storage
-import pytest
-
-
-class TestParameter:
-    def test_is_instance_of_tensor(self):
-        param = tp.Parameter(tp.Tensor([1, 2, 3]))
-        assert isinstance(param, tp.Parameter)
-
-        tensor = tp.Tensor([1, 2, 3])
-        assert not isinstance(tensor, tp.Parameter)
-
-    def test_is_equivalent_to_tensor(self):
-        tensor = tp.Tensor([1, 2, 3])
-        param = tp.Parameter(tensor)
-
-        assert tp.equal(param, tensor)
-
-    def test_can_construct_from_non_tensor(self):
-        param = tp.Parameter([1, 2, 3])
-        assert np.array_equal(cp.from_dlpack(param).get(), np.array([1, 2, 3], dtype=np.int32))
-
-    @pytest.mark.parametrize(
-        "other,is_compatible",
-        [
-            (tp.Parameter(tp.ones((1, 2), dtype=tp.float32)), True),
-            # Different shape
-            (tp.Parameter(tp.ones((2, 2), dtype=tp.float32)), False),
-            # Different dtype
-            (tp.Parameter(tp.ones((1, 2), dtype=tp.float16)), False),
-        ],
-    )
-    def test_is_compatible(self, other, is_compatible):
-        param = tp.Parameter(tp.ones((1, 2), dtype=tp.float32))
-
-        assert bool(param._is_compatible(other)) == is_compatible
 
 
 class TestDefaultParameter:
-    @pytest.mark.parametrize(
-        "other,is_compatible",
-        [
-            (tp.Parameter(tp.ones((1, 2), dtype=tp.float32)), True),
-            # Different shape
-            (tp.Parameter(tp.ones((2, 2), dtype=tp.float32)), False),
-            # Different dtype
-            (tp.Parameter(tp.ones((1, 2), dtype=tp.float16)), False),
-        ],
-    )
-    def test_is_compatible(self, other, is_compatible):
+    def test_shape_dtype_access_does_not_materialize_data(self):
         param = DefaultParameter((1, 2), dtype=tp.float32)
+        assert param.shape == [1, 2]
+        assert type(param.shape[0]) is int  # Make sure we are not compiling and getting DimensionSizes
 
-        assert bool(param._is_compatible(other)) == is_compatible
-
-    def test_is_compatible_does_not_materialize_data(self):
-        param = DefaultParameter((1, 2), dtype=tp.float32)
-        other = tp.Parameter(tp.ones((1, 2), dtype=tp.float32))
-
-        assert param._is_compatible(other)
+        assert param.dtype == tp.float32
         assert not isinstance(param.trace_tensor.producer, Storage)
 
     def test_data_can_be_materialized(self):

--- a/tripy/tests/frontend/module/test_sequential.py
+++ b/tripy/tests/frontend/module/test_sequential.py
@@ -76,12 +76,12 @@ class TestSequential:
         assert list(state_dict.keys()) == expected_state_dict_keys
 
     def test_load_state_dict(self, sequential_network):
-        new_state_dict = {"0.weight": tp.Parameter(tp.ones((3, 1)))}
+        new_state_dict = {"0.weight": tp.ones((3, 1))}
         sequential_network.load_state_dict(new_state_dict, strict=False)
         assert tp.equal(sequential_network[0].weight, new_state_dict["0.weight"])
 
     def test_modify_parameters(self, sequential_network):
-        new_param = tp.Parameter(tp.ones((2, 3)))
+        new_param = tp.ones((2, 3))
         sequential_network[1].weight = new_param
         assert sequential_network[1].weight is new_param
 
@@ -129,12 +129,12 @@ class TestDictSequential:
         assert list(state_dict.keys()) == expected_keys
 
     def test_load_state_dict(self, dict_sequential_network):
-        new_state_dict = {"layer1.weight": tp.Parameter(tp.ones((3, 1)))}
+        new_state_dict = {"layer1.weight": tp.ones((3, 1))}
         dict_sequential_network.load_state_dict(new_state_dict, strict=False)
         assert tp.equal(dict_sequential_network["layer1"].weight, new_state_dict["layer1.weight"])
 
     def test_modify_parameters(self, dict_sequential_network):
-        new_weight = tp.Parameter(tp.ones((2, 3)))
+        new_weight = tp.ones((2, 3))
         dict_sequential_network["layer2"].weight = new_weight
         assert dict_sequential_network["layer2"].weight is new_weight
 
@@ -180,10 +180,10 @@ class TestMixedContainerSequential:
 
     def test_load_state_dict(self, mixed_container_sequential_network):
         new_state_dict = {
-            "0.weight": tp.Parameter(tp.ones((2, 2, 1, 1), dtype=tp.float32)),
-            "0.bias": tp.Parameter(tp.zeros((2,), dtype=tp.float32)),
-            "3.weight": tp.Parameter(tp.zeros((1, 2), dtype=tp.float32)),
-            "3.bias": tp.Parameter(tp.zeros((1,), dtype=tp.float32)),
+            "0.weight": tp.ones((2, 2, 1, 1), dtype=tp.float32),
+            "0.bias": tp.zeros((2,), dtype=tp.float32),
+            "3.weight": tp.zeros((1, 2), dtype=tp.float32),
+            "3.bias": tp.zeros((1,), dtype=tp.float32),
         }
         mixed_container_sequential_network.load_state_dict(new_state_dict, strict=False)
 
@@ -240,7 +240,7 @@ class TestNestedSequential:
     def test_load_state_dict_nested(self, nested_sequential_network):
         # Loading state dict with parameters for both top-level and nested modules
         new_state_dict = {
-            "1.1.weight": tp.Parameter(tp.ones((1, 3))),
+            "1.1.weight": tp.ones((1, 3)),
         }
         nested_sequential_network.load_state_dict(new_state_dict, strict=False)
         assert tp.equal(nested_sequential_network[1][1].weight, new_state_dict["1.1.weight"])

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -463,8 +463,7 @@ def process_code_block_for_outputs_and_locals(
         stripped_code_lines = indent(
             black.format_file_contents(
                 dedent("\n".join(stripped_code_lines)), fast=False, mode=black.Mode(line_length=MAX_LINE_LENGTH)
-            )
-            + "\n",
+            ),
             prefix=" " * indentation,
         ).splitlines()
     except black.NothingChanged:

--- a/tripy/tests/integration/test_batchnorm.py
+++ b/tripy/tests/integration/test_batchnorm.py
@@ -37,10 +37,10 @@ class TestBatchNorm:
         )
 
         # Use Tripy's parameters and ensure they match the dtype
-        tp_batchnorm.weight = tp.Parameter(batchnorm.weight.detach())
-        tp_batchnorm.bias = tp.Parameter(batchnorm.bias.detach())
-        tp_batchnorm.running_mean = tp.Parameter(batchnorm.running_mean.detach())
-        tp_batchnorm.running_var = tp.Parameter(batchnorm.running_var.detach())
+        tp_batchnorm.weight = tp.Tensor(batchnorm.weight.detach())
+        tp_batchnorm.bias = tp.Tensor(batchnorm.bias.detach())
+        tp_batchnorm.running_mean = tp.Tensor(batchnorm.running_mean.detach())
+        tp_batchnorm.running_var = tp.Tensor(batchnorm.running_var.detach())
 
         input = torch.randn(input_shape, dtype=torch_dtype).to("cuda")
         tp_input = tp.Tensor(input, dtype=tp_dtype)

--- a/tripy/tests/integration/test_groupnorm.py
+++ b/tripy/tests/integration/test_groupnorm.py
@@ -44,8 +44,8 @@ class TestGroupNorm:
             dtype=tp_dtype,
         )
 
-        tp_groupnorm.weight = tp.Parameter(groupnorm.weight.detach())
-        tp_groupnorm.bias = tp.Parameter(groupnorm.bias.detach())
+        tp_groupnorm.weight = tp.Tensor(groupnorm.weight.detach())
+        tp_groupnorm.bias = tp.Tensor(groupnorm.bias.detach())
 
         input = torch.arange(torch.prod(torch.Tensor(input_shape))).reshape(input_shape).to(torch_dtype)
         tp_input = tp.Tensor(input, dtype=tp_dtype)

--- a/tripy/tests/integration/test_layernorm.py
+++ b/tripy/tests/integration/test_layernorm.py
@@ -45,8 +45,8 @@ class TestLayerNorm:
         )
 
         # use Tripy's parameters
-        tp_layernorm.weight = tp.Parameter(layernorm.weight.detach())
-        tp_layernorm.bias = tp.Parameter(layernorm.bias.detach())
+        tp_layernorm.weight = tp.Tensor(layernorm.weight.detach())
+        tp_layernorm.bias = tp.Tensor(layernorm.bias.detach())
 
         input = torch.arange(torch.prod(torch.Tensor(input_shape))).reshape(input_shape).to(torch_dtype)
         tp_input = tp.Tensor(input, dtype=tp_dtype)

--- a/tripy/tests/integration/test_linear.py
+++ b/tripy/tests/integration/test_linear.py
@@ -60,7 +60,7 @@ class TestQuantLinear:
                 scale = [1.0] * out_feat
             elif quant_dim == 1:
                 scale = [1.0] * in_feat
-            return tp.Parameter(scale)
+            return tp.Tensor(scale)
 
         class Network(tp.Module):
             def __init__(self):
@@ -115,13 +115,13 @@ class TestQuantLinear:
         ids=["block-wise", "per-tensor", "per-channel-0", "per-channel-1"],
     )
     def test_quant_linear_int4_weight_only(self, weight_quant_dim, scale, eager_or_compiled):
-        scale = tp.Parameter(scale)
+        scale = tp.Tensor(scale)
 
         linear = tp.Linear(4, 8, quant_dtype=tp.int4, weight_quant_dim=weight_quant_dim)
         linear.weight_scale = scale
         # HACK: Use ones for stable accuracy.
-        linear.weight = tp.Parameter(tp.ones((8, 4)))
-        linear.bias = tp.Parameter(tp.ones((8,)))
+        linear.weight = tp.ones((8, 4))
+        linear.bias = tp.ones((8,))
 
         np_weight = cp.from_dlpack(linear.weight).get()
         np_bias = cp.from_dlpack(linear.bias).get()

--- a/tripy/tests/integration/test_sequential.py
+++ b/tripy/tests/integration/test_sequential.py
@@ -28,10 +28,10 @@ class TestSequential:
         )
         tp_model = tp.Sequential(tp.Linear(1, 3, dtype=tp.float32), tp.Linear(3, 2, dtype=tp.float32))
 
-        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model[1].weight = tp.Parameter(torch_model[1].weight.detach())
-        tp_model[1].bias = tp.Parameter(torch_model[1].bias.detach())
+        tp_model[0].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model[1].weight = tp.Tensor(torch_model[1].weight.detach())
+        tp_model[1].bias = tp.Tensor(torch_model[1].bias.detach())
 
         input_tensor = torch.tensor([[1.0]], dtype=torch.float32, device="cuda")
         tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
@@ -55,10 +55,10 @@ class TestSequential:
             {"layer1": tp.Linear(1, 3, dtype=tp.float32), "layer2": tp.Linear(3, 2, dtype=tp.float32)}
         )
 
-        tp_model["layer1"].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model["layer1"].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model["layer2"].weight = tp.Parameter(torch_model[1].weight.detach())
-        tp_model["layer2"].bias = tp.Parameter(torch_model[1].bias.detach())
+        tp_model["layer1"].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model["layer1"].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model["layer2"].weight = tp.Tensor(torch_model[1].weight.detach())
+        tp_model["layer2"].bias = tp.Tensor(torch_model[1].bias.detach())
 
         input_tensor = torch.tensor([[1.0]], dtype=torch.float32, device="cuda")
         tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
@@ -87,12 +87,12 @@ class TestSequential:
             tp.Sequential(tp.Linear(3, 4, dtype=tp.float32), tp.Linear(4, 2, dtype=tp.float32)),
         )
 
-        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model[1][0].weight = tp.Parameter(torch_model[1][0].weight.detach())
-        tp_model[1][0].bias = tp.Parameter(torch_model[1][0].bias.detach())
-        tp_model[1][1].weight = tp.Parameter(torch_model[1][1].weight.detach())
-        tp_model[1][1].bias = tp.Parameter(torch_model[1][1].bias.detach())
+        tp_model[0].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model[1][0].weight = tp.Tensor(torch_model[1][0].weight.detach())
+        tp_model[1][0].bias = tp.Tensor(torch_model[1][0].bias.detach())
+        tp_model[1][1].weight = tp.Tensor(torch_model[1][1].weight.detach())
+        tp_model[1][1].bias = tp.Tensor(torch_model[1][1].bias.detach())
 
         input_tensor = torch.tensor([[1.0]], dtype=torch.float32, device="cuda")
         tp_input = tp.Tensor(input_tensor, dtype=tp.float32)
@@ -112,10 +112,10 @@ class TestSequential:
         )
         tp_model = tp.Sequential(tp.Linear(1, 3, dtype=tp.float32), tp.Linear(3, 2, dtype=tp.float32))
 
-        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model[1].weight = tp.Parameter(torch_model[1].weight.detach())
-        tp_model[1].bias = tp.Parameter(torch_model[1].bias.detach())
+        tp_model[0].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model[1].weight = tp.Tensor(torch_model[1].weight.detach())
+        tp_model[1].bias = tp.Tensor(torch_model[1].bias.detach())
 
         torch_state_dict = torch_model.state_dict()
         tp_state_dict = tp_model.state_dict()
@@ -138,10 +138,10 @@ class TestSequential:
             {"layer1": tp.Linear(1, 3, dtype=tp.float32), "layer2": tp.Linear(3, 2, dtype=tp.float32)}
         )
 
-        tp_model["layer1"].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model["layer1"].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model["layer2"].weight = tp.Parameter(torch_model[1].weight.detach())
-        tp_model["layer2"].bias = tp.Parameter(torch_model[1].bias.detach())
+        tp_model["layer1"].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model["layer1"].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model["layer2"].weight = tp.Tensor(torch_model[1].weight.detach())
+        tp_model["layer2"].bias = tp.Tensor(torch_model[1].bias.detach())
 
         torch_state_dict = torch_model.state_dict()
         tp_state_dict = tp_model.state_dict()
@@ -161,12 +161,12 @@ class TestSequential:
             tp.Sequential(tp.Linear(3, 4, dtype=tp.float32), tp.Linear(4, 2, dtype=tp.float32)),
         )
 
-        tp_model[0].weight = tp.Parameter(torch_model[0].weight.detach())
-        tp_model[0].bias = tp.Parameter(torch_model[0].bias.detach())
-        tp_model[1][0].weight = tp.Parameter(torch_model[1][0].weight.detach())
-        tp_model[1][0].bias = tp.Parameter(torch_model[1][0].bias.detach())
-        tp_model[1][1].weight = tp.Parameter(torch_model[1][1].weight.detach())
-        tp_model[1][1].bias = tp.Parameter(torch_model[1][1].bias.detach())
+        tp_model[0].weight = tp.Tensor(torch_model[0].weight.detach())
+        tp_model[0].bias = tp.Tensor(torch_model[0].bias.detach())
+        tp_model[1][0].weight = tp.Tensor(torch_model[1][0].weight.detach())
+        tp_model[1][0].bias = tp.Tensor(torch_model[1][0].bias.detach())
+        tp_model[1][1].weight = tp.Tensor(torch_model[1][1].weight.detach())
+        tp_model[1][1].bias = tp.Tensor(torch_model[1][1].bias.detach())
 
         torch_state_dict = torch_model.state_dict()
         tp_state_dict = tp_model.state_dict()

--- a/tripy/tests/performance/cases/linear_block.py
+++ b/tripy/tests/performance/cases/linear_block.py
@@ -36,7 +36,7 @@ def linear_block(tripy_dtype, torch_dtype):
             for layer in self.layers:
                 # Adjust the weights to prevent FP16 overflows:
                 weight = np.tile(np.array([[-1, 1], [1, -1]], dtype=TRIPY_TO_NUMPY[tripy_dtype]), (128, 128))
-                layer.weight = tp.Parameter(weight)
+                layer.weight = tp.Tensor(weight)
 
         def __call__(self, input):
             for layer in self.layers:

--- a/tripy/tests/performance/test_perf.py
+++ b/tripy/tests/performance/test_perf.py
@@ -153,10 +153,10 @@ def test_tripy_overhead():
 
 def test_tripy_param_update(benchmark):
     m = tp.Module()
-    m.param = tp.Parameter([1, 2, 3, 4])
+    m.param = tp.Tensor([1, 2, 3, 4])
 
     # Leave the instantiation outside of the measured section to avoid overhead from registry calls.
-    new_param = tp.Parameter([5, 6, 7, 8])
+    new_param = tp.Tensor([5, 6, 7, 8])
 
     def measure_thunk():
         m.param = new_param

--- a/tripy/tripy/frontend/module/__init__.py
+++ b/tripy/tripy/frontend/module/__init__.py
@@ -16,4 +16,3 @@
 #
 
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import Parameter

--- a/tripy/tripy/frontend/module/batchnorm.py
+++ b/tripy/tripy/frontend/module/batchnorm.py
@@ -20,7 +20,8 @@ from dataclasses import dataclass
 from tripy import export, utils
 from tripy.common import datatype
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import DefaultParameter, Parameter
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules")
@@ -51,16 +52,16 @@ class BatchNorm(Module):
     eps: float
     r""":math:`\epsilon` value added to the denominator to prevent division by zero during normalization."""
 
-    weight: Parameter
+    weight: Tensor
     r"""The :math:`\gamma` parameter of shape :math:`[\text{num_features}]`."""
 
-    bias: Parameter
+    bias: Tensor
     r"""The :math:`\beta` parameter of shape :math:`[\text{num_features}]`."""
 
-    running_mean: Parameter
+    running_mean: Tensor
     r"""The running mean for the feature channels of shape :math:`[\text{num_features}]`."""
 
-    running_var: Parameter
+    running_var: Tensor
     r"""The running variance for the feature channels of shape :math:`[\text{num_features}]`."""
 
     def __init__(self, num_features: int, dtype: datatype.dtype = datatype.float32, eps: float = 1e-5) -> None:

--- a/tripy/tripy/frontend/module/conv.py
+++ b/tripy/tripy/frontend/module/conv.py
@@ -15,17 +15,17 @@
 # limitations under the License.
 #
 
-from dataclasses import dataclass
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Optional
 
 from tripy import export, utils
 from tripy.common import datatype
-from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import Parameter, DefaultParameter
-from tripy.frontend.trace.ops import utils as op_utils
-
 from tripy.common.exception import raise_error
+from tripy.frontend.module.module import Module
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
+from tripy.frontend.trace.ops import utils as op_utils
 
 
 @dataclass
@@ -38,7 +38,7 @@ class ConvBase(Module):
     stride: Sequence[int]
     groups: int
     dilation: Sequence[int]
-    bias: Optional[Parameter]
+    bias: Optional[Tensor]
 
     def __init__(
         self,
@@ -108,7 +108,7 @@ class Conv(ConvBase):
     dtype: datatype.dtype
     r"""The data type to use for the convolution weights."""
 
-    weight: Parameter
+    weight: Tensor
     r"""The kernel of shape :math:`(\text{out_channels}, \frac{\text{in_channels}}{\text{groups}}, *\text{kernel_dims})`."""
 
     padding: Sequence[Sequence[int]]
@@ -142,7 +142,7 @@ class Conv(ConvBase):
     For each dimension with value :math:`x`, :math:`x-1` zeros are inserted between kernel weights.
     """
 
-    bias: Optional[Parameter]
+    bias: Optional[Tensor]
     r"""
     The bias term to add to the output. The bias has a shape of :math:`(\text{out_channels},)`.
     """

--- a/tripy/tripy/frontend/module/conv_transpose.py
+++ b/tripy/tripy/frontend/module/conv_transpose.py
@@ -22,7 +22,8 @@ from typing import Optional
 from tripy import export
 from tripy.common import datatype
 from tripy.frontend.module.conv import ConvBase
-from tripy.frontend.module.parameter import DefaultParameter, Parameter
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules", autodoc_options=[":no-show-inheritance:"])
@@ -45,7 +46,7 @@ class ConvTranspose(ConvBase):
     dtype: datatype.dtype
     r"""The data type to use for the convolution weights."""
 
-    weight: Parameter
+    weight: Tensor
     r"""
     The kernel of shape :math:`(\text{in_channels}, \frac{\text{out_channels}}{\text{groups}}, *\text{kernel_dims})`.
     """
@@ -86,7 +87,7 @@ class ConvTranspose(ConvBase):
     For each dimension with value :math:`x`, :math:`x-1` zeros are inserted between kernel weights.
     """
 
-    bias: Optional[Parameter]
+    bias: Optional[Tensor]
     r"""
     The bias term to add to the output. The bias has a shape of :math:`(\text{out_channels},)`.
     """

--- a/tripy/tripy/frontend/module/embedding.py
+++ b/tripy/tripy/frontend/module/embedding.py
@@ -20,7 +20,8 @@ from dataclasses import dataclass
 from tripy import export, utils
 from tripy.common import datatype
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import Parameter, DefaultParameter
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules")
@@ -35,7 +36,7 @@ class Embedding(Module):
     dtype: datatype.dtype
     r"""The data type used to perform the operation"""
 
-    weight: Parameter
+    weight: Tensor
     r"""The embedding lookup table of shape :math:`[\text{num_embeddings}, \text{embedding_dim}]`."""
 
     def __init__(self, num_embeddings: int, embedding_dim: int, dtype: datatype.dtype = datatype.float32) -> None:

--- a/tripy/tripy/frontend/module/groupnorm.py
+++ b/tripy/tripy/frontend/module/groupnorm.py
@@ -19,10 +19,10 @@ from dataclasses import dataclass
 
 from tripy import export, utils
 from tripy.common import datatype
-from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import Parameter, DefaultParameter
-
 from tripy.common.exception import raise_error
+from tripy.frontend.module.module import Module
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules")
@@ -46,10 +46,10 @@ class GroupNorm(Module):
     dtype: datatype.dtype
     r"""The data type used to perform the operation."""
 
-    weight: Parameter
+    weight: Tensor
     r"""The :math:`\gamma` parameter of shape :math:`[\text{num_channels}]`."""
 
-    bias: Parameter
+    bias: Tensor
     r"""The :math:`\beta` parameter of shape :math:`[\text{num_channels}]`."""
 
     eps: float
@@ -111,8 +111,8 @@ class GroupNorm(Module):
             A tensor of the same shape as the input.
         """
         from tripy.frontend.trace.ops.reduce import mean, var
-        from tripy.frontend.trace.ops.unary_elementwise import rsqrt
         from tripy.frontend.trace.ops.reshape import reshape
+        from tripy.frontend.trace.ops.unary_elementwise import rsqrt
 
         input_shape = x.shape
 

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -21,7 +21,8 @@ from typing import Tuple, Union
 from tripy import export, utils
 from tripy.common import datatype
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import DefaultParameter, Parameter
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules")
@@ -45,10 +46,10 @@ class LayerNorm(Module):
     normalized_shape: Tuple[int]
     r"""Defines the shape of the input tensor that is to be normalized over."""
 
-    weight: Parameter
+    weight: Tensor
     r"""The :math:`\gamma` parameter of shape :math:`\text{normalized_shape}`."""
 
-    bias: Parameter
+    bias: Tensor
     r"""The :math:`\beta` parameter of shape :math:`\text{normalized_shape}`."""
 
     eps: float

--- a/tripy/tripy/frontend/module/linear.py
+++ b/tripy/tripy/frontend/module/linear.py
@@ -21,7 +21,8 @@ from typing import Optional
 from tripy import export, utils
 from tripy.common import datatype
 from tripy.frontend.module.module import Module
-from tripy.frontend.module.parameter import DefaultParameter, Parameter
+from tripy.frontend.module.parameter import DefaultParameter
+from tripy.frontend.tensor import Tensor
 
 
 @export.public_api(document_under="operations/modules")
@@ -37,19 +38,19 @@ class Linear(Module):
     dtype: datatype.dtype
     r"""The data type used to perform the operation"""
 
-    weight: Parameter
+    weight: Tensor
     r"""The :math:`W` matrix of shape :math:`[\text{out_features}, \text{in_features}]`"""
 
-    bias: Optional[Parameter]
+    bias: Optional[Tensor]
     r"""The :math:`b` matrix of shape :math:`[1, \text{out_features}]`"""
 
     quant_dtype: Optional[datatype.dtype]
     r"""The quantization data type"""
 
-    weight_scale: Optional[Parameter]
+    weight_scale: Optional[Tensor]
     r"""The quantization scale for weight"""
 
-    input_scale: Optional[Parameter]
+    input_scale: Optional[Tensor]
     r"""The quantization scale for input"""
 
     weight_quant_dim: Optional[int]


### PR DESCRIPTION
Removes the Parameter API which was used to denote constants in computation graphs. We can instead use regular `Tensor`s since anything not specified as an input to the compile call is treated as a constant.

`DefaultParameter` is preserved as an internal implementation detail for efficiently defining expected parameter shapes/dtypes without materializing data.