### PR TITLE
Move internal changes

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
@@ -25,6 +25,7 @@
 #define MLIR_TENSORRT_C_COMPILER_COMPILER
 
 #include "mlir-c/IR.h"
+#include "mlir-c/Pass.h"
 #include "mlir-c/Support.h"
 #include "mlir-executor-c/Common/Common.h"
 #include "mlir-executor-c/Support/Status.h"
@@ -123,8 +124,24 @@ static inline bool mtrtStableHloToExecutableOptionsIsNull(
 }
 
 //===----------------------------------------------------------------------===//
+// StableHloPipeline APIs
+//===----------------------------------------------------------------------===//
+
+static inline bool mtrtStableHloPipelineIsNull(MlirPassManager pm) {
+  return !pm.ptr;
+}
+
+MLIR_CAPI_EXPORTED MTRT_Status mtrtStableHloPipelineGetCached(
+    MTRT_CompilerClient client, MTRT_StableHLOToExecutableOptions options,
+    MlirPassManager *result);
+
+//===----------------------------------------------------------------------===//
 // Main StableHLO Compiler API Functions
 //===----------------------------------------------------------------------===//
+
+/// Get Executable using StableHloPassManager.
+MLIR_CAPI_EXPORTED MTRT_Status mtrtCompilerGetExecutable(
+    MlirPassManager pm, MlirOperation module, MTRT_Executable *result);
 
 /// Compiler StableHLO to Executable.
 MLIR_CAPI_EXPORTED MTRT_Status mtrtCompilerStableHLOToExecutable(

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
@@ -108,6 +108,7 @@ public:
   /// Whether to ignore `deviceX` options and instead infer them from the GPUs
   /// on the host system running the compilation.
   bool shouldInferFromHost = false;
+  Status inferFromHost();
 
 public:
   void addToOptions(mlir::OptionsContext &context) {

--- a/mlir-tensorrt/executor/test/Unit/CMakeLists.txt
+++ b/mlir-tensorrt/executor/test/Unit/CMakeLists.txt
@@ -6,6 +6,7 @@ set_target_properties(MLIRTensorRTExecutorUnitTests PROPERTIES FOLDER "MLIR-Tens
 function(add_mlir_executor_unittest target)
   set(LLVM_LINK_COMPONENTS Support)
   add_llvm_executable(${target} IGNORE_EXTERNALIZE_DEBUGINFO NO_INSTALL_RPATH ${ARGN})
+  set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   add_dependencies(MLIRTensorRTExecutorUnitTests ${target})
   llvm_update_compile_flags(${target})
   if(TARGET gtest)

--- a/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/_mlir_libs/_api.pyi
+++ b/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/_mlir_libs/_api.pyi
@@ -16,6 +16,8 @@ __all__ = [
     "StableHLOToExecutableOptions",
     "Type",
     "bf16",
+    "PyStableHloPipeline",
+    "get_executable",
     "compiler_stablehlo_to_executable",
     "device",
     "f16",
@@ -292,6 +294,12 @@ class StableHLOToExecutableOptions:
 class Type:
     def __init__(self, cast_from_type: Type) -> None: ...
 
+class PyStableHloPipeline:
+    def __init__(
+        self, arg0: CompilerClient, arg1: StableHLOToExecutableOptions
+    ) -> None: ...
+
+def get_executable(client: CompilerClient, module: Operation) -> Executable: ...
 def compiler_stablehlo_to_executable(
     client: CompilerClient, module: Operation, options: StableHLOToExecutableOptions
 ) -> Executable: ...

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/linspace.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/linspace.mlir
@@ -1,0 +1,16 @@
+// RUN: %pick-one-gpu tensorrt-opt -split-input-file -pass-pipeline="builtin.module(translate-tensorrt-to-engine)" \
+// RUN:  -mlir-elide-elementsattrs-if-larger=32 -tensorrt-builder-opt-level=0 -tensorrt-strongly-typed %s | FileCheck %s
+// RUN: %pick-one-gpu tensorrt-opt -split-input-file -pass-pipeline="builtin.module(translate-tensorrt-to-engine)" \
+// RUN:  -mlir-elide-elementsattrs-if-larger=32 -tensorrt-builder-opt-level=0 %s | FileCheck %s
+
+// CHECK-LABEL: @dynamic_nd_iota_3
+//  CHECK-SAME: tensorrt.engine
+func.func @dynamic_nd_iota_3(%arg0: tensor<2xi32> {
+  tensorrt.value_bounds = #tensorrt.shape_profile<min=[1, 3], opt=[4, 3], max=[12, 3]>,
+  tensorrt.host_tensor
+}) -> tensor<?x3xi64> {
+  %cst_f16 = tensorrt.constant dense<0> : tensor<i64>
+  %cst_f16_0 = tensorrt.constant dense<[0, 1]> : tensor<2xi64>
+  %0 = tensorrt.linspace[%cst_f16 : tensor<i64>] [%arg0 : tensor<2xi32>] [%cst_f16_0 : tensor<2xi64>] : tensor<?x3xi64>
+  return %0 : tensor<?x3xi64>
+}

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/linspace.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/linspace.mlir
@@ -51,16 +51,3 @@ func.func @dynamic_nd_iota_2(%arg0: tensor<2xi32> {
   %0 = tensorrt.linspace[%cst_i32 : tensor<i32>] [%arg0 : tensor<2xi32>] [%cst_i32_0 : tensor<2xi32>] : tensor<?x3xi32>
   return %0 : tensor<?x3xi32>
 }
-
-// CHECK-LABEL: @dynamic_nd_iota_3
-//  CHECK-SAME: tensorrt.engine
-func.func @dynamic_nd_iota_3(%arg0: tensor<2xi32> {
-  tensorrt.value_bounds = #tensorrt.shape_profile<min=[1, 3], opt=[4, 3], max=[12, 3]>,
-  tensorrt.host_tensor
-}) -> tensor<?x3xi64> {
-  %cst_f16 = tensorrt.constant dense<0> : tensor<i64>
-  %cst_f16_0 = tensorrt.constant dense<[0, 1]> : tensor<2xi64>
-  %0 = tensorrt.linspace[%cst_f16 : tensor<i64>] [%arg0 : tensor<2xi32>] [%cst_f16_0 : tensor<2xi64>] : tensor<?x3xi64>
-  return %0 : tensor<?x3xi64>
-}
-


### PR DESCRIPTION
This PR moves the following internal commits to OSS,

**Validate any stride for empty tensors**

Empty tensors can have a variety of strides which are all equally
meaningless. The updated validation check allows any stride if the
tensor has a dimension of size zero.

**Exporting APIs for StableHlo PassManager and TRT Executable**

This changes breaks compiler.compiler_stablehlo_to_executable into two separate APIs in such a way:
exe = compiler.compiler_stablehlo_to_executable(client, module.operation, opts)

is changed to

pipeline = compiler.StableHloPipeline(client, opts)
exe = compiler.getExecutable(pipeline, module.operation)