### PR TITLE
Minor docstring fixes

### DIFF
--- a/tripy/README.md
+++ b/tripy/README.md
@@ -29,8 +29,8 @@ What you can expect:
 
 Code is worth 1,000 words:
 
+<!-- Tripy: DOC: NO_PRINT_LOCALS Start -->
 ```py
-# doc: no-print-locals
 # Define our model:
 class Model(tp.Module):
     def __init__(self):
@@ -64,6 +64,7 @@ compiled_model = tp.compile(
 
 compiled_out = compiled_model(inp)
 ```
+<!-- Tripy: DOC: NO_PRINT_LOCALS End -->
 
 
 ## Installation

--- a/tripy/docs/generate_rsts.py
+++ b/tripy/docs/generate_rsts.py
@@ -235,7 +235,8 @@ def process_guide(guide_path: str, processed_guide_path: str):
             if not block.has_marker("doc: omit"):
                 new_blocks.extend(code_block_lines)
 
-            new_blocks.extend(local_var_lines)
+            if not block.has_marker("doc: no_print_locals"):
+                new_blocks.extend(local_var_lines)
             new_blocks.extend(output_lines)
 
         else:

--- a/tripy/docs/post0_developer_guides/debugging.md
+++ b/tripy/docs/post0_developer_guides/debugging.md
@@ -8,7 +8,6 @@ This guide outlines some methods of doing so.
 
 We include some environment variables to enable extra debugging information from MLIR-TRT:
 
-- `export TRIPY_EAGER_CACHE=0` will disable eager caching for Tripy tensors (by default Tripy caches all IRs for tensor evals in eager mode for future reuse.) 
 - `export TRIPY_MLIR_DEBUG_ENABLED=1` will enable debug prints in MLIR-TRT and dump all intermediate IRs to a directory.
 - `export TRIPY_MLIR_DEBUG_PATH=<mlir-debug-path>` sets the directory for IR dumps. The default path is `mlir-dumps`.
 - `export TRIPY_TRT_DEBUG_ENABLED=1` will dump TensorRT engines and their layer information.

--- a/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
+++ b/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
@@ -1,7 +1,11 @@
 # An Introduction To Tripy
 
 **Tripy** is a debuggable, Pythonic frontend for [TensorRT](https://developer.nvidia.com/tensorrt),
-a deep learning inference compiler:
+a deep learning inference compiler.
+
+## API Semantics
+
+Unlike TensorRT's graph-based semantics, Tripy uses a functional style:
 
 ```py
 # doc: no-print-locals

--- a/tripy/nvtripy/config.py
+++ b/tripy/nvtripy/config.py
@@ -38,12 +38,17 @@ mlir_debug_tree_path = os.environ.get("TRIPY_MLIR_DEBUG_PATH", os.path.join("/",
 enable_tensorrt_debug = os.environ.get("TRIPY_TRT_DEBUG_ENABLED", "0") == "1"
 tensorrt_debug_path = os.environ.get("TRIPY_TRT_DEBUG_PATH", os.path.join("/", "nvtripy", "tensorrt-dumps"))
 
-tripy_eager_cache: str = export.public_api(
+use_cache_in_eager_mode: bool = export.public_api(
     document_under="config.rst",
     module=sys.modules[__name__],
-    symbol="tripy_eager_cache",
-)(os.environ.get("TRIPY_EAGER_CACHE", "1") == "1")
-"""Whether to enable eager mode caching."""
+    symbol="use_cache_in_eager_mode",
+)(os.environ.get("TRIPY_USE_CACHE_IN_EAGER_MODE", "1") == "1")
+"""
+Whether to enable executable caching to speed up eager mode.
+
+This can also be enabled/disabled by setting the ``TRIPY_USE_CACHE_IN_EAGER_MODE``
+environment variable to ``1``/``0`` respectively.
+"""
 
 timing_cache_file_path: str = export.public_api(
     document_under="config.rst",

--- a/tripy/nvtripy/frontend/cache.py
+++ b/tripy/nvtripy/frontend/cache.py
@@ -132,7 +132,7 @@ class ExecutableCache:
         Returns:
             Executable: The cached executable, or None if not found.
         """
-        if not config.tripy_eager_cache:
+        if not config.use_cache_in_eager_mode:
             return None
 
         key = self._generate_key(trace, devices)
@@ -147,7 +147,7 @@ class ExecutableCache:
             executable (Executable): The executable to cache.
             devices (List[Device]): List of devices associated with the trace.
         """
-        if not config.tripy_eager_cache:
+        if not config.use_cache_in_eager_mode:
             return
 
         key = self._generate_key(trace, devices)

--- a/tripy/tests/frontend/test_cache.py
+++ b/tripy/tests/frontend/test_cache.py
@@ -118,7 +118,7 @@ class TestCache:
         assert mock_global_cache.get(Trace([layer2(input_tensor).trace_tensor]), devices=[output2.device]) is not None
 
     def test_cache_not_being_used_empty_cache(self, mock_global_cache):
-        with helper.config("tripy_eager_cache", False):
+        with helper.config("use_cache_in_eager_mode", False):
             tensor1 = tp.ones((1, 1), dtype=tp.float32)
 
             tensor1.eval()
@@ -132,7 +132,7 @@ class TestCache:
         assert mock_global_cache.get(Trace([tensor1_cached.trace_tensor]), devices=[tensor1.device]) is not None
         tensor1_cached.eval()
 
-        with helper.config("tripy_eager_cache", False):
+        with helper.config("use_cache_in_eager_mode", False):
             tensor2 = tp.ones((1, 1), dtype=tp.float32)
             tensor2.eval()
 

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -247,6 +247,9 @@ AVAILABLE_MARKERS = {
     "doc: omit": Marker.from_name("DOC: OMIT"),
     # Indicates that a block should not be evaluated for the documentation.
     "doc: no_eval": Marker.from_name("DOC: NO_EVAL"),
+    # Indicates that local variables should not be displayed for a code block in the documentation.
+    # Useful when the raw code block is also publicly visible and we don't want inline markers (e.g. in the main README.md).
+    "doc: no_print_locals": Marker.from_name("DOC: NO_PRINT_LOCALS"),
 }
 
 


### PR DESCRIPTION
[Adds a marker to disable printing locals](https://github.com/NVIDIA/TensorRT-Incubator/commit/56b0af44b0aec505acd067c1db9e1382df3e3398)

Adds a `doc: no_print_locals` markdown marker in cases where we can't
use inline comments (e.g. where the raw markdown is user-visible, like in the
main README).

[Updates documentation and naming for option to enable eager mode cache](https://github.com/NVIDIA/TensorRT-Incubator/commit/4f9ea4a2c71cdd455f191811f9e63fca9ae70544)