### PR TITLE
Move internal changes

### DIFF
--- a/mlir-tensorrt/CMakeLists.txt
+++ b/mlir-tensorrt/CMakeLists.txt
@@ -253,6 +253,14 @@ include(AddMLIRPython)
 include(MLIRDetectPythonEnv)
 mlir_configure_python_dev_packages()
 
+# Declare the Python source targets ahead-of-time since the sources may be built
+# up across multiple sub-directories.
+if(MLIR_TRT_ENABLE_PYTHON)
+  declare_mlir_python_sources(MLIRTensorRTPythonCompiler)
+  declare_mlir_python_sources(MLIRTensorRTPythonCompiler.Dialects
+    ADD_TO_PARENT MLIRTensorRTPythonCompiler)
+endif()
+
 # Add a meta target for all documentation generation targets. You can generate
 # all documentation under `${buildDir}/docs` by building this target.
 add_custom_target("mlir-tensorrt-doc")

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
@@ -164,6 +164,11 @@ public:
       &this->ctx, "debug-only", llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated,
       OmitFromCLI{}};
 
+  /// If set to `true`, we populate the pass manager instrumentation using
+  /// global MLIR CL options rather than the local options contained here.
+  Option<bool> useGlobalCLPrintingOptions{&this->ctx, "use-global-cl-options",
+                                          llvm::cl::init(false), OmitFromCLI{}};
+
   /// Apply these options to the current pass manager.
   void applyToPassManager(mlir::PassManager &pm) const;
 };
@@ -194,8 +199,6 @@ public:
       &this->ctx, "device-infer-from-host", llvm::cl::init(true),
       llvm::cl::desc("whether to ignore `deviceX` options and instead infer "
                      "them from the host GPU")};
-
-  Status inferFromHost();
 
 public:
   DeviceOptions(mlir::OptionsContext &ctx) : OptionsProvider(ctx) {

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StablehloToExecutable/TensorRTExtension.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StablehloToExecutable/TensorRTExtension.h
@@ -51,6 +51,8 @@ public:
   void addToOptions(mlir::OptionsContext &context) final {
     context.addOption("disable-tensorrt-extension", disabled,
                       llvm::cl::init(false));
+    context.addOption("use-global-tensorrt-translation-flags", useGlobalCLFlags,
+                      llvm::cl::init(false));
     translationOptions.addToOptions(context);
   }
 
@@ -63,8 +65,8 @@ private:
   /// Options for MLIR-to-TensorRT translation.
   mlir::tensorrt::TensorRTTranslationOptions translationOptions;
 
-  /// Path where we should persist the timing cache to storage.
-  std::string timingCachePath;
+  /// Whether to use global CL config for options.
+  bool useGlobalCLFlags{false};
 };
 
 } // namespace mlirtrt::compiler

--- a/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/TensorRTExtension.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/TensorRTExtension.cpp
@@ -44,8 +44,12 @@ void StablehloToExecutableTensorRTExtension::populatePasses(
   if (this->disabled)
     return;
 
+  tensorrt::TensorRTTranslationOptions translationOpts =
+      useGlobalCLFlags ? tensorrt::TensorRTTranslationOptions::fromCLFlags()
+                       : translationOptions;
+
   if (phase == Phase::PreClustering) {
-    // We must materialize TRT plugin shape regions prior to clustering.
+    // We must materialize TRT plugion shape regions prior to clustering.
     pm.addNestedPass<func::FuncOp>(tensorrt::createInferPluginShapesPass());
     return;
   }
@@ -61,9 +65,9 @@ void StablehloToExecutableTensorRTExtension::populatePasses(
     // Simplify and translate functions nested in `tensorrt.module` ops.
     auto &trtPM = pm.nest<tensorrt::TensorRTModuleOp>();
     tensorrt::buildTensorRTModuleTransformationPipeline(
-        trtPM, translationOptions.enableStronglyTyped);
+        trtPM, translationOpts.enableStronglyTyped);
     trtPM.addPass(
-        tensorrt::createTranslateTensorRTPass(nullptr, translationOptions));
+        tensorrt::createTranslateTensorRTPass(nullptr, translationOpts));
     return;
   }
 

--- a/mlir-tensorrt/compiler/test/python/IntegrationTests/Torch/test_torch_add.py
+++ b/mlir-tensorrt/compiler/test/python/IntegrationTests/Torch/test_torch_add.py
@@ -2,12 +2,11 @@
 
 import mlir_tensorrt.compiler.api as compiler
 import mlir_tensorrt.compiler.ir as ir
-import mlir_tensorrt.runtime.api as runtime
 import mlir_tensorrt.compiler.torch_bridge as torch_bridge
-
+import mlir_tensorrt.runtime.api as runtime
 import numpy as np
-import torch.nn as nn
 import torch
+import torch.nn as nn
 
 
 class Model(nn.Module):

--- a/mlir-tensorrt/python/CompilerPackage.cmake
+++ b/mlir-tensorrt/python/CompilerPackage.cmake
@@ -23,12 +23,9 @@ configure_file(
 # Structural groupings.
 ################################################################################
 
-declare_mlir_python_sources(MLIRTensorRTPythonCompiler)
 declare_mlir_python_sources(MLIRTensorRTPythonCompiler.Core
   ADD_TO_PARENT MLIRTensorRTPythonCompiler)
 declare_mlir_python_sources(MLIRTensorRTPythonCompiler.CompilerAPI
-  ADD_TO_PARENT MLIRTensorRTPythonCompiler)
-declare_mlir_python_sources(MLIRTensorRTPythonCompiler.Dialects
   ADD_TO_PARENT MLIRTensorRTPythonCompiler)
 
 ################################################################################

--- a/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/torch_bridge.py
+++ b/mlir-tensorrt/python/mlir_tensorrt_compiler/mlir_tensorrt/compiler/torch_bridge.py
@@ -1,11 +1,13 @@
-from typing import Optional, Union, Dict, Tuple, Any
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple, Union
+
 from torch import nn
 from torch.export import ExportedProgram
-from dataclasses import dataclass, field
-from .compiler_utils import OutputType
+
 from . import fx
-from .extras.fx_importer import FxImporter
+from .compiler_utils import OutputType
 from .dialects import torch as torch_d
+from .extras.fx_importer import FxImporter
 
 __all__ = ["TorchInput", "get_mlir_module_from_torch_module"]
 

--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/Target/TensorRTEncodingOpInterface/NetworkEncoder.h
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/Target/TensorRTEncodingOpInterface/NetworkEncoder.h
@@ -267,7 +267,7 @@ template <typename T, std::enable_if_t<std::is_same_v<T, int32_t> ||
                                            std::is_same_v<T, int64_t>,
                                        T *> = nullptr>
 static nvinfer1::Dims getNvInferDims(ArrayRef<T> arrayRef) {
-  assert(arrayRef.size() < nvinfer1::Dims::MAX_DIMS &&
+  assert(arrayRef.size() <= nvinfer1::Dims::MAX_DIMS &&
          "input array exceeds max dims");
   nvinfer1::Dims dims;
   dims.nbDims = arrayRef.size();

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/max-tensor-rank.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/max-tensor-rank.mlir
@@ -1,0 +1,14 @@
+// RUN: %pick-one-gpu tensorrt-opt -split-input-file -pass-pipeline="builtin.module(translate-tensorrt-to-engine)" \
+// RUN:  -mlir-elide-elementsattrs-if-larger=32 -tensorrt-builder-opt-level=0 %s | FileCheck %s
+
+!tensor_type = tensor<8x8x8x8x8x8x8x8xf32>
+
+// Check that we can convert a network with tensor ranks of max allowed by TensorRT (rank 8).
+func.func @trt_max_rank(%arg1: !tensor_type, %arg2: !tensor_type) -> (!tensor_type) {
+  %1 = tensorrt.element_wise <kSUM> (%arg1, %arg2 : !tensor_type, !tensor_type)
+    -> !tensor_type
+  return %1 : !tensor_type
+}
+
+// CHECK-LABEL: @trt_max_rank
+//  CHECK-SAME: tensorrt.engine


### PR DESCRIPTION
## [tensorrt] Fix various edge cases in 'tensorrt-broadcast-elimination'

This change fixes several edge cases in 'tensorrt-broadcast-elimination'
for a particular pattern that commutes 'tensorrt.broadcast' and
'tensorrt.collapse_rank'. Previously it did not correctly handle multiple
collapsed unit dimensions and would produce an erroneous assertion when
the collapsed input is dynamic. Several additional regression tests
are added.

## [tensorrt] Fix nvinfer1::Dims max rank assertion

Fixes an assertion which limited translation of MLIR to TensorRT to
programs with tensors of rank < 8 when it should be <= 8 to align
with TensorRT op verification and the actual nvinfer API. Adds an
additional translation test.

## NFC: apply isort to Python files

## Fix options configuration to enable global flags in "compiler task" API