### PR TITLE
Move internal change: [compiler] Add compilation task registry

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt-c/Compiler/Compiler.h
@@ -52,6 +52,10 @@ static inline bool mtrtCompilerClientIsNull(MTRT_CompilerClient options) {
   return !options.ptr;
 }
 
+MLIR_CAPI_EXPORTED MTRT_Status mtrtCompilerClientGetCompilationTask(
+    MTRT_CompilerClient client, MlirStringRef taskMnemonic,
+    const MlirStringRef *argv, unsigned argc, MlirPassManager *result);
+
 //===----------------------------------------------------------------------===//
 // MTRT_OptionsContext
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsRegistry.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsRegistry.h
@@ -28,8 +28,8 @@
 #define MLIR_TENSORRT_COMPILER_OPTIONS_REGISTRY
 
 #include "mlir-tensorrt-dialect/Utils/Options.h"
-#include "mlir-tensorrt/Compiler/Client.h"
 #include "mlir-tensorrt/Dialect/Plan/IR/Plan.h"
+#include "mlir/IR/MLIRContext.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -39,25 +39,23 @@ namespace mlirtrt::compiler {
 
 using OptionsConstructorFuncT =
     std::function<StatusOr<std::unique_ptr<mlir::OptionsContext>>(
-        const CompilerClient &client, const llvm::ArrayRef<llvm::StringRef>)>;
+        mlir::MLIRContext *, llvm::ArrayRef<llvm::StringRef>)>;
 
 /// Registers an options creation function for a specific options type.
-void registerOption(const llvm::StringRef optionsType,
-                    OptionsConstructorFuncT func);
+void registerOption(llvm::StringRef optionsType, OptionsConstructorFuncT func);
 
 /// Creates an options instance for the specified options type using a creation
 /// function that was previously registered.
 StatusOr<std::unique_ptr<mlir::OptionsContext>>
-createOptions(const CompilerClient &client, const llvm::StringRef optionsType,
-              const llvm::ArrayRef<llvm::StringRef> args);
+createOptions(mlir::MLIRContext *client, llvm::StringRef optionsType,
+              llvm::ArrayRef<llvm::StringRef> args);
 
 /// Helper to build callbacks that can create options.
 template <typename OptionsT, typename TaskT>
-StatusOr<std::unique_ptr<mlir::OptionsContext>>
-optionsCreateFromArgs(const CompilerClient &client,
-                      const llvm::ArrayRef<llvm::StringRef> args) {
+StatusOr<std::unique_ptr<OptionsT>>
+optionsCreateFromArgs(mlir::MLIRContext *context,
+                      llvm::ArrayRef<llvm::StringRef> args) {
   // Load available extensions.
-  mlir::MLIRContext *context = client.getContext();
   mlir::plan::PlanDialect *planDialect =
       context->getLoadedDialect<mlir::plan::PlanDialect>();
   compiler::TaskExtensionRegistry extensions =
@@ -83,7 +81,7 @@ optionsCreateFromArgs(const CompilerClient &client,
     return getInternalErrorStatus("failed to initialize options: %s",
                                   errMsg->c_str());
 
-  return std::unique_ptr<mlir::OptionsContext>(result.release());
+  return result;
 }
 } // namespace mlirtrt::compiler
 

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StableHloToExecutable.h
@@ -58,14 +58,18 @@ struct StablehloToExecutableOptions
   StablehloToExecutableOptions(TaskExtensionRegistry extensions);
 
   /// Whether to disallow host tensors in TensorRT clusters.
-  bool disallowHostTensorsInTensorRTClusters = false;
+  Option<bool> disallowHostTensorsInTensorRTClusters{
+      this, "plan-clustering-disallow-host-tensors-in-tensorrt-clusters",
+      llvm::cl::init(false),
+      llvm::cl::desc("Don't allow TensorRt clusters to contain host tensor "
+                     "calculations (but they can still be inputs)")};
+
+  Option<std::string> entrypoint{this, "entrypoint", llvm::cl::init("main"),
+                                 llvm::cl::desc("entrypoint function name")};
 
   /// Use non-DPS style calling convention for entrypoint function
   /// and backend types that support allocating results.
   bool enableNonDPSReturns = false;
-
-  /// Entrypoint function name.
-  std::string entrypoint = "main";
 
   /// Base class for extensions associated with StableHloToExecutableTask.
   class ExtensionBase : public TaskExtensionBase {
@@ -133,13 +137,6 @@ public:
 
   static void populatePassManager(mlir::PassManager &pm,
                                   const StablehloToExecutableOptions &options);
-
-  /// Compile a StableHLO module into a MLIR-TensorRT Runtime executable.
-  /// This is the "functional" entrypoint that will allocate a new PassManager
-  /// for a single run.
-  static mlirtrt::StatusOr<std::unique_ptr<runtime::Executable>>
-  compileStableHLOToExecutable(mlir::ModuleOp module,
-                               const StablehloToExecutableOptions &options);
 
   /// Compile a StableHLO module into a MLIR-TensorRT Runtime executable.
   /// This is the "functional" entrypoint that will allocate a new PassManager

--- a/mlir-tensorrt/compiler/lib/Compiler/OptionsRegistry.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/OptionsRegistry.cpp
@@ -23,18 +23,18 @@ using namespace mlirtrt::compiler;
 
 static llvm::ManagedStatic<llvm::StringMap<OptionsConstructorFuncT>> registry{};
 
-void mlirtrt::compiler::registerOption(const llvm::StringRef optionsType,
+void mlirtrt::compiler::registerOption(llvm::StringRef optionsType,
                                        OptionsConstructorFuncT func) {
   (*registry)[optionsType] = std::move(func);
 }
 
 mlirtrt::StatusOr<std::unique_ptr<mlir::OptionsContext>>
-mlirtrt::compiler::createOptions(const CompilerClient &client,
-                                 const llvm::StringRef optionsType,
-                                 const llvm::ArrayRef<llvm::StringRef> args) {
+mlirtrt::compiler::createOptions(mlir::MLIRContext *ctx,
+                                 llvm::StringRef optionsType,
+                                 llvm::ArrayRef<llvm::StringRef> args) {
   if (!registry->contains(optionsType))
     return getInvalidArgStatus(
         "{0} is not a valid option type. Valid options were: {1:$[ ]}",
         optionsType, llvm::iterator_range(registry->keys()));
-  return (*registry)[optionsType](client, args);
+  return (*registry)[optionsType](ctx, args);
 }

--- a/mlir-tensorrt/compiler/test/python/mlir_tensorrt_compiler/compiler_api/test_executor_translation.py
+++ b/mlir-tensorrt/compiler/test/python/mlir_tensorrt_compiler/compiler_api/test_executor_translation.py
@@ -1,0 +1,22 @@
+# RUN: %PYTHON %s | FileCheck %s
+import mlir_tensorrt.compiler.api as compiler
+import mlir_tensorrt.compiler.ir as ir
+
+
+with ir.Context() as ctx:
+    client = compiler.CompilerClient(ctx)
+    ASM = """
+    func.func @main(%arg0: i32, %arg1: i32) -> i32 attributes{
+      executor.function_metadata=#executor.func_meta<[i32, i32],[i32], num_output_args = 0>
+    }{
+      %0 = executor.sremi %arg0, %arg1 : i32
+      return %0 : i32
+    }
+    """
+
+    m = ir.Module.parse(ASM)
+    exe = compiler.translate_mlir_to_executable(m.operation)
+
+    sig = exe.get_signature("main")
+    print(sig)
+    # CHECK: FunctionSignature(Signature<args=[i32, i32], results=[i32], num_output_args=0, arg_bounds=[UNK, UNK], result_bounds=[UNK]>)

--- a/mlir-tensorrt/executor/include/mlir-executor-c/Target/ExecutorTranslations.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Target/ExecutorTranslations.h
@@ -1,0 +1,37 @@
+//===- ExecutorTranslations.h ------------------------------------*- C -*-===//
+//
+// SPDX-FileCopyrightText: Copyright 2024 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_EXECUTOR_C_TARGET_EXECUTORTRANSLATIONS
+#define MLIR_EXECUTOR_C_TARGET_EXECUTORTRANSLATIONS
+
+#include "mlir-c/IR.h"
+#include "mlir-executor-c/Common/Common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_CAPI_EXPORTED MTRT_Status
+translateToRuntimeExecutable(MlirOperation op, MTRT_Executable *executable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_EXECUTOR_C_TARGET_EXECUTORTRANSLATIONS

--- a/mlir-tensorrt/executor/lib/CAPI/CMakeLists.txt
+++ b/mlir-tensorrt/executor/lib/CAPI/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Support)
 add_subdirectory(Common)
 add_subdirectory(Runtime)
+add_subdirectory(Target)

--- a/mlir-tensorrt/executor/lib/CAPI/Target/CMakeLists.txt
+++ b/mlir-tensorrt/executor/lib/CAPI/Target/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_mlir_public_c_api_library(MLIRTensorRTCAPIExecutorTranslations
+  ExecutorTranslations.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRTensorRTSupportStatus
+  MLIRTensorRTTargetLua
+  MLIRTensorRTCAPICommon
+  )

--- a/mlir-tensorrt/executor/lib/CAPI/Target/ExecutorTranslations.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Target/ExecutorTranslations.cpp
@@ -1,0 +1,41 @@
+//===- Compiler.h -------------------------------------------------*- C -*-===//
+//
+// SPDX-FileCopyrightText: Copyright 2024 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#include "mlir-executor-c/Target/ExecutorTranslations.h"
+#include "mlir-executor-c/Support/Status.h"
+#include "mlir-executor/Runtime/API/API.h"
+#include "mlir-executor/Target/Lua/TranslateToRuntimeExecutable.h"
+#include "mlir/CAPI/IR.h"
+
+using namespace mlir;
+
+MTRT_Status translateToRuntimeExecutable(MlirOperation op,
+                                         MTRT_Executable *result) {
+  FailureOr<std::unique_ptr<mlirtrt::runtime::ExecutableStorage>> exeStorage =
+      mlir::translateToRuntimeExecutable(unwrap(op));
+  if (failed(exeStorage))
+    return mtrtStatusCreate(MTRT_StatusCode_InternalError,
+                            "failed to translate to executable");
+
+  *result = MTRT_Executable{
+      std::make_unique<mlirtrt::runtime::Executable>(std::move(*exeStorage))
+          .release()};
+
+  return mtrtStatusGetOk();
+}

--- a/mlir-tensorrt/python/CompilerPackage.cmake
+++ b/mlir-tensorrt/python/CompilerPackage.cmake
@@ -95,6 +95,7 @@ declare_mlir_python_extension(MLIRTensorRTPythonCompiler.CompilerAPI.PyBind
     MLIRTensorRTCAPICompiler
     MLIRTensorRTCAPISupportStatus
     MLIRTensorRTCAPICommon
+    MLIRTensorRTCAPIExecutorTranslations
   PRIVATE_LINK_LIBS
     LLVMSupport
     TensorRTHeaderOnly

--- a/mlir-tensorrt/tensorrt/lib/Target/TranslateToTensorRT.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TranslateToTensorRT.cpp
@@ -66,7 +66,7 @@ using namespace mlir::tensorrt;
 bool ByteSizeParser::parse(llvm::cl::Option &option, StringRef argName,
                            StringRef arg, std::optional<uint64_t> &val) {
   val = std::nullopt;
-  if (arg.empty())
+  if (arg.empty() || arg.lower() == "none")
     return false;
 
   char *End;


### PR DESCRIPTION
This change adds a CompilationTask (cached pass managers) registry
which enables creating and looking up cached compilation tasks from
the Python API by just passing a mnemonic task name and a list of
string options.

GitOrigin-RevId: f19e634e8ff8338809fe2c1b8efa730ef2e14f21