### PR TITLE
Refactors some guides

### DIFF
--- a/.github/workflows/tripy-l0.yml
+++ b/.github/workflows/tripy-l0.yml
@@ -87,7 +87,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         auto-push: ${{ !github.event.pull_request.head.repo.fork }}
         # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '105%'
+        alert-threshold: '110%'
         comment-on-alert: true
         fail-on-alert: true
         gh-pages-branch: benchmarks

--- a/tripy/README.md
+++ b/tripy/README.md
@@ -1,86 +1,36 @@
 
 # Tripy: A Python Programming Model For TensorRT
 
-<!-- Tripy: DOC: OMIT Start -->
-[**Installation**](#installation) | [**Getting Started**](#getting-started) | [**Documentation**](https://nvidia.github.io/TensorRT-Incubator/) | [**Notebooks**](./notebooks) | [**Examples**](./examples) | [**Contributing**](./CONTRIBUTING.md)
+[**Installation**](#installation)
+| [**Getting Started**](#getting-started)
+| [**Examples**](https://github.com/NVIDIA/TensorRT-Incubator/tree/main/tripy/examples)
+| [**Notebooks**](https://github.com/NVIDIA/TensorRT-Incubator/tree/main/tripy/notebooks)
+| [**Contributing**](https://github.com/NVIDIA/TensorRT-Incubator/blob/main/tripy/CONTRIBUTING.md)
+| [**Documentation**](https://nvidia.github.io/TensorRT-Incubator/)
 
+<!-- Tripy: DOC: OMIT Start -->
 [![Tripy L1](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml/badge.svg)](https://github.com/NVIDIA/TensorRT-Incubator/actions/workflows/tripy-l1.yml)
 <!-- Tripy: DOC: OMIT End -->
 
-Tripy is a Python programming model for [TensorRT](https://developer.nvidia.com/tensorrt) that aims to provide
-an excellent user experience without compromising performance. Some of the goals of Tripy are:
+**Tripy** is a debuggable, Pythonic frontend for [TensorRT](https://developer.nvidia.com/tensorrt),
+a deep learning inference compiler.
 
-- **Intuitive API**: Tripy doesn't reinvent the wheel: If you have used NumPy or
-    PyTorch before, Tripy APIs should feel familiar.
+What you can expect:
 
-- **Excellent Error Messages**: When something goes wrong, Tripy tries to provide
-    informative and actionable error messages. Even in cases where the error comes
-    from deep within the software stack, Tripy is usually able to map it back to the
-    related Python code.
+- **High Performance:** Leveraging [TensorRT](https://developer.nvidia.com/tensorrt)'s optimization capabilties.
 
-- **Friendly Documentation**: The documentation is meant to be accessible and comprehensive,
-    with plenty of examples to illustrate important points.
+- **Intuitive API:** A familiar API that follows conventions of the ecosystem.
 
+- **Debuggability:** **Eager mode** to interactively debug mistakes.
 
-## Installation
+- **Excellent Error Messages**: Informative and actionable.
 
-<!-- Tripy: DOC: OMIT Start -->
-### Installing Prebuilt Wheels
-<!-- Tripy: DOC: OMIT End -->
+- **Friendly Documentation**: Comprehensive but straight-to-the-point, with code examples.
 
-```bash
-python3 -m pip install nvtripy -f https://nvidia.github.io/TensorRT-Incubator/packages.html
-```
-
-<!-- Tripy: DOC: OMIT Start -->
-### Building Wheels From Source
-
-To get the latest changes in the repository, you can build Tripy wheels from source.
-
-1. Make sure `build` is installed:
-
-    ```bash
-    python3 -m pip install build
-    ```
-
-2. From the [`tripy` root directory](.), run:
-
-    ```bash
-    python3 -m build . -w
-    ```
-
-3. Install the wheel, which should have been created in the `dist/` directory.
-    From the [`tripy` root directory](.), run:
-
-    ```bash
-    python3 -m pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html dist/nvtripy-*.whl
-    ```
-
-4. **[Optional]** To ensure that Tripy was installed correctly, you can run a sanity check:
-
-    ```bash
-    python3 -c "import nvtripy as tp; x = tp.ones((5,), dtype=tp.int32); assert x.tolist() == [1] * 5"
-    ```
-
-<!-- Tripy: DOC: OMIT End -->
-
-## Getting Started
-
-We've included several guides in Tripy to make it easy to get started.
-We recommend starting with the
-[Introduction To Tripy](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/00-introduction-to-tripy.html)
-guide.
-
-Other features covered in our guides include:
-
-- [Compiling code (including dynamic shape support)](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/02-compiler.html)
-- [Quantization](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/01-quantization.html)
-
-To get an idea of the look and feel of Tripy, let's take a look at a short code example.
-All of the features used in this example are explained in more detail in the
-introduction guide mentioned above.
+Code is worth 1,000 words:
 
 ```py
+# doc: no-print-locals
 # Define our model:
 class Model(tp.Module):
     def __init__(self):
@@ -92,7 +42,7 @@ class Model(tp.Module):
         return x
 
 
-# Initialize the model and populate weights:
+# Initialize the model and load weights:
 model = Model()
 model.load_state_dict(
     {
@@ -114,3 +64,55 @@ compiled_model = tp.compile(
 
 compiled_out = compiled_model(inp)
 ```
+
+
+## Installation
+
+<!-- Tripy: DOC: OMIT Start -->
+### Installing Prebuilt Wheels
+<!-- Tripy: DOC: OMIT End -->
+
+```bash
+python3 -m pip install nvtripy -f https://nvidia.github.io/TensorRT-Incubator/packages.html
+```
+
+<!-- Tripy: DOC: OMIT Start -->
+### Building Wheels From Source
+
+For the latest changes, build Tripy wheels from source:
+
+1. Install `build`:
+
+    ```bash
+    python3 -m pip install build
+    ```
+
+2. Build a wheel from the [`tripy` root directory](.):
+
+    ```bash
+    python3 -m build . -w
+    ```
+
+3. Install the wheel from the [`tripy` root directory](.):
+
+    ```bash
+    python3 -m pip install -f https://nvidia.github.io/TensorRT-Incubator/packages.html dist/nvtripy-*.whl
+    ```
+
+4. **[Optional]** Sanity check:
+
+    ```bash
+    python3 -c "import nvtripy as tp; x = tp.ones((5,), dtype=tp.int32); assert x.tolist() == [1] * 5"
+    ```
+<!-- Tripy: DOC: OMIT End -->
+
+
+## Getting Started
+
+- **Start with**:
+    [Introduction To Tripy](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/00-introduction-to-tripy.html)
+
+Other guides:
+
+- [Compiling For Better Performance](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/02-compiler.html)
+- [Quantization](https://nvidia.github.io/TensorRT-Incubator/pre0_user_guides/01-quantization.html)

--- a/tripy/docs/_templates/layout.html
+++ b/tripy/docs/_templates/layout.html
@@ -1,0 +1,5 @@
+<!-- This template lets us hide the TOCs from the main page and only include them in the sidebars -->
+{% block sidebartoc %}
+<h3>{{ _('Table Of Contents') }}</h3>
+{{ toctree(includehidden=True) }}
+{% endblock %}

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -286,7 +286,8 @@ def process_docstring_impl(app, what, name, obj, options, lines):
 
         code_block_lines, local_var_lines, output_lines, _ = helper.process_code_block_for_outputs_and_locals(
             block,
-            format_contents=lambda title, contents, lang: f"\n\n.. code-block:: {lang}\n"
+            # We don't care about indentation of code within the block, so we ignore that parameter.
+            format_contents=lambda title, contents, lang, _: f"\n\n.. code-block:: {lang}\n"
             + indent((f":caption: {title}" if title else "") + f"\n\n{contents}", prefix=" " * helper.TAB_SIZE),
             err_msg=f"Failed while processing docstring for: {what}: {name} ({obj}): ",
             strip_assertions=True,

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -84,6 +84,8 @@ source_suffix = [".rst"]
 # The master toctree document.
 master_doc = "index"
 
+templates_path = ["_templates"]
+
 # General information about the project.
 project = "Tripy"
 copyright = "2024, NVIDIA"

--- a/tripy/docs/generate_rsts.py
+++ b/tripy/docs/generate_rsts.py
@@ -135,6 +135,7 @@ def build_root_index_file(constituents, guide_sets, processed_markdown_dirname):
             dedent(
                 f"""
                 .. toctree::
+                    :hidden:
                     :caption: {guide_set.title}
                     :maxdepth: 1
                 """
@@ -151,6 +152,7 @@ def build_root_index_file(constituents, guide_sets, processed_markdown_dirname):
             dedent(
                 f"""
                 .. toctree::
+                    :hidden:
                     :caption: API Reference
                     :maxdepth: 1
                 """
@@ -311,7 +313,7 @@ def main():
 
     print(f"Generating documentation hierarchy:\n{str_from_hierarchy(doc_hierarcy)}")
 
-    EXCLUDE_DIRS = ["_static"]
+    EXCLUDE_DIRS = ["_static", "_templates"]
 
     guide_sets: List[GuideSet] = []
     guide_dirs = list(

--- a/tripy/docs/generate_rsts.py
+++ b/tripy/docs/generate_rsts.py
@@ -1,4 +1,3 @@
-#
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -197,12 +196,15 @@ def process_guide(guide_path: str, processed_guide_path: str):
         if should_eval and block.lang.startswith("py"):
             print("Evaluating Python block")
 
-            def add_block(title, contents, lang):
-                # Only include the "Output:" heading when the code block is actually rendered in the documentation.
-                return (
+            def add_block(title, contents, lang, code_indentation):
+                # Indent our block to match the indentation of the code in the original block.
+                return indent(
                     "\n"
+                    # Only include the "Output:" title when the code block is rendered.
+                    # Hidden code blocks can be used to dynamically generate documentation.
                     + (title if not block.has_marker("doc: omit") else "")
-                    + f"\n```{lang}\n{dedent(contents).strip()}\n```"
+                    + f"\n```{lang}\n{dedent(contents).strip()}\n```",
+                    prefix=" " * code_indentation,
                 )
 
             code_block_lines, local_var_lines, output_lines, code_locals = (

--- a/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
+++ b/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
@@ -1,30 +1,20 @@
 # An Introduction To Tripy
 
-## What Is Tripy?
-
-Tripy is a compiler that compiles deep learning models for inference using TensorRT as a backend.
-It aims to be fast, easy to debug, and provide an easy-to-use Pythonic interface.
-
-## Your First Tripy Program
+**Tripy** is a debuggable, Pythonic frontend for [TensorRT](https://developer.nvidia.com/tensorrt),
+a deep learning inference compiler:
 
 ```py
 # doc: no-print-locals
-a = tp.arange(5)
-c = a + 1.5
+a = tp.ones((2, 3))
+b = tp.ones((2, 3))
+c = a + b
 print(c)
-assert cp.array_equal(cp.from_dlpack(c), cp.arange(5, dtype=np.float32) + 1.5) # doc: omit
+assert tp.equal(c, tp.full((2, 3), 2.0)) # doc: omit
 ```
 
-This should look familiar if you've used linear algebra or deep learning libraries like
-NumPy and PyTorch. Hopefully, the code above is self-explanatory, so we won't go into details.
+## Organizing Code With Modules
 
-## Organizing Code Using Modules
-
-The {class}`nvtripy.Module` API allows you to create reusable blocks that can be composed together
-to create models. Modules may be comprised of other modules, including modules predefined
-by Tripy, like {class}`nvtripy.Linear` and {class}`nvtripy.LayerNorm`.
-
-For example, we can define a Transfomer MLP block like so:
+{class}`nvtripy.Module`s are composable, reusable blocks of code:
 
 ```py
 class MLP(tp.Module):
@@ -40,7 +30,7 @@ class MLP(tp.Module):
         return x
 ```
 
-To use it, we just need to construct and call it:
+Usage:
 
 ```py
 # doc: no-print-locals mlp
@@ -50,109 +40,58 @@ inp = tp.iota(shape=(1, 2), dim=1, dtype=tp.float32)
 out = mlp(inp)
 ```
 
-## Compiling Code
+## Compiling For Better Performance
 
-All the code we've seen so far has been using Tripy's eager mode. It is also possible to compile
-functions or modules ahead of time, which can result in significantly better performance.
-
-*Note that the compiler imposes some requirements on the functions/modules it can compile.*
-*See {func}`nvtripy.compile` for details.*
-
-Let's compile the MLP module we defined above as an example:
+Modules and functions can be **compiled**:
 
 ```py
 # doc: no-print-locals
-# When we compile, we need to indicate which parameters to the function
-# should be runtime inputs. In this case, MLP takes a single input tensor
-# for which we can specify our desired shape and datatype.
-fast_mlp = tp.compile(mlp, args=[tp.InputInfo(shape=(1, 2), dtype=tp.float32)])
+fast_mlp = tp.compile(
+    mlp,
+    # We must indicate which parameters are runtime inputs.
+    # MLP takes 1 input tensor for which we specify shape and datatype:
+    args=[tp.InputInfo(shape=(1, 2), dtype=tp.float32)],
+)
 ```
 
-Now let's benchmark the compiled version against eager mode:
-<!--
+- **Note:** There are **restrictions** on what can be compiled - see {func}`nvtripy.compile`.
+
+Usage:
 ```py
-from nvtripy.frontend.cache import global_cache
-
-# Clear the cache to get accurate timing results.
-global_cache._cache.clear()
-```
--->
-
-```py
-# doc: no-print-locals
-import time
-
-start = time.time()
-out = mlp(inp)
-# We need to evaluate in order to actually materialize `out`.
-# See the section on lazy evaluation below for details.
-out.eval()
-end = time.time()
-
-eager_time = (end - start) * 1000
-print(f"Eager mode time: {eager_time:.4f} ms")
-
-start = time.time()
 out = fast_mlp(inp)
-out.eval()
-end = time.time()
-
-compiled_time = (end - start) * 1000
-print(f"Compiled mode time: {compiled_time:.4f} ms")
-# Make sure compiled mode is actually faster # doc: omit
-assert compiled_time < 0.01 * eager_time # doc: omit
 ```
 
-For more information on the compiler, compiled functions/modules, and dynamic shapes,
-see the [compiler guide](project:./02-compiler.md).
+- **Also see:** [Compiler guide](project:./02-compiler.md) for details, including **dynamic shapes**.
 
-## Things To Note
 
-### Eager Mode: How Does It Work?
+## Pitfalls And Best Practices
 
-If you've used TensorRT before, you may know that it does not support an eager mode.
-In order to provide eager mode support in Tripy, we actually need to compile the graph
-under the hood.
+- **Best Practice:** Use **eager mode** only for **debugging**; compile for deployment.
 
-Although we employ several tricks to make compile times faster when using eager mode,
-we do still need to compile, and so eager mode will likely be slower than other
-comparable frameworks.
+    **Why:** Eager mode internally compiles the graph (slow!) since TensorRT doesn't have eager execution.
 
-Consequently, we suggest that you use eager mode primarily for debugging and
-compiled mode for deployments.
+- **Pitfall:** Be careful timing code in **eager mode**.
 
-### Lazy Evaluation: Putting Off Work
+    **Why:** Tensors are evaluated only when used; naive timing will be inaccurate:
 
-One important point is that Tripy uses a lazy evaluation model; that is,
-no computation is performed until a value is actually needed.
+    ```py
+    # doc: no-print-locals
+    import time
 
-In most cases, this is simply an implementation detail that you will not notice.
-One exception to this is when attempting to time code. Consider the following code:
+    start = time.time()
+    a = tp.gelu(tp.ones((2, 8)))
+    end = time.time()
 
-```py
-# doc: no-print-locals
-import time
+    # `a` has not been evaluated yet - this time is not what we want!
+    define_time = end - start # doc: omit
+    print(f"Defined `a` in: {(end - start) * 1000:.3f} ms.")
 
-start = time.time()
-a = tp.arange(5)
-b = tp.arange(5)
-c = a + b + tp.tanh(a)
-end = time.time()
+    start = time.time()
+    # `a` is used (and thus evaluated) for the first time:
+    print(a)
+    end = time.time()
 
-print(f"Time to create 'c': {(end - start) * 1000:.3f} ms.")
-```
-
-Given what we said above about eager mode, it seems like Tripy is very fast!
-Of course, this is because *we haven't actually done anything yet*.
-The actual compilation and execution only happens when we evaluate `c`:
-
-```py
-# doc: no-print-locals
-start = time.time()
-print(c)
-end = time.time()
-
-print(f"Time to print 'c': {(end - start) * 1000:.3f} ms.")
-```
-
-That is why the time to print `c` is so much higher than the time to create it.
+    # This includes compilation time, not just execution time!
+    print(f"Compiled and evaluated `a` in: {(end - start) * 1000:.3f} ms.")
+    assert end - start > define_time # doc: omit
+    ```

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -564,16 +564,7 @@ def process_code_block_for_outputs_and_locals(
                 locals_str += f"\n{obj}"
 
     def split_block_lines(title, contents, lang="python"):
-        line = block.splitlines()[1]
-        indentation = len(line) - len(line.lstrip())
-
-        out = (
-            indent(
-                format_contents(title, contents, lang),
-                prefix=" " * (indentation - 4),
-            )
-            + "\n\n"
-        )
+        out = format_contents(title, contents, lang, indentation) + "\n\n"
         return out.splitlines()
 
     if locals_str:


### PR DESCRIPTION
[Refactors main README and introduction guide](https://github.com/NVIDIA/TensorRT-Incubator/pull/471/commits/2f88ae2d1f64a7a68eacea6b9cfefbdc0690bad3)
- Refactors documentation to be significantly less verbose

[Excludes table-of-contents from main page](https://github.com/NVIDIA/TensorRT-Incubator/pull/471/commits/96ffc9e4c55b72092f72665ac1de0aa2af82c45e)
- Removes the table of contents at the end of the main page since it is always
    visible in the side bar.