### PR TITLE
Adds explicit notebook tests, updates CI

### DIFF
--- a/.github/workflows/tripy-l1.yml
+++ b/.github/workflows/tripy-l1.yml
@@ -37,11 +37,12 @@ jobs:
         cd /tripy/
         pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "l1" -n 4 --durations=15 --ignore tests/performance
 
-    - name: notebook-test
+    # For some tests, we want to use the public build instead of the latest commit.
+    - name: l1-test-release-package
       run: |
         cd /tripy/
         unset PYTHONPATH
         pip uninstall tripy -y
         pip install --no-index -f https://nvidia.github.io/TensorRT-Incubator/packages.html tripy --no-deps
         pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html tripy
-        pytest --nb-test-files notebooks/
+        pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -m "l1_release_package" -n 4 --durations=15 --ignore tests/performance

--- a/.github/workflows/tripy-release.yml
+++ b/.github/workflows/tripy-release.yml
@@ -44,6 +44,12 @@ jobs:
         sphinx-build build/doc_sources build/docs -c docs/ -j 4 -W -n
         cp docs/packages.html build/docs/
 
+    # We want to make sure all functional tests, including L1, are passing before we release the wheel.
+    - name : test
+      run: |
+        cd /tripy/
+        pytest --cov=tripy/ --cov-config=.coveragerc tests/ -v -n 4 --durations=15 --ignore tests/performance
+
     - name: Release
       uses: softprops/action-gh-release@v2
       with:

--- a/tripy/examples/nanogpt/README.md
+++ b/tripy/examples/nanogpt/README.md
@@ -34,16 +34,13 @@ for expected accuracy.
     python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0
     ```
 
-    <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
+    Tripy: TEST: EXPECTED_STDOUT Start
     ```
-    What is the answer to life, the universe, and everything\? How can we know what's real\? How can
-    ====
-    (?s).*?
-    What is the answer to life, the universe, and everything\? The answer to the questions that
+    (?s).*?What is the answer to life, the universe, and everything\? (How can we know what's real\? How can|The answer to the questions that are asked of us)
     ```
-     -->
-    <!-- Tripy: TEST: EXPECTED_STDOUT End -->
+    Tripy: TEST: EXPECTED_STDOUT End
+    -->
 
 ### Running with Quantization
 
@@ -60,33 +57,26 @@ To run with a quantization mode, pass `--quant-mode` to `example.py`. The suppor
     ```bash
     python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0 --quant-mode int8-weight-only
     ```
-    <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
+    Tripy: TEST: EXPECTED_STDOUT Start
     ```
-    (?s).*?
-    What is the answer to life, the universe, and everything\? How is life possible, what is the meaning of
-    ====
-    (?s).*?
-    What is the answer to life, the universe, and everything\? The answer to the questions that
-    ====
-    (?s).*?
-    What is the answer to life, the universe, and everything\? How can
+    (?s).*?What is the answer to life, the universe, and everything\? (The answer to the questions that|How is life possible, what is the meaning of|How can)
     ```
-     -->
-    <!-- Tripy: TEST: EXPECTED_STDOUT End -->
+    Tripy: TEST: EXPECTED_STDOUT End
+    -->
 
 2. Weight-only int4 quantization:
+
+    *Note: `int4` quantization may result in poor accuracy for this model.*
+        *We include it here primarily to demonstrate the workflow.*
 
     ```bash
     python3 example.py --input-text "What is the answer to life, the universe, and everything?" --seed=0 --quant-mode int4-weight-only
     ```
-    <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
+    Tripy: TEST: EXPECTED_STDOUT Start
     ```
-    (?s).*?
-    What is the answer to life, the universe, and everything\? What is what is what is what is what is
+    (?s).*?What is the answer to life, the universe, and everything\? What is what is what is what is what is
     ```
-     -->
-    <!-- Tripy: TEST: EXPECTED_STDOUT End -->
-
-    *Note: `int4` quantization may result in poor accuracy. We include it here primarily to demonstrate the workflow.*
+    Tripy: TEST: EXPECTED_STDOUT End
+    -->

--- a/tripy/examples/segment-anything-model-v2/README.md
+++ b/tripy/examples/segment-anything-model-v2/README.md
@@ -12,12 +12,17 @@ This is an implementation of SAM2 model ([original repository](https://github.co
 
     ```bash
     sudo apt-get update && sudo apt-get install ffmpeg libsm6 libxext6  -y
-    wget -O truck.jpg https://raw.githubusercontent.com/facebookresearch/sam2/main/notebooks/images/truck.jpg
     python3 -m pip install -r requirements.txt
+    ```
+
+2. Retrieve an example image and the checkpoint:
+
+    ```bash
+    wget -O truck.jpg https://raw.githubusercontent.com/facebookresearch/sam2/main/notebooks/images/truck.jpg
     mkdir checkpoints && cd checkpoints && wget https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt
     ```
 
-2. Run the example:
+3. Run the example:
 
     ```bash
     python3 image_demo.py

--- a/tripy/examples/segment-anything-model-v2/README.md
+++ b/tripy/examples/segment-anything-model-v2/README.md
@@ -28,13 +28,13 @@ This is an implementation of SAM2 model ([original repository](https://github.co
     python3 image_demo.py
     ```
 
-    <!-- Tripy: TEST: EXPECTED_STDOUT Start -->
     <!--
+    Tripy: TEST: EXPECTED_STDOUT Start
     ```
     Scores for each prediction: {0.78759766~5%} {0.640625~5%} {0.05099487~5%}
     ```
-     -->
-    <!-- Tripy: TEST: EXPECTED_STDOUT End -->
+    Tripy: TEST: EXPECTED_STDOUT End
+    -->
 
 ### Video segmentation pipeline
 

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -99,4 +99,5 @@ testpaths = [
 addopts = "--strict-markers"
 markers = [
     "l1: Indicates that the test should only be run in nightlies.",
+    "l1_release_package: Indicates that the test should be run in nightlies using the public build of Tripy."
 ]

--- a/tripy/tests/README.md
+++ b/tripy/tests/README.md
@@ -18,8 +18,8 @@ You can also provide marker arguments to only run specific test cadences
 L0 tests, use:
 
 ```bash
-pytest tests/ -v -m "not l1" -n 4 --dist worksteal --ignore tests/performance
-pytest tests/performance -v -m "not l1"
+pytest tests/ -v -m "not l1 and not l1_release_package" -n 4 --dist worksteal --ignore tests/performance
+pytest tests/performance -v -m "not l1 and not l1_release_package"
 ```
 
 Note that the L0/L1 tests can be parallelized. In that case, performance tests
@@ -35,7 +35,7 @@ tests together.
 For example, to profile L0 tests, run:
 
 ```bash
-pytest tests/ -v -m "not l1" --ignore tests/performance --profile
+pytest tests/ -v -m "not l1 and not l1_release_package" --ignore tests/performance --profile
 ```
 
 You can visualize the results using `snakeviz`.

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -498,19 +498,18 @@ def process_code_block_for_outputs_and_locals(
     code_start, code_end = get_code_bounds(block_lines)
     code = dedent("\n".join(block_lines[code_start:code_end]))
 
-    try:
-        with capture_output() as outfile:
+    with capture_output() as outfile:
+        try:
             code_locals = exec_code(code, local_vars)
-    except Exception as e:
-        if allow_exception:
-            code_locals = local_vars
-        else:
-            print(
-                f"Exception occurred while executing code block: {type(e).__name__}: {e}\n"
-                f"Note: Code block was:\n\n{block}"
-            )
-            print(err_msg)
-            raise
+        except Exception as e:
+            if allow_exception:
+                # We print the error message here so it can be captured in `outfile`
+                # and displayed in the output in cases where we actually expect exceptions.
+                print(e)
+                code_locals = local_vars
+            else:
+                print(f"{err_msg}\n" f"Note: Code block was:\n\n{block}")
+                raise
 
     new_locals = {
         key: value for key, value in code_locals.items() if key not in local_vars or value is not local_vars[key]

--- a/tripy/tests/test_examples.py
+++ b/tripy/tests/test_examples.py
@@ -86,7 +86,11 @@ EXAMPLES = [
 ]
 
 
+# We want to test our examples with both the latest commit and public build.
+# This is because we always want the examples to work with pip-installable build, but also
+# don't want them to break on TOT.
 @pytest.mark.l1
+@pytest.mark.l1_release_package
 @pytest.mark.parametrize("example", EXAMPLES, ids=lambda case: str(case))
 def test_examples(example, sandboxed_install_run):
 

--- a/tripy/tests/test_notebooks.py
+++ b/tripy/tests/test_notebooks.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import os
+
+import pytest
+from tests import helper
+
+NOTEBOOKS_ROOT = os.path.join(helper.ROOT_DIR, "notebooks")
+
+NOTEBOOKS = glob.glob(os.path.join(NOTEBOOKS_ROOT, "*.ipynb"))
+# Paranoid check:
+assert os.path.join(NOTEBOOKS_ROOT, "resnet50.ipynb") in NOTEBOOKS
+
+
+# Like our example, we want to test notebooks with both the release package and TOT.
+@pytest.mark.l1
+@pytest.mark.l1_release_package
+@pytest.mark.parametrize("notebook_path", NOTEBOOKS)
+def test_notebooks(nb_regression, notebook_path):
+    nb_regression.check(notebook_path)

--- a/tripy/tripy/frontend/tensor.py
+++ b/tripy/tripy/frontend/tensor.py
@@ -36,7 +36,7 @@ from tripy.utils.stack_info import StackInfo
 
 # We include code for everything above the `BaseTraceOp.build` function, which is called at most
 # this many stack frames above the constructor.
-STACK_DEPTH_OF_BUILD = 4
+STACK_DEPTH_OF_BUILD = 5
 
 
 class TensorMeta(type):


### PR DESCRIPTION
- Adds an explicit `pytest` test for the notebooks so that it works just like any other test.

- Adds a new `l1_release_package` cadence which will run a test using the release package instead of TOT.

- Updates the release pipeline to run testing before pushing the release.

- Updates the L1 pipeline to run the `l1_release_package` tests.

- Fixes a bug in the documentation where expected errors would not be displayed