### PR TITLE
Adds an OptionsBundle class to allow options classes to subscribe to option groups

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/Client.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/Client.h
@@ -116,7 +116,7 @@ public:
     auto it = cachedPassManagers.find(key);
     if (it == cachedPassManagers.end()) {
       auto pm = std::make_unique<CompilationTaskType>(context, options);
-      setupPassManagerLogging(*pm, options.debugOptions);
+      setupPassManagerLogging(*pm, options.template get<DebugOptions>());
       auto *ptr = pm.get();
       cachedPassManagers[key] = std::move(pm);
       return *ptr;

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
@@ -33,6 +33,7 @@
 
 #include "mlir-executor/Runtime/API/API.h"
 #include "mlir-executor/Support/Status.h"
+#include "mlir-tensorrt-dialect/Utils/OptionsBundle.h"
 #include "mlir-tensorrt/Compiler/Client.h"
 #include "mlir-tensorrt/Compiler/Extension.h"
 #include "mlir-tensorrt/Compiler/Options.h"
@@ -50,7 +51,7 @@ namespace mlirtrt::compiler {
 
 class StableHloToExecutableTask;
 
-struct StableHLOToExecutableOptions : public mlir::OptionsContext {
+struct StableHLOToExecutableOptions : public mlir::OptionsBundle<DebugOptions> {
   /// Initializes the options. The extensions in the provided registry
   /// must be extensions for the StableHloToExecutable task.
   StableHLOToExecutableOptions(TaskExtensionRegistry extensions);
@@ -66,9 +67,6 @@ struct StableHLOToExecutableOptions : public mlir::OptionsContext {
   /// Infer target device information from the first visible CUDA device on the
   /// host executing this code.
   Status inferDeviceOptionsFromHost();
-
-  /// Get the mutable DebugOptions.
-  DebugOptions &getDebugOptions() { return debugOptions; }
 
   /// Return the hash of the options. Returns `nullopt` when the TensorRT
   /// layer metadata callback is set since that can't be reliably hashed.
@@ -102,8 +100,6 @@ struct StableHLOToExecutableOptions : public mlir::OptionsContext {
 
   /// Entrypoint function name.
   std::string entrypoint = "main";
-
-  DebugOptions debugOptions;
 
   std::function<std::string(mlir::Operation *)> layerMetadataCallback{nullptr};
 

--- a/mlir-tensorrt/compiler/lib/CAPI/Compiler/Compiler.cpp
+++ b/mlir-tensorrt/compiler/lib/CAPI/Compiler/Compiler.cpp
@@ -224,12 +224,12 @@ MTRT_Status mtrtStableHloToExecutableOptionsSetDebugOptions(
     const char *dumpTensorRTDir) {
 
   StableHLOToExecutableOptions *cppOpts = unwrap(options);
-  cppOpts->debugOptions.enableLLVMDebugFlag = enableDebugging;
+  cppOpts->get<DebugOptions>().enableLLVMDebugFlag = enableDebugging;
   for (unsigned i = 0; i < debugTypeSizes; i++)
-    cppOpts->debugOptions.llvmDebugTypes.emplace_back(debugTypes[i]);
+    cppOpts->get<DebugOptions>().llvmDebugTypes.emplace_back(debugTypes[i]);
 
   if (dumpIrTreeDir)
-    cppOpts->debugOptions.dumpIRPath = std::string(dumpIrTreeDir);
+    cppOpts->get<DebugOptions>().dumpIRPath = std::string(dumpIrTreeDir);
 
   return mtrtStatusGetOk();
 }

--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/Utils/OptionsBundle.h
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/Utils/OptionsBundle.h
@@ -1,0 +1,56 @@
+//===- OptionsBundle.h ------------------------------------------*- C++ -*-===//
+//
+// SPDX-FileCopyrightText: Copyright 2024 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_TENSORRT_DIALECT_UTILS_OPTIONS_BUNDLE
+#define MLIR_TENSORRT_DIALECT_UTILS_OPTIONS_BUNDLE
+
+#include "mlir-tensorrt-dialect/Utils/Options.h"
+#include <tuple>
+
+namespace mlir {
+
+/// This class allows us to have options classes subscribe to one or more option
+/// providers.
+template <typename... OptionProviders>
+class OptionsBundle : public OptionsContext {
+public:
+  OptionsBundle() {
+    std::apply(
+        [&](auto &...optionProvider) {
+          (optionProvider.addToOptions(*this), ...);
+        },
+        optionProviders);
+  }
+
+  template <typename OptionsProviderT>
+  const OptionsProviderT &get() const {
+    return std::get<OptionsProviderT>(optionProviders);
+  }
+
+  template <typename OptionsProviderT>
+  OptionsProviderT &get() {
+    return std::get<OptionsProviderT>(optionProviders);
+  }
+
+private:
+  std::tuple<OptionProviders...> optionProviders{};
+};
+} // namespace mlir
+
+#endif /* MLIR_TENSORRT_DIALECT_UTILS_OPTIONS_BUNDLE */


### PR DESCRIPTION
Introduces an `OptionsBundle` class that will make it easier to share groups of
options across different options classes. This class essentially allows you to bundle
together option providers like `DebugOptions` so that they don't need to be managed
individually.