### PR TITLE
Enable contributions from external sources

### DIFF
--- a/.github/workflows/tripy-l0.yml
+++ b/.github/workflows/tripy-l0.yml
@@ -79,15 +79,21 @@ jobs:
         run: |
           pytest tests/performance -v -m "not l1" --benchmark-warmup=on --benchmark-json benchmark.json
 
-    - name: Store benchmark result
+    - name: Check benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:
         tool: 'pytest'
         output-file-path: ${{ github.workspace }}/tripy/benchmark.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
+        auto-push: false
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '105%'
         comment-on-alert: true
         fail-on-alert: true
         gh-pages-branch: benchmarks
+
+    - name: Upload benchmark result
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-results
+        path: ${{ github.workspace }}/tripy/benchmark.json

--- a/.github/workflows/tripy-update-benchmark.yml
+++ b/.github/workflows/tripy-update-benchmark.yml
@@ -1,0 +1,27 @@
+name: Post-merge benchmark update
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  upload-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results
+          path: ${{ github.workspace }}/benchmark.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: ${{ github.workspace }}/benchmark.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          gh-pages-branch: benchmarks

--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -72,11 +72,13 @@ pre-commit install
 
 ### Getting Up To Speed
 
-We've added several guides [here](./docs/post0_developer_guides/) that can help you better understand
-the codebase. We recommend starting with the [architecture](./docs/post0_developer_guides/architecture.md)
+We've added several guides that can help you better understand
+the codebase. We recommend starting with the
+[architecture](https://nvidia.github.io/TensorRT-Incubator/post0_developer_guides/architecture.html)
 documentation.
 
-If you're intersted in adding a new operator to Tripy, refer to [this guide](./docs/post0_developer_guides/how-to-add-new-ops.md).
+If you're intersted in adding a new operator to Tripy, refer to
+[this guide](https://nvidia.github.io/TensorRT-Incubator/post0_developer_guides/how-to-add-new-ops.html).
 
 
 ### Making Commits

--- a/tripy/nvtripy/__init__.py
+++ b/tripy/nvtripy/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 # Import TensorRT to make sure all dependent libraries are loaded first.
 import tensorrt

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nvtripy"
-version = "0.0.7"
+version = "0.0.8"
 authors = [{ name = "NVIDIA", email = "svc_tensorrt@nvidia.com" }]
 description = "Tripy: A Python Programming Model For TensorRT"
 readme = "README.md"


### PR DESCRIPTION
[Updates contributing guide to point to rendered documentation](https://github.com/NVIDIA/TensorRT-Incubator/commit/b0df1d1a6eddfa3b591a7b124c5e6f0a3ad8fb4c)

[Updates version to 0.0.8](https://github.com/NVIDIA/TensorRT-Incubator/commit/aa12cfe11f47367c828c75821e5f708b57774604)

[Updates L0 to store benchmark results in a post-merge pipeline](https://github.com/NVIDIA/TensorRT-Incubator/commit/52ade530667e4462dffdcaeb8e4c848015d0941f)

By performing the upload of benchmark results in a post-merge pipeline, we
can enable contributions from forks, which don't otherwise have permission
to push new benchmark results.