### PR TITLE
Fixes type checking, nanoGPT

### DIFF
--- a/.github/workflows/tripy-l0.yml
+++ b/.github/workflows/tripy-l0.yml
@@ -69,7 +69,7 @@ jobs:
         image: ${{ env.l0_image }}
         options: --gpus all -v ${{ github.workspace }}/tripy:/tripy
         run: |
-          pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "not l1 and not manual" -n 4 --durations=15 --ignore tests/performance
+          pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "not l1" -n 4 --durations=15 --ignore tests/performance
 
     - name: Run performance benchmarks
       uses: addnab/docker-run-action@v3
@@ -77,7 +77,7 @@ jobs:
         image: ${{ env.l0_image }}
         options: --gpus all -v ${{ github.workspace }}/tripy:/tripy
         run: |
-          pytest tests/performance -v -m "not l1 and not manual" --benchmark-warmup=on --benchmark-json benchmark.json
+          pytest tests/performance -v -m "not l1" --benchmark-warmup=on --benchmark-json benchmark.json
 
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/tripy-l1.yml
+++ b/.github/workflows/tripy-l1.yml
@@ -35,8 +35,8 @@ jobs:
     - name: l1-test
       run: |
         cd /tripy/
-        pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "l1 and not manual" -n 4 --durations=15 --ignore tests/performance
-    
+        pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "l1" -n 4 --durations=15 --ignore tests/performance
+
     - name: notebook-test
       run: |
         cd /tripy/

--- a/tripy/docs/pre0_user_guides/02-compiler.md
+++ b/tripy/docs/pre0_user_guides/02-compiler.md
@@ -59,7 +59,7 @@ When we compiled above, we used a static shape of `(1, 2)` for the input.
 Tripy also supports specifying a range of possible values for each dimension like so:
 
 ```py
-inp_info = tp.InputInfo(shape=([1, 8, 16], 2), dtype=tp.float32)
+inp_info = tp.InputInfo(shape=((1, 8, 16), 2), dtype=tp.float32)
 ```
 
 The shape we used above indicates that the 0th dimension should support a range of values

--- a/tripy/examples/nanogpt/example.py
+++ b/tripy/examples/nanogpt/example.py
@@ -103,7 +103,7 @@ def main():
         1,
         # We can specify dynamic dimensions by using a sequence indicating the min/opt/max values that
         # a dimension should support:
-        [1, len(input_ids), padded_seq_len],
+        (1, len(input_ids), padded_seq_len),
     )
     model = tp.compile(model, args=[tp.InputInfo(input_shape, dtype=tp.int32)])
     compile_end_time = time.perf_counter()

--- a/tripy/examples/nanogpt/weight_loader.py
+++ b/tripy/examples/nanogpt/weight_loader.py
@@ -26,16 +26,20 @@ def load_weights_from_hf(model, model_type, dtype):
 
     tripy_state_dict = model.state_dict()
     # attention biases are initialized in the model based on block size.
-    tripy_keys = [key for key in tripy_state_dict.keys() if not key.endswith(".attn.bias")]
+    tripy_keys = {key for key in tripy_state_dict.keys() if not key.endswith(".attn.bias")}
 
     # Load huggingface/transformers model
     model_hf = GPT2LMHeadModel.from_pretrained(model_type)
     hf_state_dict = model_hf.state_dict()
     # We ignore some of the keys in the HF checkpoint:
-    hf_keys = [
+    hf_keys = {
         key for key in hf_state_dict.keys() if not key.endswith(".attn.masked_bias") and not key.endswith(".attn.bias")
-    ]
-    assert len(hf_keys) == len(tripy_keys), f"Mismatched keys: {hf_keys} != {tripy_keys}"
+    }
+    assert hf_keys == tripy_keys, (
+        f"Mismatched keys. Note:\n"
+        f"`hf_keys` extra keys: {hf_keys - tripy_keys}\n"
+        f"`tripy_keys` extra keys: {tripy_keys - hf_keys}"
+    )
 
     # See https://paperswithcode.com/method/weight-tying for details on why we do this:
     hf_state_dict["transformer.wte.weight"] = hf_state_dict["lm_head.weight"]

--- a/tripy/tests/backend/api/test_input_info.py
+++ b/tripy/tests/backend/api/test_input_info.py
@@ -42,21 +42,21 @@ class TestInput:
         assert inp.shape_bounds.max == expected_max
 
     @pytest.mark.parametrize(
-        "shape, expected_error",
+        "shape",
         [
             # Not a number
-            (
-                (tp.int32, 1),
-                "Shape values should be either a single integer-like value or a 3-element tuple specifying min/opt/max bounds.",
-            ),
+            (tp.int32, 1),
             # Too few elements in dimension
-            (((1, 1), 1), "Incorrect number of shape values provided"),
+            ((1, 1), 1),
             # Too many elements in dimension
-            (((1, 1, 1, 1), 1), "Incorrect number of shape values provided"),
+            ((1, 1, 1, 1), 1),
             # Tuple containing a non-number
-            (((tp.int32, 1, 1), 1), "Shape values must be integers or `DimensionSize`s."),
+            ((tp.int32, 1, 1), 1),
         ],
     )
-    def test_invalid_shape(self, shape, expected_error):
-        with helper.raises(tp.TripyException, expected_error):
+    def test_invalid_shape(self, shape):
+        with helper.raises(
+            tp.TripyException,
+            r"Not a valid overload because: For parameter: 'shape', expected an instance of type: 'Sequence\[int \| tripy.DimensionSize | Tuple\[int \| tripy.DimensionSize, int \| tripy.DimensionSize, int \| tripy.DimensionSize\]\]' but got argument of type: ",
+        ):
             tp.InputInfo(shape=shape, dtype=tp.float32)

--- a/tripy/tests/frontend/module/test_module.py
+++ b/tripy/tests/frontend/module/test_module.py
@@ -101,7 +101,10 @@ class TestModule:
     ):
         state_dict = {"param": [0, 0]}
 
-        with helper.raises(tp.TripyException, match=r"Expected a tensor for parameter: 'param', but got: List\[int\]"):
+        with helper.raises(
+            tp.TripyException,
+            match=r"Not a valid overload because: For parameter: 'state_dict', expected an instance of type: 'Dict\[str, tripy.Tensor\]' but got argument of type: 'Dict\[str, List\[int\]\]'.",
+        ):
             network.load_state_dict(state_dict, strict=False)
 
     def test_load_state_dict_with_different_shapes_fails(

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -502,13 +502,13 @@ def process_code_block_for_outputs_and_locals(
         with capture_output() as outfile:
             code_locals = exec_code(code, local_vars)
     except Exception as e:
-        print(
-            f"Exception occurred while executing code block: {type(e).__name__}: {e}\n"
-            f"Note: Code block was:\n\n{block}"
-        )
         if allow_exception:
             code_locals = local_vars
         else:
+            print(
+                f"Exception occurred while executing code block: {type(e).__name__}: {e}\n"
+                f"Note: Code block was:\n\n{block}"
+            )
             print(err_msg)
             raise
 

--- a/tripy/tripy/backend/api/compile.py
+++ b/tripy/tripy/backend/api/compile.py
@@ -83,8 +83,8 @@ def compile(
         compiled_add = tp.compile(
             add,
             args=[
-                tp.InputInfo(([1, 2, 3], 2), dtype=tp.float32),
-                tp.InputInfo(([1, 2, 3], 2), dtype=tp.float32),
+                tp.InputInfo(shape=((1, 2, 3), 2), dtype=tp.float32),
+                tp.InputInfo(shape=((1, 2, 3), 2), dtype=tp.float32),
             ],
         )
 

--- a/tripy/tripy/backend/api/executable.py
+++ b/tripy/tripy/backend/api/executable.py
@@ -105,8 +105,8 @@ class Executable:
             compiled_add = tp.compile(
                 add,
                 args=[
-                    tp.InputInfo(([1, 2, 3],), dtype=tp.float32),
-                    tp.InputInfo(([1, 2, 3],), dtype=tp.float32),
+                    tp.InputInfo(shape=((1, 2, 3),), dtype=tp.float32),
+                    tp.InputInfo(shape=((1, 2, 3),), dtype=tp.float32),
                 ],
             )
 
@@ -278,8 +278,8 @@ class Executable:
             compiled_add = tp.compile(
                 add,
                 args=[
-                    tp.InputInfo(([1, 2, 3],), dtype=tp.float32),
-                    tp.InputInfo(([1, 2, 3],), dtype=tp.float32),
+                    tp.InputInfo(shape=((1, 2, 3),), dtype=tp.float32),
+                    tp.InputInfo(shape=((1, 2, 3),), dtype=tp.float32),
                 ],
             )
 

--- a/tripy/tripy/backend/api/input_info.py
+++ b/tripy/tripy/backend/api/input_info.py
@@ -63,25 +63,8 @@ class InputInfo:
         for elem in shape:
             if is_int_like(elem):
                 elem = (elem,) * 3
-            elif isinstance(elem, Sequence):
-                if not all(is_int_like(val) for val in elem):
-                    raise_error(
-                        "Shape values must be integers or `DimensionSize`s.",
-                        [f"Shape: {shape} contains an element of incorrect type: {repr(elem)}"],
-                    )
-                if len(elem) != 3:
-                    raise_error(
-                        "Incorrect number of shape values provided.",
-                        [
-                            f"Exactly 3 shape values must be provided for each dimension (min/opt/max)"
-                            f" but got: {len(elem)} values in shape: {shape}. "
-                        ],
-                    )
-            else:
-                raise_error(
-                    "Shape values should be either a single integer-like value or a 3-element tuple specifying min/opt/max bounds.",
-                    [f"Shape: {shape} contains an invalid element: {elem}"],
-                )
+
+            assert len(elem) == 3 and all(is_int_like(val) for val in elem)
 
             min_shape.append(elem[0])
             opt_shape.append(elem[1])

--- a/tripy/tripy/frontend/module/layernorm.py
+++ b/tripy/tripy/frontend/module/layernorm.py
@@ -16,7 +16,7 @@
 #
 
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Sequence, Union
 
 from tripy import export, utils
 from tripy.common import datatype
@@ -43,7 +43,7 @@ class LayerNorm(Module):
     dtype: datatype.dtype
     r"""The data type used to perform the operation."""
 
-    normalized_shape: Tuple[int]
+    normalized_shape: Sequence[int]
     r"""Defines the shape of the input tensor that is to be normalized over."""
 
     weight: Tensor
@@ -56,7 +56,7 @@ class LayerNorm(Module):
     """A value added to the denominator to prevent division by zero."""
 
     def __init__(
-        self, normalized_shape: Union[int, Tuple[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5
+        self, normalized_shape: Union[int, Sequence[int]], dtype: datatype.dtype = datatype.float32, eps: float = 1e-5
     ) -> None:
         r"""
         Args:

--- a/tripy/tripy/frontend/module/sequential.py
+++ b/tripy/tripy/frontend/module/sequential.py
@@ -12,30 +12,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union, Tuple, Dict, Iterator, Any
-from dataclasses import dataclass
 import copy
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, Tuple, Union
 
 from tripy import export
 from tripy.common.exception import raise_error
 from tripy.frontend.module import Module
 
+ModuleLike = Union[Module, Callable[["tripy.Tensor"], "tripy.Tensor"]]
 
-@export.public_api(
-    document_under="modules/sequential.rst",
-)
+
+@export.public_api(document_under="modules/sequential.rst")
 @dataclass
 class Sequential(Module):
     r"""
     A module to stack multiple callable layers or modules in a sequential order. The `Sequential`
-    container can accept either a list of modules/callable objects or a dictionary of named modules/callable objects. Layers are
-    added in the order they are passed, and each is called sequentially during the forward pass.
+    container can accept either a list of modules/callable objects or a dictionary of named modules/callable objects.
+    Layers are added in the order they are passed, and each is called sequentially during the forward pass.
     """
 
-    def __init__(self, *modules: Union[Module, Dict[str, Module]]) -> None:
+    def __init__(self, *modules: Union[ModuleLike, Dict[str, ModuleLike]]) -> None:
         r"""
         Args:
-            *modules: The modules to include in the sequence.
+            *modules: The module(s) or callable(s) to include in the sequence.
+                These must take exactly one input and return exactly one output.
                 Can be passed as individual positional arguments or as a single dictionary of named modules.
 
         .. code-block:: python

--- a/tripy/tripy/frontend/trace/ops/pooling.py
+++ b/tripy/tripy/frontend/trace/ops/pooling.py
@@ -17,7 +17,7 @@
 
 import enum
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence
 
 from tripy import constraints, export, utils
 from tripy.common.exception import raise_error
@@ -39,7 +39,7 @@ class Pooling(BaseTraceOp):
     kind: Kind
     kernel_dims: Sequence[int]
     stride: Sequence[int]
-    padding: Sequence[Tuple[int]]
+    padding: Sequence[Sequence[int]]
 
     infer_rank = op_utils.InferRankPolicies.same_as_input()
 
@@ -147,7 +147,7 @@ def maxpool(
     input: "tripy.Tensor",
     kernel_dims: Sequence[int],
     stride: Optional[Sequence[int]] = None,
-    padding: Optional[Sequence[Tuple[int]]] = None,
+    padding: Optional[Sequence[Sequence[int]]] = None,
 ) -> "tripy.Tensor":
     r"""
     Applies a max pooling over the input tensor.
@@ -206,7 +206,7 @@ def avgpool(
     input: "tripy.Tensor",
     kernel_dims: Sequence[int],
     stride: Optional[Sequence[int]] = None,
-    padding: Optional[Sequence[Tuple[int]]] = None,
+    padding: Optional[Sequence[Sequence[int]]] = None,
 ) -> "tripy.Tensor":
     r"""
     Applies an average pooling over the input tensor.

--- a/tripy/tripy/frontend/trace/ops/squeeze.py
+++ b/tripy/tripy/frontend/trace/ops/squeeze.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Sequence, Tuple, Union
 
 from tripy import constraints, export, utils
 from tripy.frontend.trace.ops import utils as op_utils
@@ -54,13 +54,13 @@ class Squeeze(BaseTraceOp):
     constraints={"input": "T1", constraints.RETURN_VALUE: "T1"},
     variables={"T1": ["float32", "float16", "bfloat16", "float8", "int8", "int32", "int64", "bool"]},
 )
-def squeeze(input: "tripy.Tensor", dims: Union[Tuple, int]) -> "tripy.Tensor":
+def squeeze(input: "tripy.Tensor", dims: Union[Sequence[int], int]) -> "tripy.Tensor":
     """
     Returns a new tensor with all specified singleton dimensions of the input tensor removed.
 
     Args:
         input: The input tensor.
-        dims: The singleton dimensions to be removed.
+        dims: The singleton dimension(s) to be removed.
               If this is not provided, all dimensions of size 1 are removed.
 
     Raises:


### PR DESCRIPTION
[Adds support for various types in our type checking logic](https://github.com/NVIDIA/TensorRT-Incubator/commit/3c95dafa9e4c21c8fab6ab7e2e83ecb98c664b83)

Adds support for dictionaries, tuple, and callables in our type checking.
Also removes a fallback path where we would skip type checking if we weren't
able to handle an annotation. Since we're only doing type checking on Tripy APIs,
where we control the type annotations, we should not have this fallback path but
should instead add support for whatever types we use.

Also updates various parts of the code to respect type annotations. Many of these
were working before since the type annotation would just be ignored.

[Updates pipelines to remove mentions of the "manual" test cadence](https://github.com/NVIDIA/TensorRT-Incubator/commit/f9d2d9bd59e14fe239e7a11e5c4c3923af3487b3)

[Updates nanoGPT to not store certain tensors as members](https://github.com/NVIDIA/TensorRT-Incubator/commit/a92c2fa523c0d142cb4bb1e3f9ebd88bdfa87fac)