### PR TITLE
Fix weight loader for nanogpt by not asserting on exactly same state …

### DIFF
--- a/tripy/examples/nanogpt/model.py
+++ b/tripy/examples/nanogpt/model.py
@@ -67,9 +67,9 @@ class CausalSelfAttention(tp.Module):
             tp.tril(tp.ones((config.block_size, config.block_size), dtype=config.dtype)),
             (1, 1, config.block_size, config.block_size),
         )
-        self.zeros = tp.zeros((1, 1, self.seq_len, self.seq_len), dtype=config.dtype)
 
     def __call__(self, x: tp.Tensor):
+        zeros = tp.zeros((1, 1, self.seq_len, self.seq_len), dtype=x.dtype)
         B, T = x.shape[0:2]
         qkv = self.c_attn(x)  # (batch_size, seq_len, 3 * embedding_size)
 
@@ -89,7 +89,7 @@ class CausalSelfAttention(tp.Module):
         att = (q @ k_t) * (1.0 / math.sqrt(self.embedding_size // self.num_heads))
         att = tp.masked_fill(
             att,
-            self.bias[:, :, :T, :T] == self.zeros[:, :, :T, :T],
+            self.bias[:, :, :T, :T] == zeros[:, :, :T, :T],
             float("-inf"),
         )
 
@@ -139,11 +139,13 @@ class Transformer(tp.Module):
         self.wpe = tp.Embedding(config.block_size, config.embedding_size, dtype=config.dtype)
         self.h = [Block(config) for _ in range(config.num_layers)]
         self.ln_f = tp.LayerNorm(config.embedding_size)
-        self.pos = tp.reshape(tp.arange(0, config.seq_len, dtype=tp.int32), (1, config.seq_len))
+        self.config_seq_len = config.seq_len
 
     def __call__(self, idx):
+        pos = tp.reshape(tp.arange(0, self.config_seq_len, dtype=tp.int32), (1, self.config_seq_len))
+
         tok_emb = self.wte(idx)  # token embeddings of shape (batch_size, seq_len, embedding_size)
-        pos_emb = self.wpe(self.pos[:, : idx.shape[1]])  # position embeddings of shape (seq_len, embedding_size)
+        pos_emb = self.wpe(pos[:, : idx.shape[1]])  # position embeddings of shape (seq_len, embedding_size)
         x = tok_emb + pos_emb  # (batch_size, seq_len, embedding_size)
         for block in self.h:
             x = block(x)

--- a/tripy/examples/nanogpt/weight_loader.py
+++ b/tripy/examples/nanogpt/weight_loader.py
@@ -35,7 +35,6 @@ def load_weights_from_hf(model, model_type, dtype):
     hf_keys = [
         key for key in hf_state_dict.keys() if not key.endswith(".attn.masked_bias") and not key.endswith(".attn.bias")
     ]
-    assert len(hf_keys) == len(tripy_keys), f"Mismatched keys: {hf_keys} != {tripy_keys}"
 
     # See https://paperswithcode.com/method/weight-tying for details on why we do this:
     hf_state_dict["transformer.wte.weight"] = hf_state_dict["lm_head.weight"]
@@ -52,7 +51,7 @@ def load_weights_from_hf(model, model_type, dtype):
         param = tp.Tensor(weight)
         tripy_state_dict[key] = param
 
-    model.load_state_dict(tripy_state_dict)
+    model.load_state_dict(tripy_state_dict, strict=False)
 
 
 def load_quant_weights_from_hf(model, model_type, dtype, quant_mode):

--- a/tripy/examples/nanogpt/weight_loader.py
+++ b/tripy/examples/nanogpt/weight_loader.py
@@ -35,6 +35,7 @@ def load_weights_from_hf(model, model_type, dtype):
     hf_keys = [
         key for key in hf_state_dict.keys() if not key.endswith(".attn.masked_bias") and not key.endswith(".attn.bias")
     ]
+    assert len(hf_keys) == len(tripy_keys), f"Mismatched keys: {hf_keys} != {tripy_keys}"
 
     # See https://paperswithcode.com/method/weight-tying for details on why we do this:
     hf_state_dict["transformer.wte.weight"] = hf_state_dict["lm_head.weight"]
@@ -51,7 +52,7 @@ def load_weights_from_hf(model, model_type, dtype):
         param = tp.Tensor(weight)
         tripy_state_dict[key] = param
 
-    model.load_state_dict(tripy_state_dict, strict=False)
+    model.load_state_dict(tripy_state_dict)
 
 
 def load_quant_weights_from_hf(model, model_type, dtype, quant_mode):


### PR DESCRIPTION
…dict since Tripy modules can have more init constants

https://github.com/NVIDIA/TensorRT-Incubator/blob/main/tripy/examples/nanogpt/model.py#L70
https://github.com/NVIDIA/TensorRT-Incubator/blob/main/tripy/examples/nanogpt/model.py#L142

The above two constants are not weights and are not present in HF state dict.