### PR TITLE
[Tripy] Permit `eval` while tracing, but do not update trace.

### DIFF
--- a/tripy/nvtripy/backend/api/compile.py
+++ b/tripy/nvtripy/backend/api/compile.py
@@ -184,13 +184,6 @@ def compile(
     trace_inputs = [trace_input_map[name] for name in compiled_arg_names]
     trace = Trace(trace_outputs, trace_inputs, shapes=shapes)
 
-    for op in trace.ops:
-        for tensor in op.inputs + op.outputs:
-            if tensor.is_compile_tracer and tensor.eval_stack_info is not None:
-                raise_error(
-                    "Cannot evaluate a tensor while compiling.", ["Tensor was evaluated here:", tensor.eval_stack_info]
-                )
-
     flat_ir = trace.to_flat_ir()
     mlir = flat_ir.to_mlir()
     compiler = MLIRCompiler(trt_builder_opt_level=optimization_level)

--- a/tripy/nvtripy/frontend/trace/tensor.py
+++ b/tripy/nvtripy/frontend/trace/tensor.py
@@ -40,9 +40,6 @@ class TraceTensor:
 
     # Whether this tensor was constructed in order to trace a computation graph for the compiler.
     is_compile_tracer: bool = False
-    # Stack information for the point at which this tensor was evaluated if it was.
-    # This is useful in the compiler to disallow evaluation during tracing.
-    eval_stack_info: Optional[utils.StackInfo] = None
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
Addresses #409. Evaluation while tracing still gives a warning but does not alter the graph, so it does not produce any errors.