### PR TITLE
Updates Tripy to work with Python 3.9, moves files into utils

### DIFF
--- a/tripy/Dockerfile
+++ b/tripy/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:22.04
+FROM python:3.9
 
 LABEL org.opencontainers.image.description="Tripy development container"
 
 WORKDIR /tripy
 
-SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/bin/bash"]
 
 # Setup user account
 ARG uid=1000
@@ -29,22 +29,6 @@ RUN pip install build .[docs,dev,test,build] \
     -f https://nvidia.github.io/TensorRT-Incubator/packages.html \
     --extra-index-url https://download.pytorch.org/whl \
     --extra-index-url https://pypi.nvidia.com
-
-# Installl lldb for debugging purposes in Tripy container.
-# The LLVM version should correspond on LLVM_VERSION specified in https://github.com/NVIDIA/TensorRT-Incubator/blob/main/mlir-tensorrt/build_tools/docker/Dockerfile#L30.
-ARG LLVM_VERSION=17
-ENV LLVM_VERSION=$LLVM_VERSION
-ENV LLVM_PACKAGES="lldb-${LLVM_VERSION}"
-RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" > /etc/apt/sources.list.d/llvm.list && \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list && \
-    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null > /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
-    apt-get update && \
-    apt-get install -y ${LLVM_PACKAGES} && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/lldb-17 /usr/bin/lldb
 
 # Export tripy into the PYTHONPATH so it doesn't need to be installed after making changes
 ENV PYTHONPATH=/tripy

--- a/tripy/docs/README.md
+++ b/tripy/docs/README.md
@@ -45,7 +45,7 @@ which specifies doc metadata for each API (e.g. location).
 - Docstring must include *at least* **one [code example](#code-examples)**.
 
 - If the function accepts `tp.Tensor`s, must indicate **data type constraints**
-    with the [`wrappers.interface`](../nvtripy/wrappers.py) decorator.
+    with the [`wrappers.interface`](../nvtripy/utils/wrappers.py) decorator.
 
 **Example:**
 

--- a/tripy/docs/conf.py
+++ b/tripy/docs/conf.py
@@ -28,7 +28,7 @@ from tests import helper
 
 import nvtripy as tp
 from nvtripy.common.datatype import DATA_TYPES
-from nvtripy.wrappers import TYPE_VERIFICATION
+from nvtripy.utils.wrappers import TYPE_VERIFICATION
 
 PARAM_PAT = re.compile(":param .*?:")
 

--- a/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
+++ b/tripy/docs/post0_developer_guides/how-to-add-new-ops.md
@@ -176,7 +176,8 @@ it as a `nvtripy.Module` under [`frontend/module`](source:/nvtripy/frontend/modu
 
 ```py
 # doc: no-eval
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 from nvtripy.types import ShapeLike
 
 # We can use the `export.public_api()` decorator to automatically export this

--- a/tripy/nvtripy/backend/api/compile.py
+++ b/tripy/nvtripy/backend/api/compile.py
@@ -153,7 +153,7 @@ def compile(
         return arg
 
     new_args = []
-    positional_arg_info, _ = utils.get_positional_arg_names(func, *args)
+    positional_arg_info, _ = utils.utils.get_positional_arg_names(func, *args)
     for name, arg in positional_arg_info:
         new_args.append(process_arg(name, arg))
 
@@ -165,7 +165,7 @@ def compile(
     # as `InputInfo`s, but the order needs to match the signature of the original function.
     compiled_arg_names = [name for name in signature.parameters.keys() if name in input_names]
 
-    trace_outputs = utils.make_list(func(*new_args, **new_kwargs))
+    trace_outputs = utils.utils.make_list(func(*new_args, **new_kwargs))
 
     if not trace_outputs:
         raise_error(

--- a/tripy/nvtripy/backend/api/executable.py
+++ b/tripy/nvtripy/backend/api/executable.py
@@ -14,18 +14,17 @@
 # limitations under the License.
 import base64
 import inspect
-from typing import Sequence, Union, Tuple
+from dataclasses import dataclass
+from typing import Sequence, Tuple, Union
 
 import mlir_tensorrt.runtime.api as runtime
-
 from nvtripy import export
 from nvtripy.backend.mlir import Executor
 from nvtripy.backend.mlir import utils as mlir_utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend import Tensor
-from nvtripy.function_registry import str_from_type_annotation
 from nvtripy.utils import json as json_utils
-from dataclasses import dataclass
+from nvtripy.utils.types import str_from_type_annotation
 
 
 # TODO(MLIR-TRT #923): Can generalize `InputInfo` and drop this class.

--- a/tripy/nvtripy/backend/mlir/compiler.py
+++ b/tripy/nvtripy/backend/mlir/compiler.py
@@ -76,7 +76,7 @@ class Compiler:
             return compiler.compiler_stablehlo_to_executable(self.compiler_client, module.operation, opts)
 
     # The optional flat_ir parameter is used to generate nicer error messages.
-    @utils.log_time
+    @utils.utils.log_time
     def compile(self, mlir_module: ir.Module, flat_ir: Optional["FlatIR"] = None) -> compiler.Executable:
         logger.mlir(lambda: f"{mlir_module.operation.get_asm(large_elements_limit=32)}\n")
         opts = self._make_mlir_opts(self.trt_builder_opt_level)

--- a/tripy/nvtripy/backend/mlir/executor.py
+++ b/tripy/nvtripy/backend/mlir/executor.py
@@ -18,7 +18,6 @@
 from typing import List
 
 import mlir_tensorrt.runtime.api as runtime
-
 from nvtripy.backend.api.stream import default_stream
 from nvtripy.backend.mlir.memref import create_memref
 from nvtripy.backend.mlir.utils import MLIRRuntimeClient, convert_runtime_dtype_to_tripy_dtype
@@ -26,7 +25,7 @@ from nvtripy.backend.utils import TensorInfo
 from nvtripy.common import datatype, device
 from nvtripy.common.exception import raise_error
 from nvtripy.common.utils import convert_list_to_array
-from nvtripy.utils import make_tuple
+from nvtripy.utils.utils import make_tuple
 
 
 class Executor:

--- a/tripy/nvtripy/backend/mlir/memref.py
+++ b/tripy/nvtripy/backend/mlir/memref.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 #
 
-import math
 import re
 
 import mlir_tensorrt.runtime.api as runtime
-
 from nvtripy.backend.mlir import utils as mlir_utils
 from nvtripy.common import device as tp_device
-from nvtripy.utils import raise_error
+from nvtripy.common.exception import raise_error
 
 EMPTY_MEMREF_CACHE = {}
 

--- a/tripy/nvtripy/backend/mlir/utils.py
+++ b/tripy/nvtripy/backend/mlir/utils.py
@@ -368,7 +368,7 @@ def map_error_to_user_code_and_raise(flat_ir, exc, stderr):
         return (
             [
                 "This error occured while trying to compile the following FlatIR expression:",
-                utils.code_pretty_str(str(op)),
+                utils.utils.code_pretty_str(str(op)),
                 "\n",
             ]
             + (

--- a/tripy/nvtripy/common/exception.py
+++ b/tripy/nvtripy/common/exception.py
@@ -72,7 +72,7 @@ def str_from_source_info(source_info, enable_color=True, is_first_frame=True, ca
     frame_info = ""
     if is_first_frame:
         frame_info += "\n\n"
-    pretty_code = utils.code_pretty_str(
+    pretty_code = utils.utils.code_pretty_str(
         source_info.code, source_info.file, source_info.line, source_info.function, enable_color=enable_color
     )
 
@@ -84,7 +84,7 @@ def str_from_source_info(source_info, enable_color=True, is_first_frame=True, ca
         # it is not possible for us to determine which column offset is correct, so we
         # won't include it in that case.
         try:
-            candidate_column_offsets = utils.get_candidate_column_offsets(source_info, callee_info)
+            candidate_column_offsets = utils.ast.get_candidate_column_offsets(source_info, callee_info)
         except:
             pass
         else:
@@ -107,9 +107,12 @@ def _get_function_file_and_lines(func):
     return filename, start_line, start_line + len(lines)
 
 
-def str_from_stack_info(stack_info: "utils.StackInfo", enable_color: bool = True) -> Optional[str]:
+def str_from_stack_info(stack_info: "utils.stack_info.StackInfo", enable_color: bool = True) -> Optional[str]:
     def should_exclude(source_info):
-        return source_info.code is None or source_info.module in utils.get_module_names_to_exclude_from_stack_info()
+        return (
+            source_info.code is None
+            or source_info.module in utils.stack_info.get_module_names_to_exclude_from_stack_info()
+        )
 
     frame_strs = []
     num_frames_printed = 0
@@ -157,7 +160,7 @@ def raise_error(summary: str, details: List[Any] = []):
     """
 
     pre_summary = ""
-    stack_info = utils.get_stack_info()
+    stack_info = utils.stack_info.get_stack_info()
     user_frame_index = stack_info.get_first_user_frame_index()
     if user_frame_index is not None:
         stack_info.fetch_source_code()
@@ -168,7 +171,7 @@ def raise_error(summary: str, details: List[Any] = []):
         stack_info_message = None
         if hasattr(detail, "stack_info"):
             stack_info_message = str_from_stack_info(detail.stack_info)
-        elif isinstance(detail, utils.StackInfo):
+        elif isinstance(detail, utils.stack_info.StackInfo):
             stack_info_message = str_from_stack_info(detail)
 
         if stack_info_message is not None:

--- a/tripy/nvtripy/export.py
+++ b/tripy/nvtripy/export.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Any, Sequence, Union
 from types import ModuleType
 from textwrap import dedent
-from nvtripy.function_registry import FunctionRegistry
+from nvtripy.utils.function_registry import FunctionRegistry
 
 
 @dataclass

--- a/tripy/nvtripy/flat_ir/flat_ir.py
+++ b/tripy/nvtripy/flat_ir/flat_ir.py
@@ -315,7 +315,9 @@ class FlatIR:
                     main_func_op.res_attrs = ir.ArrayAttr.get(res_attrs)
 
                 module.operation.attributes["sym_name"] = ir.StringAttr.get(
-                    utils.UniqueNameGen.gen_uid([inp.name for inp in self.inputs], [out.name for out in self.outputs])
+                    utils.utils.UniqueNameGen.gen_uid(
+                        [inp.name for inp in self.inputs], [out.name for out in self.outputs]
+                    )
                 )
 
                 return module
@@ -340,7 +342,7 @@ class FlatIR:
         """
         Registers a tensor with this FlatIR instance. If the tensor has no name, a name unique to this FlatIR will be assigned.
         """
-        tensor.name = utils.default(tensor.name, f"t_inter{len(self.tensor_map)}")
+        tensor.name = utils.utils.default(tensor.name, f"t_inter{len(self.tensor_map)}")
         if tensor.name in self.tensor_map:
             return self.tensor_map[tensor.name]
         self.tensor_map[tensor.name] = tensor

--- a/tripy/nvtripy/flat_ir/function.py
+++ b/tripy/nvtripy/flat_ir/function.py
@@ -85,7 +85,7 @@ class FlatIRFunction:
                 [tensor_signature(t) for t in op.outputs],
                 tuple(
                     getattr(op, field.name)
-                    for field in utils.get_dataclass_fields(op, BaseFlatIROp)
+                    for field in utils.utils.get_dataclass_fields(op, BaseFlatIROp)
                     if field.name not in ("inputs", "outputs")
                 ),
             )

--- a/tripy/nvtripy/flat_ir/ops/base.py
+++ b/tripy/nvtripy/flat_ir/ops/base.py
@@ -85,7 +85,7 @@ class BaseFlatIROp(abc.ABC):
         skip_fields = self.str_skip_fields()
         args = [
             f"{field.name}={repr(getattr(self, field.name))}"
-            for field in utils.get_dataclass_fields(self, BaseFlatIROp)
+            for field in utils.utils.get_dataclass_fields(self, BaseFlatIROp)
             if field.name not in skip_fields
         ]
         return f"{outputs_str} = {self._op_name()}({', '.join([str(inp.name) for inp in self.inputs] + args)})"

--- a/tripy/nvtripy/flat_ir/ops/constant.py
+++ b/tripy/nvtripy/flat_ir/ops/constant.py
@@ -34,7 +34,7 @@ class ConstantOp(BaseFlatIROp):
     data: Union[runtime.MemRefValue, Sequence]
 
     def str_skip_fields(self) -> Set[str]:
-        if not isinstance(self.data, Sequence) or utils.should_omit_constant_in_str(self.outputs[0].shape):
+        if not isinstance(self.data, Sequence) or utils.utils.should_omit_constant_in_str(self.outputs[0].shape):
             return {"data"}
         return set()
 

--- a/tripy/nvtripy/flat_ir/ops/plugin.py
+++ b/tripy/nvtripy/flat_ir/ops/plugin.py
@@ -23,13 +23,12 @@ from typing import Any, Dict, Sequence
 import mlir_tensorrt.compiler.api as compiler
 from mlir_tensorrt.compiler import ir
 from mlir_tensorrt.compiler.dialects import tensorrt
-
 from nvtripy import utils
 from nvtripy.flat_ir.ops.base import BaseFlatIROp
-from nvtripy.utils import Result
+from nvtripy.utils.result import Result
 
 
-@utils.call_once
+@utils.utils.call_once
 def initialize_plugin_registry():
     import tensorrt as trt
 
@@ -41,7 +40,7 @@ def initialize_plugin_registry():
 
 
 def plugin_field_to_attr(field_info: "compiler.PluginFieldInfo", values: Any) -> Result[Any]:
-    values = utils.make_list(values)
+    values = utils.utils.make_list(values)
 
     if field_info.type == compiler.PluginFieldType.CHAR:
         if len(values) != 1:
@@ -121,7 +120,7 @@ class PluginOp(BaseFlatIROp):
         params = {}
         for name, values in self.creator_params.items():
             if name not in field_schema:
-                utils.raise_error_io_info(
+                utils.ops.raise_error_io_info(
                     self,
                     f"{plugin_err_prefix} has no field called: {name}",
                     [f"Note: Valid fields are: {list(sorted(field_schema.keys()))}"],
@@ -130,7 +129,7 @@ class PluginOp(BaseFlatIROp):
 
             result = plugin_field_to_attr(field_schema[name], values)
             if not result:
-                utils.raise_error_io_info(
+                utils.ops.raise_error_io_info(
                     self,
                     f"{plugin_err_prefix}: Invalid value provided for field: {name}",
                     result.error_details + [f" Note: Provided field value was: {repr(values)}"],

--- a/tripy/nvtripy/flat_ir/tensor.py
+++ b/tripy/nvtripy/flat_ir/tensor.py
@@ -20,7 +20,7 @@ import copy
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
-from nvtripy import utils
+from nvtripy.utils import stack_info
 
 _BUILD_CONTEXT: List[List[Any]] = []
 
@@ -32,7 +32,7 @@ class FlatIRTensor:
     """
 
     name: str
-    stack_info: utils.StackInfo
+    stack_info: stack_info.StackInfo
     dtype: "nvtripy.common.dtype"
     device: "nvtripy.common.device"
     rank: int
@@ -47,8 +47,8 @@ class FlatIRTensor:
     """
     reason_context: Optional[List[List[Any]]] = None
 
-    @contextlib.contextmanager
     @staticmethod
+    @contextlib.contextmanager
     def context(ctx: List[Any]):
         try:
             global _BUILD_CONTEXT
@@ -74,7 +74,7 @@ class FlatIRTensor:
             name=None,
             # Include code from the caller of this function up, and not just user code
             # since this is an intermediate tensor created within nvtripy.
-            stack_info=utils.get_stack_info(include_code_index=1),
+            stack_info=stack_info.get_stack_info(include_code_index=1),
             dtype=dtype,
             device=device,
             rank=rank,
@@ -92,7 +92,7 @@ class FlatIRTensor:
             name=name,
             # Include code from the caller of this function up, and not just user code
             # since this is an intermediate tensor created within nvtripy.
-            stack_info=utils.get_stack_info(include_code_index=1),
+            stack_info=stack_info.get_stack_info(include_code_index=1),
             dtype=self.dtype,
             device=self.device,
             rank=self.rank,

--- a/tripy/nvtripy/frontend/cache.py
+++ b/tripy/nvtripy/frontend/cache.py
@@ -119,7 +119,7 @@ class ExecutableCache:
         """
         normalized_trace = self._normalize_trace(trace)
         key = normalized_trace + "\ndevices:\n" + "\n".join([str(device) for device in devices])
-        return utils.md5(key.encode("utf-8"))
+        return utils.utils.md5(key.encode("utf-8"))
 
     def get(self, trace: "Trace", devices: List["tripy.common.device"]) -> Optional[runtime.Executable]:
         """

--- a/tripy/nvtripy/frontend/module/batchnorm.py
+++ b/tripy/nvtripy/frontend/module/batchnorm.py
@@ -26,7 +26,7 @@ from nvtripy.frontend.tensor import Tensor
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["num_features"])
+@utils.utils.constant_fields(["num_features"])
 class BatchNorm(Module):
     r"""
     Applies batch normalization over an N-dimensional input tensor using precomputed statistics:

--- a/tripy/nvtripy/frontend/module/conv.py
+++ b/tripy/nvtripy/frontend/module/conv.py
@@ -29,7 +29,7 @@ from nvtripy.frontend.trace.ops import utils as op_utils
 
 
 @dataclass
-@utils.constant_fields(["dtype", "padding", "stride", "groups", "dilation"])
+@utils.utils.constant_fields(["dtype", "padding", "stride", "groups", "dilation"])
 class ConvBase(Module):
     r"""Base class for sharing common functionality between Conv and ConvTranspose."""
 
@@ -55,7 +55,7 @@ class ConvBase(Module):
 
         super().__init__()
 
-        self.groups = utils.default(groups, 1)
+        self.groups = utils.utils.default(groups, 1)
 
         if self.groups <= 0:
             raise_error(
@@ -73,9 +73,9 @@ class ConvBase(Module):
 
         op_utils.check_conv_pooling_args(kernel_dims, stride, padding, dilation)
         rank = len(kernel_dims) + 2
-        self.padding = utils.default(padding, tuple(((0, 0) for _ in range(rank - 2))))
-        self.stride = utils.default(stride, (1,) * (rank - 2))
-        self.dilation = utils.default(dilation, (1,) * (rank - 2))
+        self.padding = utils.utils.default(padding, tuple(((0, 0) for _ in range(rank - 2))))
+        self.stride = utils.utils.default(stride, (1,) * (rank - 2))
+        self.dilation = utils.utils.default(dilation, (1,) * (rank - 2))
 
         self.bias = None
         if bias:

--- a/tripy/nvtripy/frontend/module/embedding.py
+++ b/tripy/nvtripy/frontend/module/embedding.py
@@ -26,7 +26,7 @@ from nvtripy.frontend.tensor import Tensor
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["dtype"])
+@utils.utils.constant_fields(["dtype"])
 class Embedding(Module):
     """
     A lookup table for embedding vectors of a fixed size.

--- a/tripy/nvtripy/frontend/module/groupnorm.py
+++ b/tripy/nvtripy/frontend/module/groupnorm.py
@@ -27,7 +27,7 @@ from nvtripy.frontend.tensor import Tensor
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["num_groups", "num_channels", "dtype"])
+@utils.utils.constant_fields(["num_groups", "num_channels", "dtype"])
 class GroupNorm(Module):
     r"""
     Applies group normalization over the input tensor:

--- a/tripy/nvtripy/frontend/module/layernorm.py
+++ b/tripy/nvtripy/frontend/module/layernorm.py
@@ -27,7 +27,7 @@ from nvtripy.frontend.tensor import Tensor
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["dtype", "normalized_shape"])
+@utils.utils.constant_fields(["dtype", "normalized_shape"])
 class LayerNorm(Module):
     r"""
     Applies layer normalization over the input tensor:

--- a/tripy/nvtripy/frontend/module/linear.py
+++ b/tripy/nvtripy/frontend/module/linear.py
@@ -27,7 +27,7 @@ from nvtripy.frontend.tensor import Tensor
 
 @export.public_api(document_under="operations/modules")
 @dataclass
-@utils.constant_fields(["dtype", "quant_dtype"])
+@utils.utils.constant_fields(["dtype", "quant_dtype"])
 class Linear(Module):
     r"""
     Applies a linear transformation to the input:

--- a/tripy/nvtripy/frontend/module/module.py
+++ b/tripy/nvtripy/frontend/module/module.py
@@ -23,7 +23,7 @@ from nvtripy import export, utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.module.parameter import DefaultParameter
 from nvtripy.frontend.tensor import Tensor
-from nvtripy.function_registry import type_str_from_arg
+from nvtripy.utils.function_registry import type_str_from_arg
 from nvtripy.logging import logger
 
 
@@ -40,21 +40,21 @@ def _check_param_compatible(original_param, new_param, param_name):
         # Note that this is required for the constructor to work since `original_param` will not be set.
         return
 
-    is_compatible = utils.Result.ok()
+    is_compatible = utils.result.Result.ok()
 
     skip_shape_comparison = isinstance(original_param, DefaultParameter) and not original_param.is_shape_known
     if not skip_shape_comparison:
         original_shape = original_param.shape
         new_shape = new_param.shape
         if original_shape != new_shape:
-            is_compatible = utils.Result.err(
+            is_compatible = utils.result.Result.err(
                 ["New parameter shape: ", new_shape, " is not compatible with current shape: ", original_shape]
             )
 
     original_dtype = original_param.dtype
     new_dtype = new_param.dtype
     if original_dtype != new_dtype:
-        is_compatible = utils.Result.err(
+        is_compatible = utils.result.Result.err(
             ["New parameter dtype: ", new_dtype, " is not compatible with current dtype: ", original_dtype]
         )
 

--- a/tripy/nvtripy/frontend/ops/allclose.py
+++ b/tripy/nvtripy/frontend/ops/allclose.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/cumsum.py
+++ b/tripy/nvtripy/frontend/ops/cumsum.py
@@ -12,9 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nvtripy import export, wrappers
+from nvtripy import export
 
 from nvtripy.frontend import utils as frontend_utils
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/equal.py
+++ b/tripy/nvtripy/frontend/ops/equal.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.datatype import DATA_TYPES
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/flatten.py
+++ b/tripy/nvtripy/frontend/ops/flatten.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 import math
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/gelu.py
+++ b/tripy/nvtripy/frontend/ops/gelu.py
@@ -17,7 +17,8 @@
 
 import math
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/outer.py
+++ b/tripy/nvtripy/frontend/ops/outer.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/relu.py
+++ b/tripy/nvtripy/frontend/ops/relu.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/repeat.py
+++ b/tripy/nvtripy/frontend/ops/repeat.py
@@ -15,10 +15,11 @@
 #
 from typing import Union
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend import utils as frontend_utils
 from nvtripy.types import IntLike
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/sigmoid.py
+++ b/tripy/nvtripy/frontend/ops/sigmoid.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/silu.py
+++ b/tripy/nvtripy/frontend/ops/silu.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/softmax.py
+++ b/tripy/nvtripy/frontend/ops/softmax.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/stack.py
+++ b/tripy/nvtripy/frontend/ops/stack.py
@@ -15,8 +15,9 @@
 
 from typing import Sequence
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/tensor_initializers.py
+++ b/tripy/nvtripy/frontend/ops/tensor_initializers.py
@@ -18,12 +18,13 @@
 import numbers
 from typing import Optional, Union
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common import datatype
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops.fill import full, full_like
 from nvtripy.frontend.trace.ops.iota import iota, iota_like
 from nvtripy.frontend.trace.ops.where import where
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/initializers")

--- a/tripy/nvtripy/frontend/ops/transpose.py
+++ b/tripy/nvtripy/frontend/ops/transpose.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/ops/unsqueeze.py
+++ b/tripy/nvtripy/frontend/ops/unsqueeze.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from nvtripy import export, wrappers
+from nvtripy import export
+from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")

--- a/tripy/nvtripy/frontend/tensor.py
+++ b/tripy/nvtripy/frontend/tensor.py
@@ -134,7 +134,7 @@ class Tensor(metaclass=TensorMeta):
     ):
         stack_info = StackInfo([])
         if fetch_stack_info:
-            stack_info = utils.get_stack_info(include_code_index=STACK_DEPTH_OF_BUILD)
+            stack_info = utils.stack_info.get_stack_info(include_code_index=STACK_DEPTH_OF_BUILD)
 
         name = name if name is not None else Tensor._get_unique_name()
 
@@ -150,7 +150,7 @@ class Tensor(metaclass=TensorMeta):
         )
 
         # TODO(#155): Remove this hack:
-        instance.trace_tensor.device = utils.default(device, instance.trace_tensor.device)
+        instance.trace_tensor.device = utils.utils.default(device, instance.trace_tensor.device)
 
         # Explicit cast if necessary
         # TODO(#155): Add copy as well when host allocation is fixed
@@ -238,7 +238,7 @@ class Tensor(metaclass=TensorMeta):
         # TODO(#155): Remove this hack of overriding the device type.
         self.trace_tensor.device = output_devices[0]
 
-        self.trace_tensor.eval_stack_info = utils.get_stack_info()
+        self.trace_tensor.eval_stack_info = utils.stack_info.get_stack_info()
         if self.trace_tensor.is_compile_tracer:
             logger.warning(
                 f"Tensor was evaluated while compiling which may cause unexpected behavior in the executable.\n"

--- a/tripy/nvtripy/frontend/trace/ops/base.py
+++ b/tripy/nvtripy/frontend/trace/ops/base.py
@@ -161,7 +161,7 @@ class BaseTraceOp(abc.ABC):
         skip_fields = self.str_skip_fields()
         args = [
             f"{field.name}={getattr(self, field.name)}"
-            for field in utils.get_dataclass_fields(self, BaseTraceOp)
+            for field in utils.utils.get_dataclass_fields(self, BaseTraceOp)
             if field.name not in skip_fields
         ]
         return f"{self.outputs[0].name} = {self.__class__.__name__.lower()}({', '.join([inp.name for inp in self.inputs] + args)})"

--- a/tripy/nvtripy/frontend/trace/ops/binary_elementwise.py
+++ b/tripy/nvtripy/frontend/trace/ops/binary_elementwise.py
@@ -18,11 +18,12 @@
 from dataclasses import dataclass
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common import datatype
 from nvtripy.frontend.ops.registry import register_tensor_method
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import TensorLike
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/cast.py
+++ b/tripy/nvtripy/frontend/trace/ops/cast.py
@@ -17,9 +17,10 @@
 
 from dataclasses import dataclass
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/concatenate.py
+++ b/tripy/nvtripy/frontend/trace/ops/concatenate.py
@@ -18,10 +18,11 @@
 from dataclasses import dataclass
 from typing import Sequence
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/convolution.py
+++ b/tripy/nvtripy/frontend/trace/ops/convolution.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import wrappers
+from nvtripy.utils import wrappers
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 
 

--- a/tripy/nvtripy/frontend/trace/ops/copy.py
+++ b/tripy/nvtripy/frontend/trace/ops/copy.py
@@ -18,9 +18,10 @@
 from dataclasses import dataclass
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.device import device
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/dequantize.py
+++ b/tripy/nvtripy/frontend/trace/ops/dequantize.py
@@ -20,11 +20,12 @@ from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common import datatype
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/expand.py
+++ b/tripy/nvtripy/frontend/trace/ops/expand.py
@@ -17,11 +17,12 @@
 
 from dataclasses import dataclass
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/fill.py
+++ b/tripy/nvtripy/frontend/trace/ops/fill.py
@@ -20,11 +20,12 @@ from typing import Optional
 
 import nvtripy.frontend.trace.ops.utils as op_utils
 import nvtripy.frontend.utils as frontend_utils
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.common import datatype
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike, TensorLike
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -129,5 +130,5 @@ def full_like(input: "nvtripy.Tensor", value: TensorLike, dtype: Optional["nvtri
         assert np.array_equal(cp.from_dlpack(output).get(), np.array([[2, 2], [2, 2]], dtype=np.float32))
     """
     return Fill.build(
-        [frontend_utils.tensor_from_shape_like(input.shape), value], dtype=utils.default(dtype, input.dtype)
+        [frontend_utils.tensor_from_shape_like(input.shape), value], dtype=utils.utils.default(dtype, input.dtype)
     )

--- a/tripy/nvtripy/frontend/trace/ops/flip.py
+++ b/tripy/nvtripy/frontend/trace/ops/flip.py
@@ -18,10 +18,11 @@
 from dataclasses import dataclass
 from typing import Optional, Sequence, Union
 
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.frontend.trace.ops import utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -80,7 +81,7 @@ def flip(input: "nvtripy.Tensor", dims: Optional[Union[int, Sequence[int]]] = No
         dims = [d for d in range(rank)]
     else:
         encountered = set()
-        dims = utils.make_list(dims)
+        dims = utils.utils.make_list(dims)
 
         if rank == 0 and len(dims) != 0:
             raise_error("It is not possible to flip a rank-0 tensor.")

--- a/tripy/nvtripy/frontend/trace/ops/gather.py
+++ b/tripy/nvtripy/frontend/trace/ops/gather.py
@@ -18,8 +18,9 @@
 from dataclasses import dataclass
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -33,7 +34,7 @@ class Gather(BaseTraceOp):
         from nvtripy import int32
 
         if self.inputs[1].dtype != int32:
-            utils.raise_error_io_info(
+            utils.ops.raise_error_io_info(
                 self,
                 "Index tensor for gather operation should be of int32 type.",
                 details=[

--- a/tripy/nvtripy/frontend/trace/ops/iota.py
+++ b/tripy/nvtripy/frontend/trace/ops/iota.py
@@ -19,11 +19,12 @@ from dataclasses import dataclass
 from typing import Optional
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.common import datatype
 from nvtripy.frontend import utils as frontend_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -129,6 +130,6 @@ def iota_like(input: "nvtripy.Tensor", dim: int = 0, dtype: Optional[datatype.dt
     return iota_impl(
         frontend_utils.tensor_from_shape_like(input.shape),
         dim,
-        utils.default(dtype, input.dtype),
+        utils.utils.default(dtype, input.dtype),
         output_rank=input.rank,
     )

--- a/tripy/nvtripy/frontend/trace/ops/matmul.py
+++ b/tripy/nvtripy/frontend/trace/ops/matmul.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import wrappers
+from nvtripy.utils import wrappers
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.ops.registry import register_tensor_method
 from nvtripy.frontend.trace.ops.base import BaseTraceOp

--- a/tripy/nvtripy/frontend/trace/ops/pad.py
+++ b/tripy/nvtripy/frontend/trace/ops/pad.py
@@ -18,12 +18,13 @@
 from dataclasses import dataclass
 from typing import Sequence, Union
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend import utils as frontend_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/permute.py
+++ b/tripy/nvtripy/frontend/trace/ops/permute.py
@@ -18,10 +18,11 @@
 from dataclasses import dataclass
 from typing import Sequence
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/pooling.py
+++ b/tripy/nvtripy/frontend/trace/ops/pooling.py
@@ -19,11 +19,12 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -190,8 +191,8 @@ def maxpool(
         raise_error("Unsupported kernel_dims, must be 2D or 3D.", [f"Got kernel_dims={kernel_dims}"])
 
     op_utils.check_conv_pooling_args(kernel_dims, stride, padding)
-    stride = utils.default(stride, [1] * spatial_dims)
-    padding = utils.default(padding, [(0, 0)] * spatial_dims)
+    stride = utils.utils.default(stride, [1] * spatial_dims)
+    padding = utils.utils.default(padding, [(0, 0)] * spatial_dims)
 
     return Pooling.build([input], Pooling.Kind.MAX, kernel_dims, stride, padding)
 
@@ -249,7 +250,7 @@ def avgpool(
         raise_error("Unsupported kernel_dims, must be 2D or 3D.", [f"Got kernel_dims={kernel_dims}"])
 
     op_utils.check_conv_pooling_args(kernel_dims, stride, padding)
-    stride = utils.default(stride, [1] * spatial_dims)
-    padding = utils.default(padding, [(0, 0)] * spatial_dims)
+    stride = utils.utils.default(stride, [1] * spatial_dims)
+    padding = utils.utils.default(padding, [(0, 0)] * spatial_dims)
 
     return Pooling.build([input], Pooling.Kind.AVG, kernel_dims, stride, padding)

--- a/tripy/nvtripy/frontend/trace/ops/quantize.py
+++ b/tripy/nvtripy/frontend/trace/ops/quantize.py
@@ -19,12 +19,13 @@ import numbers
 from dataclasses import dataclass
 from typing import Any, Sequence, Union
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common import datatype
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 
 from nvtripy.frontend.trace.ops import utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/reduce.py
+++ b/tripy/nvtripy/frontend/trace/ops/reduce.py
@@ -20,10 +20,11 @@ import math
 from dataclasses import dataclass
 from typing import Optional, Sequence, Union
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common import datatype
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
-from nvtripy.utils import make_list
+from nvtripy.utils.utils import make_list
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/reshape.py
+++ b/tripy/nvtripy/frontend/trace/ops/reshape.py
@@ -18,11 +18,12 @@
 import math
 from dataclasses import dataclass
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/resize.py
+++ b/tripy/nvtripy/frontend/trace/ops/resize.py
@@ -19,12 +19,13 @@ import numbers
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend import utils as frontend_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import ShapeLike
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/shape.py
+++ b/tripy/nvtripy/frontend/trace/ops/shape.py
@@ -17,7 +17,7 @@
 
 from dataclasses import dataclass
 
-from nvtripy import wrappers
+from nvtripy.utils import wrappers
 from nvtripy.common.datatype import DATA_TYPES
 from nvtripy.frontend.ops.registry import register_tensor_method
 from nvtripy.frontend.trace.ops.base import BaseTraceOp

--- a/tripy/nvtripy/frontend/trace/ops/slice.py
+++ b/tripy/nvtripy/frontend/trace/ops/slice.py
@@ -18,13 +18,14 @@
 from dataclasses import dataclass
 from typing import Sequence, Union
 
-from nvtripy import utils, wrappers
+from nvtripy import utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.ops.registry import register_tensor_method
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 from nvtripy.types import TensorLike
-from nvtripy.utils import make_tuple
+from nvtripy.utils.utils import make_tuple
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -227,9 +228,9 @@ def __getitem__(
                 args.append(clamp_bound(adjusted_start))
                 args.append(clamp_bound(adjusted_stop))
             else:
-                args.append(clamp_bound(convert_to_positive_idx(utils.default(idx.start, 0))))
-                args.append(clamp_bound(convert_to_positive_idx(utils.default(idx.stop, t_shape[i]))))
-            args.append(abs(utils.default(idx.step, 1)))
+                args.append(clamp_bound(convert_to_positive_idx(utils.utils.default(idx.start, 0))))
+                args.append(clamp_bound(convert_to_positive_idx(utils.utils.default(idx.stop, t_shape[i]))))
+            args.append(abs(utils.utils.default(idx.step, 1)))
         else:
             raise_error(
                 "Slice index type is not supported.",
@@ -259,12 +260,11 @@ def __getitem__(
 
 @wrappers.interface(convert_to_tensors=True)
 def slice_helper(tensor, *slice_params: TensorLike):
-    from nvtripy import function_registry
-    from nvtripy.utils import get_arg_candidate_column_offsets
+    from nvtripy.utils import function_registry
+    from nvtripy.utils.ast import get_arg_candidate_column_offsets
 
     # The default behavior of the tensor conversion will not add the correct column info to the slice params
     # because this call occurs *inside* the overridden call to __getitem__, so we adjust the column info manually.
-
     # Look for the stack frame index to __getitem__. We need to go one stack frame beyond to get to the *user* call of __getitem__.
     def find_frame_index(arg):
         # Internal WAR: the constraints decorator is applied before the function registry decorator, so in the constraints tests,

--- a/tripy/nvtripy/frontend/trace/ops/split.py
+++ b/tripy/nvtripy/frontend/trace/ops/split.py
@@ -18,10 +18,11 @@
 from dataclasses import dataclass
 from typing import Sequence, Union
 
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -165,7 +166,7 @@ class Split(BaseTraceOp):
         skip_fields = self.str_skip_fields()
         args = [
             f"{field.name}={getattr(self, field.name)}"
-            for field in utils.get_dataclass_fields(self, BaseTraceOp)
+            for field in utils.utils.get_dataclass_fields(self, BaseTraceOp)
             if field.name not in skip_fields
         ]
 

--- a/tripy/nvtripy/frontend/trace/ops/squeeze.py
+++ b/tripy/nvtripy/frontend/trace/ops/squeeze.py
@@ -15,9 +15,10 @@
 from dataclasses import dataclass
 from typing import Sequence, Tuple, Union
 
-from nvtripy import export, utils, wrappers
+from nvtripy import export, utils
 from nvtripy.frontend.trace.ops import utils as op_utils
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)
@@ -95,4 +96,4 @@ def squeeze(input: "nvtripy.Tensor", dims: Union[Sequence[int], int]) -> "nvtrip
 
         assert np.array_equal(cp.from_dlpack(output).get(), np.squeeze(cp.from_dlpack(input).get(), (0, 2)))
     """
-    return Squeeze.build([input], utils.make_tuple(dims))
+    return Squeeze.build([input], utils.utils.make_tuple(dims))

--- a/tripy/nvtripy/frontend/trace/ops/storage.py
+++ b/tripy/nvtripy/frontend/trace/ops/storage.py
@@ -66,17 +66,17 @@ class Storage(BaseTraceOp):
                 data_array = None
             else:
                 self.dtype = common_utils.get_element_type(data)
-                data_array = common_utils.convert_list_to_array(utils.flatten_list(data), dtype=self.dtype)
-            self.shape = tuple(utils.get_shape(data))
+                data_array = common_utils.convert_list_to_array(utils.utils.flatten_list(data), dtype=self.dtype)
+            self.shape = tuple(utils.utils.get_shape(data))
             self.data = memref.create_memref(
                 shape=self.shape,
                 dtype=self.dtype,
                 array=data_array,
             )
-            self.device = utils.default(device, tp_device.create_directly("gpu", 0))
+            self.device = utils.utils.default(device, tp_device.create_directly("gpu", 0))
 
         # Set data_str only for objects that won't be treated as Trace inputs
-        if not utils.should_lift_storage_op_as_input(self.shape):
+        if not utils.utils.should_lift_storage_op_as_input(self.shape):
             self.data_str = str(original_data)  # TODO (#448): Fix floating point str representation
 
         self.outputs[0].shape = list(self.shape)

--- a/tripy/nvtripy/frontend/trace/ops/unary_elementwise.py
+++ b/tripy/nvtripy/frontend/trace/ops/unary_elementwise.py
@@ -18,9 +18,10 @@
 import enum
 from dataclasses import dataclass
 
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
 import nvtripy.frontend.trace.ops.utils as op_utils
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/ops/utils.py
+++ b/tripy/nvtripy/frontend/trace/ops/utils.py
@@ -34,7 +34,6 @@ from nvtripy.flat_ir.ops import (
     SelectOp,
 )
 from nvtripy.flat_ir.tensor import FlatIRTensor
-from nvtripy.utils import Result
 
 
 def is_minus_one(arg):
@@ -172,8 +171,8 @@ def compute_shape_of_broadcast(
 ):
     from nvtripy.frontend.trace.ops.binary_elementwise import Comparison
 
-    shape1_name = utils.default(shape1_name, "a tensor")
-    shape2_name = utils.default(shape2_name, "another tensor")
+    shape1_name = utils.utils.default(shape1_name, "a tensor")
+    shape2_name = utils.utils.default(shape2_name, "another tensor")
 
     # can't just use the max of shape1 and shape2 because it will be incorrect if a dim is 0
     # (the broadcast of 0 and 1 is 0)

--- a/tripy/nvtripy/frontend/trace/ops/where.py
+++ b/tripy/nvtripy/frontend/trace/ops/where.py
@@ -19,8 +19,9 @@ import numbers
 from dataclasses import dataclass
 
 import nvtripy.frontend.trace.ops.utils as op_utils
-from nvtripy import export, wrappers
+from nvtripy import export
 from nvtripy.frontend.trace.ops.base import BaseTraceOp
+from nvtripy.utils import wrappers
 
 
 @dataclass(repr=False)

--- a/tripy/nvtripy/frontend/trace/tensor.py
+++ b/tripy/nvtripy/frontend/trace/tensor.py
@@ -28,7 +28,7 @@ class TraceTensor:
     """
 
     name: str
-    stack_info: utils.StackInfo
+    stack_info: utils.stack_info.StackInfo
     dtype: "nvtripy.common.dtype"
     device: "nvtripy.common.device"
     producer: "BaseTraceOp"
@@ -42,7 +42,7 @@ class TraceTensor:
     is_compile_tracer: bool = False
     # Stack information for the point at which this tensor was evaluated if it was.
     # This is useful in the compiler to disallow evaluation during tracing.
-    eval_stack_info: Optional[utils.StackInfo] = None
+    eval_stack_info: Optional[utils.stack_info.StackInfo] = None
 
     def __str__(self) -> str:
         return (

--- a/tripy/nvtripy/frontend/trace/trace.py
+++ b/tripy/nvtripy/frontend/trace/trace.py
@@ -118,7 +118,7 @@ class Trace:
             visited.add(id(trace_tensor))
 
             producer = trace_tensor.producer
-            if isinstance(producer, Storage) and utils.should_lift_storage_op_as_input(producer.shape):
+            if isinstance(producer, Storage) and utils.utils.should_lift_storage_op_as_input(producer.shape):
                 inputs.append(trace_tensor)
             else:
                 for inp in producer.inputs:

--- a/tripy/nvtripy/utils/__init__.py
+++ b/tripy/nvtripy/utils/__init__.py
@@ -14,9 +14,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from nvtripy.utils.stack_info import StackInfo, get_stack_info, get_module_names_to_exclude_from_stack_info
-from nvtripy.utils.utils import *
-from nvtripy.utils.ast import *
-from nvtripy.utils.result import Result
-from nvtripy.utils.ops import raise_error_io_info

--- a/tripy/nvtripy/utils/function_registry.py
+++ b/tripy/nvtripy/utils/function_registry.py
@@ -18,82 +18,13 @@
 import functools
 import inspect
 from collections import OrderedDict, defaultdict
-from collections.abc import Sequence as ABCSequence, Callable as ABCCallable
+from collections.abc import Callable as ABCCallable
+from collections.abc import Sequence as ABCSequence
 from dataclasses import dataclass
 from textwrap import dedent, indent
 from typing import Any, Callable, Dict, ForwardRef, List, Optional, Sequence, Union, get_args, get_origin
 
-
-def get_type_name(typ):
-    # Attach module name if possible
-    module_name = ""
-    try:
-        module_name = typ.__module__ + "."
-    except AttributeError:
-        pass
-    else:
-        # Modify prefix for built-in types or Tripy types.
-        # If we include modules for Tripy, they will include all submodules, which can be confusing
-        # e.g. Tensor will be something like "nvtripy.frontend.tensor.Tensor"
-        if module_name.startswith("nvtripy"):
-            module_name = "nvtripy."
-        if module_name.startswith("builtins"):
-            module_name = ""
-
-    return module_name + typ.__qualname__
-
-
-def str_from_type_annotation(annotation, postprocess_annotation=None):
-    postprocess_annotation = postprocess_annotation or (lambda x: x)
-
-    if annotation is type(None):
-        return postprocess_annotation("None")
-
-    if isinstance(annotation, str):
-        return postprocess_annotation(annotation)
-
-    if get_origin(annotation) is Union:
-        types = list(get_args(annotation))
-        return " | ".join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)
-
-    if get_origin(annotation) in {ABCSequence, list, tuple}:
-        types = get_args(annotation)
-        return f"{annotation.__name__}[{', '.join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)}]"
-
-    if get_origin(annotation) is ABCCallable:
-        params, ret = get_args(annotation)
-        return f"{annotation.__name__}[[{', '.join(map(str_from_type_annotation, params))}], {str_from_type_annotation(ret)}]"
-
-    if get_origin(annotation) is dict:
-        key_annotations, value_annotations = get_args(annotation)
-        return f"Dict[{str_from_type_annotation( key_annotations)}, {str_from_type_annotation( value_annotations)}]"
-
-    if isinstance(annotation, ForwardRef):
-        return postprocess_annotation(str(annotation.__forward_arg__))
-
-    # typing module annotations are likely to be better when pretty-printed due to including subscripts
-    return postprocess_annotation(str(annotation) if annotation.__module__ == "typing" else get_type_name(annotation))
-
-
-def type_str_from_arg(arg: Any) -> str:
-    # it is more useful to report more detailed types for sequences/tuples in error messages
-    from typing import List, Tuple
-
-    if isinstance(arg, List):
-        if len(arg) == 0:
-            return "List"
-        arg_types = sorted({type_str_from_arg(member) for member in arg})
-        return f"List[{' | '.join(arg_types)}]"
-    elif isinstance(arg, Tuple):
-        return f"Tuple[{', '.join(map(type_str_from_arg, arg))}]"
-    elif isinstance(arg, Dict):
-        if len(arg) == 0:
-            return "Dict"
-        key_types = sorted({type_str_from_arg(key) for key in arg.keys()})
-        value_types = sorted({type_str_from_arg(value) for value in arg.values()})
-        return f"Dict[{' | '.join(key_types)}, {' | '.join(value_types)}]"
-
-    return get_type_name(type(arg))
+from nvtripy.utils.types import str_from_type_annotation, type_str_from_arg
 
 
 @dataclass

--- a/tripy/nvtripy/utils/json/utils.py
+++ b/tripy/nvtripy/utils/json/utils.py
@@ -39,7 +39,7 @@ def save(obj: Any, dest: Union[str, typing.IO]):
         obj: The object to save
         dest: A path or file-like object
     """
-    utils.save_file(to_json(obj), dest, mode="w")
+    utils.utils.save_file(to_json(obj), dest, mode="w")
 
 
 def load(src: Union[str, typing.IO]) -> Any:
@@ -52,4 +52,4 @@ def load(src: Union[str, typing.IO]) -> Any:
     Returns:
         The loaded object
     """
-    return from_json(utils.load_file(src, mode="r"))
+    return from_json(utils.utils.load_file(src, mode="r"))

--- a/tripy/nvtripy/utils/result.py
+++ b/tripy/nvtripy/utils/result.py
@@ -17,6 +17,7 @@
 
 from dataclasses import dataclass
 from typing import Any, Optional, List
+from nvtripy.utils.types import str_from_type_annotation
 
 
 @dataclass
@@ -50,7 +51,7 @@ class Result:
         return super().__getattribute__(name)
 
     def __class_getitem__(cls, item):
-        return f"{cls.__name__}[{item if isinstance(item, str) else item.__name__}]"
+        return f"{cls.__name__}[{str_from_type_annotation(item)}]"
 
     def __str__(self):
         return repr(self)

--- a/tripy/nvtripy/utils/stack_info.py
+++ b/tripy/nvtripy/utils/stack_info.py
@@ -19,7 +19,7 @@
 # working directly with the frame.
 import sys
 from dataclasses import dataclass
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 
 @dataclass
@@ -94,7 +94,7 @@ class StackInfo(list):
 
 
 def get_stack_info(include_code_index: int = None) -> StackInfo:
-    import nvtripy.function_registry
+    import nvtripy.utils.function_registry
 
     stack_info = StackInfo([], include_code_index)
 
@@ -115,7 +115,7 @@ def get_stack_info(include_code_index: int = None) -> StackInfo:
             _dispatch_target="",
             column_range=None,
         )
-        if source_info.module == nvtripy.function_registry.__name__ and source_info.function == "wrapper":
+        if source_info.module == nvtripy.utils.function_registry.__name__ and source_info.function == "wrapper":
             source_info._dispatch_target = frame.f_locals["key"]
 
         try:
@@ -141,7 +141,7 @@ def get_module_names_to_exclude_from_stack_info():
     Returns a set of module names to exclude from stack information when displaying exceptions
     or trying to retrieve column information from code.
     """
-    import nvtripy.function_registry
-    import nvtripy.wrappers
+    import nvtripy.utils.function_registry as function_registry
+    import nvtripy.utils.wrappers as wrappers
 
-    return {mod.__name__ for mod in [nvtripy.function_registry, nvtripy.wrappers]}
+    return {mod.__name__ for mod in [function_registry, wrappers]}

--- a/tripy/nvtripy/utils/types.py
+++ b/tripy/nvtripy/utils/types.py
@@ -1,0 +1,82 @@
+from collections.abc import Callable as ABCCallable
+from collections.abc import Sequence as ABCSequence
+from typing import Any, Dict, ForwardRef, Union, get_args, get_origin
+
+
+def _get_type_name(typ):
+    # Attach module name if possible
+    module_name = ""
+    try:
+        module_name = typ.__module__ + "."
+    except AttributeError:
+        pass
+    else:
+        # Modify prefix for built-in types or Tripy types.
+        # If we include modules for Tripy, they will include all submodules, which can be confusing
+        # e.g. Tensor will be something like "nvtripy.frontend.tensor.Tensor"
+        if module_name.startswith("nvtripy"):
+            module_name = "nvtripy."
+        if module_name.startswith("builtins"):
+            module_name = ""
+
+    return module_name + typ.__qualname__
+
+
+def str_from_type_annotation(annotation, postprocess_annotation=None):
+    def get_name(obj):
+        try:
+            # Python 3.9 does not have a __name__ attribute for annotations.
+            return obj.__name__
+        except AttributeError:
+            return obj._name
+
+    postprocess_annotation = postprocess_annotation or (lambda x: x)
+
+    if annotation is type(None):
+        return postprocess_annotation("None")
+
+    if isinstance(annotation, str):
+        return postprocess_annotation(annotation)
+
+    if get_origin(annotation) is Union:
+        types = list(get_args(annotation))
+        return " | ".join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)
+
+    if get_origin(annotation) in {ABCSequence, list, tuple}:
+        types = get_args(annotation)
+        return f"{get_name(annotation)}[{', '.join(str_from_type_annotation(typ, postprocess_annotation) for typ in types)}]"
+
+    if get_origin(annotation) is ABCCallable:
+        params, ret = get_args(annotation)
+        return f"{get_name(annotation)}[[{', '.join(map(str_from_type_annotation, params))}], {str_from_type_annotation(ret)}]"
+
+    if get_origin(annotation) is dict:
+        key_annotations, value_annotations = get_args(annotation)
+        return f"Dict[{str_from_type_annotation( key_annotations)}, {str_from_type_annotation( value_annotations)}]"
+
+    if isinstance(annotation, ForwardRef):
+        return postprocess_annotation(str(annotation.__forward_arg__))
+
+    # typing module annotations are likely to be better when pretty-printed due to including subscripts
+    return postprocess_annotation(str(annotation) if annotation.__module__ == "typing" else _get_type_name(annotation))
+
+
+def type_str_from_arg(arg: Any) -> str:
+    # it is more useful to report more detailed types for sequences/tuples in error messages
+    from typing import List, Tuple
+
+    if isinstance(arg, List):
+        if len(arg) == 0:
+            return "List"
+        arg_types = sorted({type_str_from_arg(member) for member in arg})
+        return f"List[{' | '.join(arg_types)}]"
+    elif isinstance(arg, Tuple):
+        return f"Tuple[{', '.join(map(type_str_from_arg, arg))}]"
+    elif isinstance(arg, Dict):
+        if len(arg) == 0:
+            return "Dict"
+        key_types = sorted({type_str_from_arg(key) for key in arg.keys()})
+        value_types = sorted({type_str_from_arg(value) for value in arg.values()})
+        return f"Dict[{' | '.join(key_types)}, {' | '.join(value_types)}]"
+
+    return _get_type_name(type(arg))

--- a/tripy/nvtripy/utils/utils.py
+++ b/tripy/nvtripy/utils/utils.py
@@ -17,7 +17,6 @@
 
 import dataclasses
 import functools
-import glob
 import hashlib
 import inspect
 import os

--- a/tripy/tests/common/test_exception.py
+++ b/tripy/tests/common/test_exception.py
@@ -19,12 +19,10 @@ import re
 from dataclasses import dataclass
 from textwrap import dedent
 
-from tests import helper
-
 import nvtripy as tp
-from nvtripy.common.exception import TripyException, _get_function_file_and_lines, str_from_stack_info, raise_error
-from nvtripy.utils import StackInfo, get_stack_info
-from nvtripy.utils.stack_info import SourceInfo
+from nvtripy.common.exception import TripyException, raise_error, str_from_stack_info
+from nvtripy.utils.stack_info import SourceInfo, StackInfo, get_stack_info
+from tests import helper
 
 
 @dataclass
@@ -125,7 +123,7 @@ class TestRaiseError:
         )
 
     def test_wrappers_is_excluded(self):
-        from nvtripy import wrappers
+        from nvtripy.utils import wrappers
 
         tensor = tp.ones((2, 3))
 

--- a/tripy/tests/helper.py
+++ b/tripy/tests/helper.py
@@ -150,7 +150,7 @@ def consolidate_code_blocks(doc):
 def exec_code(code, code_locals=None) -> Dict[str, Any]:
     # By default, don't inherit most variables from the current environment
     # so we can be sure the docstring examples work in total isolation.
-    code_locals = copy.copy(utils.default(code_locals, {}))
+    code_locals = copy.copy(utils.utils.default(code_locals, {}))
     exec(code, {"tp": tp, "np": np, "torch": torch, "cp": cp}, code_locals)
     return code_locals
 
@@ -383,7 +383,7 @@ def process_code_block_for_outputs_and_locals(
     strip_assertions: bool = False,
 ):
     # Make sure to update `docs/README.md` if updating the behavior of this function.
-    local_vars = utils.default(local_vars, {})
+    local_vars = utils.utils.default(local_vars, {})
 
     TRIPY_CLASSES = [tripy_obj for tripy_obj in discover_tripy_objects() if inspect.isclass(tripy_obj)]
     # Special tags are documented under docs/README.md.

--- a/tripy/tests/performance/test_perf.py
+++ b/tripy/tests/performance/test_perf.py
@@ -137,7 +137,7 @@ def test_tripy_overhead():
 
         return run_timed_trials(measure_thunk, warm_up_runs=warm_up_runs, iterations=iterations)
 
-    assert measure_overhead(1) < 60.0
+    assert measure_overhead(1) < 250.0
 
     # Check that the overhead increases at most linearly as we increase number of I/O tensors.
     overheads = [measure_overhead(i) for i in range(3, 10)]

--- a/tripy/tests/utils/test_function_registry.py
+++ b/tripy/tests/utils/test_function_registry.py
@@ -17,15 +17,12 @@
 
 import inspect
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 import pytest
-import torch
-from tests import helper
-
-import nvtripy as tp
 from nvtripy import TripyException
-from nvtripy.function_registry import AnnotationInfo, FunctionRegistry, str_from_type_annotation, type_str_from_arg
+from nvtripy.utils.function_registry import AnnotationInfo, FunctionRegistry
+from tests import helper
 
 
 @pytest.fixture()
@@ -578,40 +575,3 @@ class TestFunctionRegistry:
             match="Not a valid overload because: For parameter: 'args', expected an instance of type: 'int' but got argument of type: 'str'",
         ):
             registry["test"](1, 2, 3, 4, "hi")
-
-
-@pytest.mark.parametrize(
-    "typ, expected",
-    [
-        (tp.types.IntLike, "int | nvtripy.DimensionSize"),
-        (Tuple[tp.types.IntLike], "Tuple[int | nvtripy.DimensionSize]"),
-        (List[tp.types.IntLike], "List[int | nvtripy.DimensionSize]"),
-        (Dict[str, tp.Tensor], "Dict[str, nvtripy.Tensor]"),
-        (tp.types.TensorLike, "nvtripy.Tensor | numbers.Number"),
-        (tp.types.ShapeLike, "Sequence[int | nvtripy.DimensionSize]"),
-        (tp.Tensor, "nvtripy.Tensor"),
-        (torch.Tensor, "torch.Tensor"),
-        (int, "int"),
-        (Optional[int], "int | None"),
-        (Callable[[int], int], "Callable[[int], int]"),
-    ],
-)
-def test_str_from_type_annotation(typ, expected):
-    assert str_from_type_annotation(typ) == expected
-
-
-@pytest.mark.parametrize(
-    "typ, expected",
-    [
-        (tp.Tensor([1, 2, 3]), "nvtripy.Tensor"),
-        (torch.tensor([1, 2, 3]), "torch.Tensor"),
-        (0, "int"),
-        ("hi", "str"),
-        ([0, 1, 2], "List[int]"),
-        ([0, "1", 2], "List[int | str]"),
-        ({0: 1}, "Dict[int, int]"),
-        ({0: 1, "a": "b"}, "Dict[int | str, int | str]"),
-    ],
-)
-def test_type_str_from_arg(typ, expected):
-    assert type_str_from_arg(typ) == expected

--- a/tripy/tests/utils/test_result.py
+++ b/tripy/tests/utils/test_result.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-from nvtripy.utils import Result
-
+from nvtripy.utils.result import Result
 from tests import helper
 
 

--- a/tripy/tests/utils/test_stack_info.py
+++ b/tripy/tests/utils/test_stack_info.py
@@ -28,7 +28,7 @@ class TestGetStackInfo:
         def func():
             # Make sure these two lines remain adjacent since we need to know the offset to use for the line number.
             expected_line_num = sys._getframe().f_lineno + 1
-            return nvtripy.utils.get_stack_info(), expected_line_num
+            return nvtripy.utils.stack_info.get_stack_info(), expected_line_num
 
         # Make sure these two lines remain adjacent since we need to know the offset to use for the line number.
         expected_outer_line_num = sys._getframe().f_lineno + 1
@@ -40,7 +40,7 @@ class TestGetStackInfo:
             file=__file__,
             line=expected_inner_line_num,
             function=func.__name__,
-            code="            return nvtripy.utils.get_stack_info(), expected_line_num",
+            code="            return nvtripy.utils.stack_info.get_stack_info(), expected_line_num",
             _dispatch_target="",
             column_range=None,
         )
@@ -58,7 +58,7 @@ class TestGetStackInfo:
     def test_include_code_index(self, include_code_index):
         # We should include code for all frames up to user code. If the index is past the user frame,
         # then code is included only for the user frame.
-        stack_info = nvtripy.utils.get_stack_info(include_code_index=include_code_index)
+        stack_info = nvtripy.utils.stack_info.get_stack_info(include_code_index=include_code_index)
         stack_info.fetch_source_code()
 
         num_frames_with_code = len([frame for frame in stack_info if frame.code])

--- a/tripy/tests/utils/test_types.py
+++ b/tripy/tests/utils/test_types.py
@@ -1,0 +1,44 @@
+from nvtripy.utils.types import str_from_type_annotation, type_str_from_arg
+import pytest
+from typing import Callable, Dict, List, Optional, Tuple
+
+import nvtripy as tp
+import pytest
+import torch
+
+
+@pytest.mark.parametrize(
+    "typ, expected",
+    [
+        (tp.types.IntLike, "int | nvtripy.DimensionSize"),
+        (Tuple[tp.types.IntLike], "Tuple[int | nvtripy.DimensionSize]"),
+        (List[tp.types.IntLike], "List[int | nvtripy.DimensionSize]"),
+        (Dict[str, tp.Tensor], "Dict[str, nvtripy.Tensor]"),
+        (tp.types.TensorLike, "nvtripy.Tensor | numbers.Number"),
+        (tp.types.ShapeLike, "Sequence[int | nvtripy.DimensionSize]"),
+        (tp.Tensor, "nvtripy.Tensor"),
+        (torch.Tensor, "torch.Tensor"),
+        (int, "int"),
+        (Optional[int], "int | None"),
+        (Callable[[int], int], "Callable[[int], int]"),
+    ],
+)
+def test_str_from_type_annotation(typ, expected):
+    assert str_from_type_annotation(typ) == expected
+
+
+@pytest.mark.parametrize(
+    "typ, expected",
+    [
+        (tp.Tensor([1, 2, 3]), "nvtripy.Tensor"),
+        (torch.tensor([1, 2, 3]), "torch.Tensor"),
+        (0, "int"),
+        ("hi", "str"),
+        ([0, 1, 2], "List[int]"),
+        ([0, "1", 2], "List[int | str]"),
+        ({0: 1}, "Dict[int, int]"),
+        ({0: 1, "a": "b"}, "Dict[int | str, int | str]"),
+    ],
+)
+def test_type_str_from_arg(typ, expected):
+    assert type_str_from_arg(typ) == expected

--- a/tripy/tests/utils/test_utils.py
+++ b/tripy/tests/utils/test_utils.py
@@ -25,10 +25,10 @@ from collections import defaultdict
 
 class TestMd5:
     def test_hash_same_for_same_objects(self):
-        assert utils.md5(0) == utils.md5(0)
+        assert utils.utils.md5(0) == utils.utils.md5(0)
 
     def test_hash_different_for_different_objects(self):
-        assert utils.md5(0) != utils.md5(1)
+        assert utils.utils.md5(0) != utils.utils.md5(1)
 
     @pytest.mark.parametrize(
         "func",
@@ -42,11 +42,11 @@ class TestMd5:
     def test_hash_equivalence(self, func):
         obj0 = func()
         obj1 = func()
-        assert utils.md5(obj0) == utils.md5(obj1)
+        assert utils.utils.md5(obj0) == utils.utils.md5(obj1)
 
 
 def make_with_constant_field():
-    @utils.constant_fields("field")
+    @utils.utils.constant_fields("field")
     class WithConstField:
         def __init__(self):
             self.custom_setter_called_count = defaultdict(int)
@@ -101,11 +101,11 @@ class TestUniqueNameGen:
         ],
     )
     def test_gen_uid(self, inputs, outputs, expected_prefix):
-        uid = utils.UniqueNameGen.gen_uid(inputs, outputs)
+        uid = utils.utils.UniqueNameGen.gen_uid(inputs, outputs)
         assert uid.startswith(expected_prefix)
-        assert uid.endswith(str(utils.UniqueNameGen._counter))
-        assert uid in utils.UniqueNameGen._used_names
+        assert uid.endswith(str(utils.utils.UniqueNameGen._counter))
+        assert uid in utils.utils.UniqueNameGen._used_names
 
     def test_uniqueness(self):
-        uids = [utils.UniqueNameGen.gen_uid() for _ in range(100)]
+        uids = [utils.utils.UniqueNameGen.gen_uid() for _ in range(100)]
         assert len(set(uids)) == 100

--- a/tripy/tests/wrappers/test_interface.py
+++ b/tripy/tests/wrappers/test_interface.py
@@ -27,9 +27,9 @@ from tests.conftest import skip_if_older_than_sm89
 from tests.wrappers.object_builders import create_obj
 
 import nvtripy as tp
-from nvtripy import wrappers
+from nvtripy.utils import wrappers
 from nvtripy.common.datatype import DATA_TYPES
-from nvtripy.wrappers import TYPE_VERIFICATION
+from nvtripy.utils.wrappers import TYPE_VERIFICATION
 from nvtripy.export import PUBLIC_APIS
 
 # Get all functions/methods which have tensors in the type signature


### PR DESCRIPTION
- Updates the `Dockerfile` to use a Python 3.9 container (the lowest version we support) so we can be sure we're not relying on features that are not available there.

     This unforunately means that we need to drop `lldb` from the container
     since it depends on Python 3.10. However, `gdb` is still available.

- Moves various files into `utils`. We were previously unable to do this because the `__init__.py` file of `utils` would import lots of things, creating circular dependencies. Now, the top-level `utils` module will not import everything, meaning there is no risk of circular dependencies.

- Makes some minor changes in the code to make Python 3.9 work (e.g. using `._name` instead of `.__name__`)