### PR TITLE
Enable end to end DPS testing

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Dialect/Plan/Transforms/Passes.td
@@ -248,8 +248,8 @@ def StablehloClusteringPass : Pass<"stablehlo-clustering", "::mlir::ModuleOp"> {
     Option<"entrypoint", "entrypoint", "std::string", "\"\"",
       "the name of the entrypoint function; if empty then the clustering runs"
       " on all functions">,
-    Option<"enableNonDPSReturns",
-      "enable-non-dps-returns", "bool", "false",
+    Option<"forceEntrypointsReturnAllocs",
+      "force-entrypoints-return-allocs", "bool", "false",
       "allow backend clusters to directly allocate outputs">,
     Option<"disableCreateShapeFuncPass", "disable-create-shape-func-pass", "bool", "false",
       "don't apply create shape to func pass in TensorRT clusters">
@@ -331,7 +331,7 @@ def CreateClosedRegionsPass : Pass<"plan-create-closed-regions", "::mlir::Module
       "(used only in testing) specifies to outline regions by walking in "
       " pre-order; used for verifying results are not sensitive "
       "to traversal order">,
-    Option<"enableNonDPSReturns", "enable-non-dps-returns", "bool",
+    Option<"forceEntrypointsReturnAllocs", "force-entrypoints-return-allocs", "bool",
            /*default=*/"false",
            "Allow backend clusters to directly allocate outputs">
   ];

--- a/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/StablehloToExecutable.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/StablehloToExecutable.cpp
@@ -130,7 +130,10 @@ void StablehloToExecutableTask::buildPostClusteringPipeline(
 
   // Perform bufferization.
   pm.addPass(createMemRefCastEliminationPass());
-  pm.addPass(plan::createPlanAllocTensorsPass());
+  plan::PlanAllocTensorsPassOptions allocTensorOpts{};
+  allocTensorOpts.forceEntrypointsReturnAllocs =
+      opts.forceEntrypointsReturnAllocs;
+  pm.addPass(plan::createPlanAllocTensorsPass(allocTensorOpts));
   pm.addPass(plan::createPlanBufferizePass());
   pm.addPass(createMemRefCastEliminationPass());
   pm.addPass(createCanonicalizerPass());

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CMakeLists.txt
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CMakeLists.txt
@@ -37,6 +37,7 @@ add_mlir_tensorrt_library(MLIRTensorRTPlanTransforms
   MLIRTensorRTStablehloScalarToArith
   MLIRTensorRTStablehloToTensorRT
   MLIRTensorRTTensorRTRuntimeDialect
+  MLIRBufferizationToMemRef
   MLIRTransforms
   StablehloOps
 )

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CreateClosedRegions.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/CreateClosedRegions.cpp
@@ -561,12 +561,12 @@ createInlineClosedAllocGroupOp(RewriterBase &rewriter, plan::InlineGroupOp op,
 static LogicalResult createClosedGroupOp(RewriterBase &rewriter,
                                          plan::InlineGroupOp op,
                                          DataFlowSolver &solver,
-                                         bool enableNonDPSReturns) {
+                                         bool forceEntrypointsReturnAllocs) {
   OpBuilder::InsertionGuard g(rewriter);
 
   // Materialize destination operands if not using non-DPS call convention.
   SmallVector<DestinationOperandMaterializationResult> destinationOperands;
-  if (!enableNonDPSReturns)
+  if (!forceEntrypointsReturnAllocs)
     if (failed(materializeDestinationOperands(rewriter, op, solver,
                                               destinationOperands)))
       return failure();
@@ -581,7 +581,7 @@ static LogicalResult createClosedGroupOp(RewriterBase &rewriter,
 
   // Create and populate the appropriate closed group op based on call
   // convention.
-  if (!enableNonDPSReturns)
+  if (!forceEntrypointsReturnAllocs)
     return createInlineClosedGroupOp(rewriter, op, solver, inputs,
                                      destinationOperands);
   return createInlineClosedAllocGroupOp(rewriter, op, solver, inputs);
@@ -629,7 +629,7 @@ public:
     IRRewriter rewriter(ctx);
     for (InlineGroupOp groupOp : llvm::make_early_inc_range(groupOps)) {
       if (failed(createClosedGroupOp(rewriter, groupOp, solver,
-                                     enableNonDPSReturns)))
+                                     forceEntrypointsReturnAllocs)))
         return signalPassFailure();
     }
   }

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/Passes.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/Passes.cpp
@@ -24,6 +24,7 @@
 //===----------------------------------------------------------------------===//
 #include "mlir-tensorrt/Dialect/Plan/Transforms/Passes.h"
 #include "mlir-tensorrt/Transforms/Passes.h"
+#include "mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h"
 #include "mlir/Dialect/Bufferization/IR/BufferDeallocationOpInterface.h"
 #include "mlir/Dialect/Bufferization/Pipelines/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
@@ -48,7 +49,8 @@ void plan::buildPlanSegmentationPipeline(
       plan::createPlanPopulateFunctionBoundsAttributesPass());
   pm.addPass(plan::createStablehloClusteringPass(opts));
   plan::CreateClosedRegionsPassOptions closedRegionOptions{};
-  closedRegionOptions.enableNonDPSReturns = opts.enableNonDPSReturns;
+  closedRegionOptions.forceEntrypointsReturnAllocs =
+      opts.forceEntrypointsReturnAllocs;
   pm.addPass(plan::createCreateClosedRegionsPass(closedRegionOptions));
   pm.addPass(plan::createOutlineClustersPass());
   pm.addPass(mlir::createFuncExtDuplicateFunctionEliminationPass());
@@ -80,6 +82,7 @@ void plan::buildPlanBufferDeallocationPipeline(
   pm.addPass(createCanonicalizerPass());
   pm.addPass(bufferization::createBufferDeallocationSimplificationPass());
   pm.addPass(bufferization::createLowerDeallocationsPass());
+  pm.addPass(mlir::createBufferizationToMemRefPass());
   pm.addPass(createCSEPass());
   pm.addPass(createCanonicalizerPass());
 }

--- a/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
+++ b/mlir-tensorrt/compiler/lib/Dialect/Plan/Transforms/StablehloClustering.cpp
@@ -277,11 +277,11 @@ public:
                });
 
     for (func::FuncOp func : funcs) {
-      if (failed(
-              applyClusteringToFunc(rewriter, func, solver, schedule,
-                                    StablehloClusteringPassOptions{
-                                        entrypoint, enableNonDPSReturns,
-                                        /*disableCreateShapeFuncPass=*/false})))
+      if (failed(applyClusteringToFunc(
+              rewriter, func, solver, schedule,
+              StablehloClusteringPassOptions{
+                  entrypoint, forceEntrypointsReturnAllocs,
+                  /*disableCreateShapeFuncPass=*/false})))
         return signalPassFailure();
     }
 

--- a/mlir-tensorrt/compiler/test/Dialect/Plan/create-closed-regions.mlir
+++ b/mlir-tensorrt/compiler/test/Dialect/Plan/create-closed-regions.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-tensorrt-opt %s -plan-create-closed-regions -split-input-file | FileCheck %s
 // RUN: mlir-tensorrt-opt %s -plan-create-closed-regions=test-pre-walk-order=true -split-input-file | FileCheck %s
-// RUN: mlir-tensorrt-opt %s -plan-create-closed-regions=enable-non-dps-returns=true -split-input-file | FileCheck %s --check-prefix=CHECK-ALLOC
+// RUN: mlir-tensorrt-opt %s -plan-create-closed-regions=force-entrypoints-return-allocs=true -split-input-file | FileCheck %s --check-prefix=CHECK-ALLOC
 
 func.func @test_simple_static(%arg0: tensor<10xf32>, %arg1: tensor<10xf32>) -> tensor<10xf32> {
   %0 = plan.inline_group target(#plan.tensorrt_cluster<disallow_shape_tensor_calculations = false, benefit = 1>) -> tensor<10xf32> {

--- a/mlir-tensorrt/compiler/test/python/IntegrationTests/test_non_dps_cconv.py
+++ b/mlir-tensorrt/compiler/test/python/IntegrationTests/test_non_dps_cconv.py
@@ -1,0 +1,323 @@
+# RUN: %PYTHON %s
+import time
+
+import mlir_tensorrt.compiler.api as compiler
+import mlir_tensorrt.compiler.ir as ir
+import mlir_tensorrt.runtime.api as runtime
+import numpy as np
+
+single_return = """
+func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+  %1 = stablehlo.add %arg0, %arg0 : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  func.return %1 : tensor<2x3x4xf32>
+}
+"""
+
+scalar_return = """
+func.func @main(%arg0: tensor<2x3x4xf32>) -> index {
+  %1 = tensor.rank %arg0 : tensor<2x3x4xf32>
+  func.return %1 : index
+}
+"""
+
+mixed_return = """
+func.func @main(%arg0: tensor<2x3x4xf32>) -> (tensor<2x3x4xf32>, index) {
+  %1 = stablehlo.add %arg0, %arg0 : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %2 = tensor.rank %1 : tensor<2x3x4xf32>
+  func.return %1, %2 : tensor<2x3x4xf32>, index
+}
+"""
+
+multiple_return = """
+func.func @main(%arg0: tensor<2x3x4xf32>) -> (tensor<2x3x4xf32>, tensor<2x3x4xf32>) {
+  %1 = stablehlo.add %arg0, %arg0 : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  %2 = stablehlo.add %arg0, %1 : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+  func.return %1, %2 : tensor<2x3x4xf32>, tensor<2x3x4xf32>
+}
+"""
+
+dynamic_shape = """
+func.func @main(%arg0: tensor<?x2xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [2, 2], opt = [4, 2], max = [6, 2]>},
+                %arg1: tensor<?x2xf32> {tensorrt.shape_profile = #tensorrt.shape_profile<min = [2, 2], opt = [4, 2], max = [6, 2]>})
+                -> tensor<?x2xf32> {
+  %0 = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x2xf32>) -> tensor<i32>
+  %1 = stablehlo.reshape %0 : (tensor<i32>) -> tensor<1xi32>
+  %2 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<?x2xf32>) -> tensor<i32>
+  %3 = stablehlo.reshape %2 : (tensor<i32>) -> tensor<1xi32>
+  %4 = stablehlo.concatenate %1, %3, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  %5 = stablehlo.get_dimension_size %arg1, dim = 0 : (tensor<?x2xf32>) -> tensor<i32>
+  %6 = stablehlo.reshape %5 : (tensor<i32>) -> tensor<1xi32>
+  %7 = stablehlo.get_dimension_size %arg1, dim = 1 : (tensor<?x2xf32>) -> tensor<i32>
+  %8 = stablehlo.reshape %7 : (tensor<i32>) -> tensor<1xi32>
+  %9 = stablehlo.concatenate %6, %8, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  %10 = stablehlo.maximum %4, %9 : tensor<2xi32>
+  %11 = stablehlo.dynamic_broadcast_in_dim %arg0, %10, dims = [0, 1] : (tensor<?x2xf32>, tensor<2xi32>) -> tensor<?x2xf32>
+  %12 = stablehlo.dynamic_broadcast_in_dim %arg1, %10, dims = [0, 1] : (tensor<?x2xf32>, tensor<2xi32>) -> tensor<?x2xf32>
+  %13 = stablehlo.add %11, %12 : tensor<?x2xf32>
+  return %13 : tensor<?x2xf32>
+}
+"""
+
+session_tracking_h2h = """
+func.func @main() -> (tensor<?xi32, #plan.memory_space<host_pinned>> {tensorrt.host_tensor}) {
+  %c = stablehlo.constant dense<[1, 2]> : tensor<2xi32>
+  %0 = bufferization.alloc_tensor() {memory_space = #plan.memory_space<host_pinned>} : tensor<2xi32, #plan.memory_space<host_pinned>>
+  %1 = bufferization.materialize_in_destination %c in %0 : (tensor<2xi32>, tensor<2xi32, #plan.memory_space<host_pinned>>) -> tensor<2xi32, #plan.memory_space<host_pinned>>
+  %cast = tensor.cast %1 : tensor<2xi32, #plan.memory_space<host_pinned>> to tensor<?xi32, #plan.memory_space<host_pinned>>
+  return %cast : tensor<?xi32, #plan.memory_space<host_pinned>>
+}
+"""
+
+empty_shape_tensor = """
+func.func @main() -> (tensor<?x?xi32, #plan.memory_space<host_pinned>> {tensorrt.host_tensor}) {
+  %c = stablehlo.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %c_0 = stablehlo.constant dense<2> : tensor<i32>
+  %c_1 = stablehlo.constant dense<1> : tensor<1xi32>
+  %c_2 = stablehlo.constant dense<2> : tensor<1xi32>
+  %c_3 = stablehlo.constant dense<2> : tensor<i32>
+  %c_4 = stablehlo.constant dense<2> : tensor<1xi32>
+  %0 = stablehlo.concatenate %c_2, %c_4, %c_1, dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xi32>
+  %1 = stablehlo.dynamic_reshape %c, %0 : (tensor<2x2xi32>, tensor<3xi32>) -> tensor<?x?x?xi32>
+  %c_5 = stablehlo.constant dense<2> : tensor<i32>
+  %c_6 = stablehlo.constant dense<2> : tensor<1xi32>
+  %c_7 = stablehlo.constant dense<2> : tensor<i32>
+  %c_8 = stablehlo.constant dense<2> : tensor<1xi32>
+  %c_9 = stablehlo.constant dense<0> : tensor<i32>
+  %c_10 = stablehlo.constant dense<0> : tensor<1xi32>
+  %2 = stablehlo.concatenate %c_6, %c_8, %c_10, dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xi32>
+  %3 = stablehlo.dynamic_broadcast_in_dim %1, %2, dims = [0, 1, 2] : (tensor<?x?x?xi32>, tensor<3xi32>) -> tensor<?x?x?xi32>
+  %c_11 = stablehlo.constant dense<2> : tensor<1xi32>
+  %c_12 = stablehlo.constant dense<> : tensor<0xi32>
+  %c_13 = stablehlo.constant dense<> : tensor<0xi32>
+  %4 = stablehlo.compare  EQ, %c_12, %c_13 : (tensor<0xi32>, tensor<0xi32>) -> tensor<0xi1>
+  %5 = stablehlo.select %4, %c_12, %c_12 : tensor<0xi1>, tensor<0xi32>
+  %6 = stablehlo.dynamic_broadcast_in_dim %c_7, %5, dims = [] : (tensor<i32>, tensor<0xi32>) -> tensor<i32>
+  %7 = stablehlo.dynamic_broadcast_in_dim %c_9, %5, dims = [] : (tensor<i32>, tensor<0xi32>) -> tensor<i32>
+  %8 = stablehlo.multiply %6, %7 : tensor<i32>
+  %9 = stablehlo.reshape %8 : (tensor<i32>) -> tensor<1xi32>
+  %10 = stablehlo.concatenate %c_11, %9, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  %11 = stablehlo.dynamic_reshape %3, %10 : (tensor<?x?x?xi32>, tensor<2xi32>) -> tensor<?x?xi32>
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %11, %c0 : tensor<?x?xi32>
+  %c1 = arith.constant 1 : index
+  %dim_14 = tensor.dim %11, %c1 : tensor<?x?xi32>
+  %12 = bufferization.alloc_tensor(%dim, %dim_14) {memory_space = #plan.memory_space<host_pinned>} : tensor<?x?xi32, #plan.memory_space<host_pinned>>
+  %13 = bufferization.materialize_in_destination %11 in %12 : (tensor<?x?xi32>, tensor<?x?xi32, #plan.memory_space<host_pinned>>) -> tensor<?x?xi32, #plan.memory_space<host_pinned>>
+  %cast = tensor.cast %13 : tensor<?x?xi32, #plan.memory_space<host_pinned>> to tensor<?x?xi32, #plan.memory_space<host_pinned>>
+  return %cast : tensor<?x?xi32, #plan.memory_space<host_pinned>>
+}
+"""
+
+
+# The RuntimeClient can and should persist across multiple Executables, RuntimeSessions, etc.
+# It is primarily an interface for creating and manipulating buffers.
+client = runtime.RuntimeClient()
+stream = client.create_stream()
+devices = client.get_devices()
+
+
+def compile_executable(program, debug=False):
+    # Build/parse the main function.
+    with ir.Context() as context:
+        m = ir.Module.parse(program)
+
+        # Use the compiler API to compile to executable.
+        client = compiler.CompilerClient(context)
+        c_opts = [
+            "--tensorrt-builder-opt-level=3",
+            "--tensorrt-strongly-typed=false",
+            "--entrypoint=main",
+            "--force-entrypoints-return-allocs",
+        ]
+        opts = compiler.StableHLOToExecutableOptions(client, c_opts)
+        if debug:
+            opts.set_debug_options(False, [], "tmp")
+        exe = compiler.compiler_stablehlo_to_executable(client, m.operation, opts)
+        return exe
+
+
+def test_single_return():
+    exe = compile_executable(single_return)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    arg0 = client.create_memref(
+        np.arange(0.0, 24.0, dtype=np.float32).reshape(2, 3, 4).data,
+        device=devices[0],
+        stream=stream,
+    )
+    results = session.execute_function(
+        "main", in_args=[arg0], stream=stream, client=client
+    )
+
+    output = np.asarray(client.copy_to_host(results[0], stream=stream))
+    stream.sync()
+
+    print(output)
+
+
+def test_scalar_return():
+    exe = compile_executable(scalar_return)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    arg0 = client.create_memref(
+        np.arange(0.0, 24.0, dtype=np.float32).reshape(2, 3, 4).data,
+        device=devices[0],
+        stream=stream,
+    )
+    results = session.execute_function(
+        "main", in_args=[arg0], stream=stream, client=client
+    )
+
+    print(results[0].data)
+
+
+def test_mixed_return():
+    exe = compile_executable(mixed_return)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    arg0 = client.create_memref(
+        np.arange(0.0, 24.0, dtype=np.float32).reshape(2, 3, 4).data,
+        device=devices[0],
+        stream=stream,
+    )
+    results = session.execute_function(
+        "main", in_args=[arg0], stream=stream, client=client
+    )
+
+    assert type(results[0]) == runtime.MemRefValue
+    assert type(results[1]) == runtime.ScalarValue
+
+    output = np.asarray(client.copy_to_host(results[0], stream=stream))
+    stream.sync()
+
+    print(output)
+    print(results[1].data)
+
+
+def test_multiple_return():
+    exe = compile_executable(multiple_return)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    arg0 = client.create_memref(
+        np.arange(0.0, 24.0, dtype=np.float32).reshape(2, 3, 4).data,
+        device=devices[0],
+        stream=stream,
+    )
+    results = session.execute_function(
+        "main", in_args=[arg0], stream=stream, client=client
+    )
+
+    output_0 = np.asarray(client.copy_to_host(results[0], stream=stream))
+    output_1 = np.asarray(client.copy_to_host(results[1], stream=stream))
+
+    stream.sync()
+
+    print(output_0)
+    print(output_1)
+
+
+def test_dynamic_shape():
+    exe = compile_executable(dynamic_shape)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    arg0 = client.create_memref(
+        np.arange(0.0, 8.0, dtype=np.float32).reshape((4, 2)).data,
+        device=devices[0],
+        stream=stream,
+    )
+    arg1 = client.create_memref(
+        np.ones((4, 2), dtype=np.float32).data, device=devices[0], stream=stream
+    )
+
+    results = session.execute_function(
+        "main", in_args=[arg0, arg1], stream=stream, client=client
+    )
+
+    output = np.asarray(client.copy_to_host(results[0], stream=stream))
+    stream.sync()
+
+    print(output)
+
+
+def test_session_tracking_d2h():
+    exe = compile_executable(session_tracking_h2h)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    results = session.execute_function("main", in_args=[], stream=stream, client=client)
+    stream.sync()
+    print(np.asarray(results[0]))
+
+
+def test_empty_shape_tensor():
+    exe = compile_executable(empty_shape_tensor)
+    session_options = runtime.RuntimeSessionOptions(num_devices=1, device_id=0)
+    session = runtime.RuntimeSession(session_options, exe)
+    results = session.execute_function("main", in_args=[], stream=stream, client=client)
+    stream.sync()
+    print(np.asarray(results[0]))
+
+
+if __name__ == "__main__":
+    print("Test: single return")
+    test_single_return()
+    # CHECK-LABEL: Test: single return
+    # CHECK: [[[ 0.  2.  4.  6.]
+    # CHECK:   [ 8. 10. 12. 14.]
+    # CHECK:   [16. 18. 20. 22.]]
+    # CHECK:
+    # CHECK:  [[24. 26. 28. 30.]
+    # CHECK:   [32. 34. 36. 38.]
+    # CHECK:   [40. 42. 44. 46.]]]
+
+    # print("Test: multiple return")
+    # test_multiple_return()
+    # # CHECK-LABEL: Test: multiple return
+    # # CHECK: [[[ 0.  2.  4.  6.]
+    # # CHECK:   [ 8. 10. 12. 14.]
+    # # CHECK:   [16. 18. 20. 22.]]
+    # # CHECK:
+    # # CHECK:  [[24. 26. 28. 30.]
+    # # CHECK:   [32. 34. 36. 38.]
+    # # CHECK:   [40. 42. 44. 46.]]]
+    # # CHECK: [[[ 0.  3.  6.  9.]
+    # # CHECK:   [12. 15. 18. 21.]
+    # # CHECK:   [24. 27. 30. 33.]]
+    # # CHECK:
+    # # CHECK:  [[36. 39. 42. 45.]
+    # # CHECK:   [48. 51. 54. 57.]
+    # # CHECK:   [60. 63. 66. 69.]]]
+
+    # print("Test: dynamic shape")
+    # test_dynamic_shape()
+    # # CHECK-LABEL: Test: dynamic shape
+    # # CHECK: [[1. 2.]
+    # # CHECK:  [3. 4.]
+    # # CHECK:  [5. 6.]
+    # # CHECK:  [7. 8.]]
+
+    # print("Test: device to host copy")
+    # test_session_tracking_d2h()
+    # # CHECK-LABEL: Test: device to host copy
+    # # CHECK: [1 2]
+
+    # print("Test: empty shape tensor")
+    # test_empty_shape_tensor()
+    # # CHECK-LABEL: Test: empty shape tensor
+    # # CHECK: []
+
+    # print("Test: scalar return")
+    # test_scalar_return()
+    # # CHECK-LABEL: Test: scalar return
+    # # CHECK: 3
+    # print("Test: mixed return")
+
+    # test_mixed_return()
+    # # CHECK-LABEL: Test: mixed return
+    # # CHECK: [[[ 0.  2.  4.  6.]
+    # # CHECK:   [ 8. 10. 12. 14.]
+    # # CHECK:   [16. 18. 20. 22.]]
+    # # CHECK:
+    # # CHECK:  [[24. 26. 28. 30.]
+    # # CHECK:   [32. 34. 36. 38.]
+    # # CHECK:   [40. 42. 44. 46.]]]
+    # # CHECK: 3

--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -98,7 +98,7 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtStreamCreate(MTRT_Stream *stream);
 static inline bool mtrtStreamIsNull(MTRT_Stream stream) { return !stream.ptr; }
 
 /// Returns null stream.
-static inline MTRT_Stream mtrtStreamGetNull() { return MTRT_Stream{nullptr}; }
+static inline MTRT_Stream mtrtStreamGetNull() { return MTRT_Stream{NULL}; }
 
 /// Synchronizes `MTRT_Stream`
 MLIR_CAPI_EXPORTED MTRT_Status mtrtStreamSynchronize(MTRT_Stream stream);
@@ -119,7 +119,7 @@ static inline bool mtrtDeviceIsNull(MTRT_Device device) { return !device.ptr; }
 
 /// Return a null MTRT_Device. This should be used where MTRT_Device input
 /// arguments are optional in functions below.
-static inline MTRT_Device mtrtDeviceGetNull() { return MTRT_Device{nullptr}; }
+static inline MTRT_Device mtrtDeviceGetNull() { return MTRT_Device{NULL}; }
 
 //===----------------------------------------------------------------------===//
 // MTRT_MemRefValue
@@ -226,6 +226,11 @@ static inline bool mtrtRuntimeClientIsNull(MTRT_RuntimeClient client) {
   return !client.ptr;
 }
 
+/// Returns null client.
+static inline MTRT_RuntimeClient mtrtRuntimeClientGetNull() {
+  return MTRT_RuntimeClient{NULL};
+}
+
 /// Creates a `MTRT_RuntimeClient`. Client must be alive for the lifetime of the
 /// program execution.
 /// The `stream` passed to the client is used by all underlying CUDA methods
@@ -319,6 +324,12 @@ static inline bool mtrtRuntimeValueIsNull(MTRT_RuntimeValue value) {
   return !value.ptr;
 }
 
+// Returns whether the RuntimeValue is MemRef.
+MLIR_CAPI_EXPORTED bool mtrtRuntimeValueIsMemRef(MTRT_RuntimeValue value);
+
+// Returns whether the RuntimeValue is Scalar.
+MLIR_CAPI_EXPORTED bool mtrtRuntimeValueIsScalar(MTRT_RuntimeValue value);
+
 /// Cast a MTRT_MemRefValue to a generic MTRT_RuntimeValue.
 MLIR_CAPI_EXPORTED MTRT_RuntimeValue
 mtrtMemRefCastToRuntimeValue(MTRT_MemRefValue memref);
@@ -348,6 +359,9 @@ mtrtScalarValueCastToRuntimeValue(MTRT_ScalarValue v);
 
 MLIR_CAPI_EXPORTED MTRT_Status
 mtrtScalarValueGetType(MTRT_ScalarValue scalar, MTRT_ScalarTypeCode *code);
+
+MLIR_CAPI_EXPORTED MTRT_Status mtrtScalarValueGet(MTRT_ScalarValue scalar,
+                                                  int64_t *data);
 
 //===----------------------------------------------------------------------===//
 // MTRT_RuntimeSessionOptions
@@ -402,16 +416,27 @@ static inline bool mtrtRuntimeSessionIsNull(MTRT_RuntimeSession session) {
   return !session.ptr;
 }
 
-/// Using `session`, execute the pubic function with the specified name.
-/// The `inArgs` and `outArgs` are arrays for input arguments and destination
-/// arguments, respectively. Input arguments may be MemRefs or scalars, but
-/// destination arguments must be MemRefs.
+/// Using `session`, execute the public function with the specified name.
+/// The `inArgs`, `outArgs`, and `results` are arrays for input arguments,
+/// output arguments, and return values, respectively. Arguments and results
+/// can be MemRefs, scalars, or other supported types. Both `outArgs` and
+/// `results` can be used simultaneously, allowing for functions that both
+/// modify arguments and return values.
 /// A stream may optionally be specified, otherwise pass the result of
 /// `mtrtStreamGetNull()`.
+///
+/// The `results` array must point to an array with at least the number of
+/// elements returned by mtrtRuntimeSessionGetNumResults for the given function.
 MLIR_CAPI_EXPORTED MTRT_Status mtrtRuntimeSessionExecuteFunction(
     MTRT_RuntimeSession session, MTRT_StringView name,
     const MTRT_RuntimeValue *inArgs, size_t numInArgs,
-    const MTRT_RuntimeValue *outArgs, size_t numOutArgs, MTRT_Stream stream);
+    const MTRT_RuntimeValue *outArgs, size_t numOutArgs,
+    MTRT_RuntimeValue *results, MTRT_Stream stream, MTRT_RuntimeClient client);
+
+/// Return number of results given a function name. Function name refers
+/// to an exported function in the executable.
+MLIR_CAPI_EXPORTED MTRT_Status mtrtRuntimeSessionGetNumResults(
+    MTRT_RuntimeSession session, MTRT_StringView name, int64_t *numResults);
 
 //===----------------------------------------------------------------------===//
 // DLPack

--- a/mlir-tensorrt/executor/include/mlir-executor/Runtime/API/API.h
+++ b/mlir-tensorrt/executor/include/mlir-executor/Runtime/API/API.h
@@ -434,7 +434,7 @@ public:
 
   /// Return a function by name. This asserts that the function with the given
   /// name exists.
-  FunctionView getFunction(std::string_view name) const;
+  StatusOr<FunctionView> getFunction(std::string_view name) const;
 
   ConstantView getConstant(int64_t idx) const {
     assert(view->constants() && "expected valid constant pointer");
@@ -810,6 +810,12 @@ public:
   /// Returns true if the ptr is released internally.
   bool isReleasedInternally(uintptr_t ptr) const;
 
+  /// Mark pointer for release after consumption
+  void markForReleaseAfterConsumption(uintptr_t ptr);
+
+  /// Check if pointer is marked for release after consumption
+  bool isMarkedForReleaseAfterConsumption(uintptr_t ptr);
+
 private:
   struct Metadata {
     std::atomic<int32_t> externalReferenceCount = {0};
@@ -817,6 +823,7 @@ private:
     // if this is true then it should be truelly released and untracked
     // when decrementExternalCount causes count to go to zero
     bool releasedInternally{false};
+    bool releaseAfterConsumption{false};
     PointerInfo info;
   };
 
@@ -983,7 +990,7 @@ public:
   ResourceTracker &getResourceTracker() { return resourceTracker; }
 
   /// Return the PinnedMemoryAllocator.
-  PinnedMemoryAllocator &getPinnedMemorAllocator() {
+  PinnedMemoryAllocator &getPinnedMemoryAllocator() {
     return pinnedMemoryAllocator;
   }
 

--- a/mlir-tensorrt/executor/include/mlir-executor/Support/Allocators.h
+++ b/mlir-tensorrt/executor/include/mlir-executor/Support/Allocators.h
@@ -104,6 +104,13 @@ public:
   PinnedMemoryAllocator();
   ~PinnedMemoryAllocator();
 
+  /// Marks a pointer as client-managed, deferring its deallocation
+  /// This method is used when a pinned memory pointer is returned to the client
+  /// and its lifecycle is no longer managed by the PinnedMemoryAllocator.
+  /// Pointers marked this way will not be automatically freed in the
+  /// allocator's destructor.
+  void untrack(uintptr_t ptr);
+
   StatusOr<PinnedMemoryBlock> allocate(size_t size);
 
   /// Free the block associated with the given pointer on the given stream. An
@@ -113,6 +120,9 @@ public:
 
 private:
   EventPool eventPool;
+
+  /// Stores pointers to memory blocks that are now managed by the client.
+  static std::vector<uintptr_t> clientManagedPtrs;
 
   /// Tracks all blocks allocated by the allocator.
   struct BlockTracker;

--- a/mlir-tensorrt/executor/lib/CAPI/Common/Common.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Common/Common.cpp
@@ -344,7 +344,7 @@ MTRT_Status mtrtBoundsGetMax(MTRT_Bounds bounds, MTRT_ArrayRefI64 *maxBounds) {
 MTRT_FunctionSignature mtrtGetFunctionSignature(MTRT_Executable exec,
                                                 const char *name) {
   auto sig = const_cast<impl::FunctionSignature *>(
-      unwrap(exec)->getFunction(name).getSignature().view);
+      (*unwrap(exec)->getFunction(name)).getSignature().view);
   return wrap(sig);
 }
 

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -28,6 +28,7 @@
 #include "mlir-executor/Runtime/API/ExecutableFlatbuffer.h"
 #include "mlir-executor/Runtime/Backend/Lua/LuaExtensions.h"
 #include "mlir-executor/Runtime/Backend/Lua/LuaRuntime.h"
+#include "mlir-executor/Runtime/Support/Support.h"
 #include "mlir-executor/Support/Status.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/Debug.h"
@@ -38,6 +39,17 @@
 #include <mutex>
 #ifdef MLIR_EXECUTOR_ENABLE_CUDA
 #include "cuda_runtime_api.h"
+#endif
+
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
+#include "cuda_bf16.h"
+#include "cuda_fp16.h"
+#include "cuda_fp8.h"
+#if defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 
 struct MTRT_StreamImpl;
@@ -355,6 +367,8 @@ MTRT_Status mtrtMemRefCreateExternal(
 MTRT_Status mtrtMemRefValueDestroyAsync(MTRT_MemRefValue buffer,
                                         MTRT_Stream stream) {
   MemRefValue *memref = unwrap(buffer);
+  MTRT_DBGF("destroying memref pointer 0x%lx asynchronously",
+            memref->getMemory());
   Status s = memref->getClient()->deallocate(
       std::unique_ptr<MemRefValue>(memref),
       mtrtStreamIsNull(stream) ? std::nullopt
@@ -366,6 +380,7 @@ MTRT_Status mtrtMemRefValueDestroyAsync(MTRT_MemRefValue buffer,
 
 MTRT_Status mtrtMemRefValueDestroy(MTRT_MemRefValue buffer) {
   MemRefValue *memref = unwrap(buffer);
+  MTRT_DBGF("destroying memref pointer 0x%lx", memref->getMemory());
   Status s =
       memref->getClient()->deallocate(std::unique_ptr<MemRefValue>(memref));
   if (!s.isOk())
@@ -723,6 +738,16 @@ MTRT_ScalarValue mtrtRuntimeValueDynCastToScalar(MTRT_RuntimeValue v) {
   return wrap(static_cast<ScalarValue *>(x));
 }
 
+bool mtrtRuntimeValueIsMemRef(MTRT_RuntimeValue value) {
+  RuntimeValue *x = unwrap(value);
+  return x->getKind() == RuntimeValue::Kind::MemRef;
+}
+
+bool mtrtRuntimeValueIsScalar(MTRT_RuntimeValue value) {
+  RuntimeValue *x = unwrap(value);
+  return x->getKind() == RuntimeValue::Kind::Scalar;
+}
+
 //===----------------------------------------------------------------------===//
 // MTRT_RuntimeSessionOptions
 //===----------------------------------------------------------------------===//
@@ -769,7 +794,8 @@ MTRT_Status mtrtRuntimeSessionDestroy(MTRT_RuntimeSession session) {
 MTRT_Status mtrtRuntimeSessionExecuteFunction(
     MTRT_RuntimeSession session, MTRT_StringView name,
     const MTRT_RuntimeValue *inArgs, size_t numInArgs,
-    const MTRT_RuntimeValue *outArgs, size_t numOutArgs, MTRT_Stream stream) {
+    const MTRT_RuntimeValue *outArgs, size_t numOutArgs,
+    MTRT_RuntimeValue *results, MTRT_Stream stream, MTRT_RuntimeClient client) {
   LuaRuntimeSession *cppSession =
       static_cast<LuaRuntimeSession *>(unwrap(session));
 
@@ -779,19 +805,38 @@ MTRT_Status mtrtRuntimeSessionExecuteFunction(
   llvm::SmallVector<RuntimeValue *> outArgValues =
       llvm::map_to_vector(llvm::ArrayRef(outArgs, numOutArgs),
                           [](MTRT_RuntimeValue arg) { return unwrap(arg); });
-
-  StatusOr<llvm::SmallVector<std::unique_ptr<RuntimeValue>>> result =
+  StatusOr<llvm::SmallVector<std::unique_ptr<RuntimeValue>>> resultValues =
       executeFunctionWithLuaBackend(
           *cppSession, std::string_view(name.data, name.length), inArgValues,
           outArgValues,
           !mtrtStreamIsNull(stream)
               ? std::optional(unwrap(stream)->getRawStream())
-              : std::nullopt);
-  if (!result.isOk())
-    return wrap(result.getStatus());
+              : std::nullopt,
+          !mtrtRuntimeClientIsNull(client) ? std::optional(unwrap(client))
+                                           : std::nullopt);
+  if (!resultValues.isOk())
+    return wrap(resultValues.getStatus());
+
+  for (size_t i = 0; i < resultValues->size(); ++i)
+    results[i] = wrap((*resultValues)[i].release());
 
   return mtrtStatusGetOk();
 }
+
+MTRT_Status mtrtRuntimeSessionGetNumResults(MTRT_RuntimeSession session,
+                                            MTRT_StringView name,
+                                            int64_t *numResults) {
+  LuaRuntimeSession *cppSession =
+      static_cast<LuaRuntimeSession *>(unwrap(session));
+  StatusOr<FunctionView> func = cppSession->getExecutable().getFunction(
+      std::string_view(name.data, name.length));
+  if (func.isError()) {
+    return wrap(func.getStatus());
+  }
+  *numResults = (*func).getSignature().getNumResults();
+  return mtrtStatusGetOk();
+}
+
 //===----------------------------------------------------------------------===//
 // MTRT_RuntimeClient
 //===----------------------------------------------------------------------===//
@@ -835,5 +880,53 @@ MTRT_Status mtrtScalarValueGetType(MTRT_ScalarValue scalar,
                                    MTRT_ScalarTypeCode *code) {
   ScalarValue *cppScalar = unwrap(scalar);
   *code = static_cast<MTRT_ScalarTypeCode>(cppScalar->getType().getCode());
+  return mtrtStatusGetOk();
+}
+
+MTRT_Status mtrtScalarValueGet(MTRT_ScalarValue scalar, int64_t *data) {
+  ScalarValue *cppScalar = unwrap(scalar);
+  ScalarTypeCode code = cppScalar->getType().getCode();
+  switch (code) {
+  case ScalarTypeCode::f8e4m3fn:
+    *data = static_cast<int64_t>(cppScalar->get<__nv_fp8_e4m3>());
+    break;
+  case ScalarTypeCode::f16:
+    *data = static_cast<int64_t>(cppScalar->get<__half>());
+    break;
+  case ScalarTypeCode::bf16:
+    *data = static_cast<int64_t>(cppScalar->get<nv_bfloat16>());
+    break;
+  case ScalarTypeCode::f32:
+    *data = static_cast<int64_t>(cppScalar->get<float>());
+    break;
+  case ScalarTypeCode::f64:
+    *data = static_cast<int64_t>(cppScalar->get<double>());
+    break;
+  case ScalarTypeCode::i1:
+    *data = static_cast<int64_t>(cppScalar->get<int8_t>());
+    break;
+  case ScalarTypeCode::i4:
+    *data = static_cast<int64_t>(cppScalar->get<int8_t>());
+    break;
+  case ScalarTypeCode::i8:
+    *data = static_cast<int64_t>(cppScalar->get<int8_t>());
+    break;
+  case ScalarTypeCode::ui8:
+    *data = static_cast<int64_t>(cppScalar->get<uint8_t>());
+    break;
+  case ScalarTypeCode::i16:
+    *data = static_cast<int64_t>(cppScalar->get<int16_t>());
+    break;
+  case ScalarTypeCode::i32:
+    *data = static_cast<int64_t>(cppScalar->get<int32_t>());
+    break;
+  case ScalarTypeCode::i64:
+    *data = cppScalar->get<int64_t>();
+    break;
+  default:
+    return wrap(getInvalidArgStatus(
+        "function input argument with scalar type {0} is unsupported",
+        impl::EnumNameScalarTypeCode(code)));
+  }
   return mtrtStatusGetOk();
 }

--- a/mlir-tensorrt/executor/lib/Runtime/API/API.cpp
+++ b/mlir-tensorrt/executor/lib/Runtime/API/API.cpp
@@ -149,7 +149,8 @@ static bool isHostVisible(PointerType type) {
 // ExecutableView
 //===----------------------------------------------------------------------===//
 
-FunctionView ExecutableView::getFunction(std::string_view name) const {
+StatusOr<FunctionView>
+ExecutableView::getFunction(std::string_view name) const {
   const flatbuffers::Vector<flatbuffers::Offset<impl::Function>> &functions =
       *view->functions();
   auto it = std::find_if(functions.begin(), functions.end(),
@@ -157,8 +158,8 @@ FunctionView ExecutableView::getFunction(std::string_view name) const {
                            return x->name()->string_view() == name;
                          });
   if (it == view->functions()->end())
-    return FunctionView();
-
+    return getStatusWithMsg(StatusCode::InvalidArgument, "Function with name (",
+                            name, ") is not present in the executable");
   return FunctionView(*it);
 }
 
@@ -369,6 +370,7 @@ RuntimeSession::RuntimeSession(RuntimeSessionOptions options,
 //===----------------------------------------------------------------------===//
 
 AllocTracker::~AllocTracker() {
+  MTRT_DBGF("Destroying alloc tracker %p", static_cast<void *>(this));
   MTRT_DBGF("checking %u allocations", map.size());
   llvm::SmallVector<PointerInfo> ptrsToFree;
   ptrsToFree.reserve(map.size());
@@ -392,6 +394,20 @@ AllocTracker::~AllocTracker() {
 
   if (totalSize > 0)
     MTRT_DBGF("freed %zu bytes of unfreed memory", totalSize);
+}
+
+void AllocTracker::markForReleaseAfterConsumption(uintptr_t ptr) {
+  assert(llvm::is_contained(map, ptr) &&
+         llvm::formatv("Untracked pointer {0}", ptr).str().c_str());
+  std::unique_ptr<Metadata> const &metadata = map.at(ptr);
+  metadata->releaseAfterConsumption = true;
+}
+
+bool AllocTracker::isMarkedForReleaseAfterConsumption(uintptr_t ptr) {
+  assert(llvm::is_contained(map, ptr) &&
+         llvm::formatv("Untracked pointer {0}", ptr).str().c_str());
+  std::unique_ptr<Metadata> const &metadata = map.at(ptr);
+  return metadata->releaseAfterConsumption;
 }
 
 void AllocTracker::markReleasedInternally(uintptr_t ptr) {
@@ -454,15 +470,23 @@ void AllocTracker::track(PointerInfo info) {
     // (e.g. function argument), in which case it may have been deallocated,
     // allowing an internal allocator to pick up that same address. That case is
     // not an error.
-    assert((!contains(info.ptr) || get(info.ptr).isExternallyManaged()) &&
-           "an internally managed pointer should not already be tracked");
+    if (contains(info.ptr) and get(info.ptr).isInternallyManaged()) {
+      MTRT_DBGF("Allocator %p: Internally managed pointer 0x%lx should not be "
+                "already tracked",
+                static_cast<void *>(this), info.ptr);
+      assert(0 &&
+             "an internally managed pointer should not already be tracked");
+    }
   }
-  MTRT_DBGF("AllocTracker is now tracking 0x%lx size=%lu space=%s ownership=%s",
-            info.ptr, info.size, runtime::impl::EnumNamePointerType(info.type),
-            runtime::impl::EnumNamePointerOwner(info.owner));
+  MTRT_DBGF(
+      "AllocTracker %p is now tracking 0x%lx size=%lx space=%s ownership=%s",
+      static_cast<void *>(this), info.ptr, info.size,
+      runtime::impl::EnumNamePointerType(info.type),
+      runtime::impl::EnumNamePointerOwner(info.owner));
   auto value = std::make_unique<Metadata>();
   value->externalReferenceCount.store(0);
   value->releasedInternally = false;
+  value->releaseAfterConsumption = false;
   value->info = info;
   if (!contains(info.ptr)) {
     map.insert(std::make_pair(info.ptr, std::move(value)));
@@ -489,6 +513,8 @@ void AllocTracker::track(PointerInfo info) {
 }
 
 void AllocTracker::untrack(uintptr_t ptr) {
+  MTRT_DBGF("AllocTracker %p is now untracking 0x%lx)",
+            static_cast<void *>(this), ptr);
   assert(llvm::is_contained(map, ptr) &&
          llvm::formatv("Untracked pointer {0}", ptr).str().c_str());
   map.erase(map.find(ptr));
@@ -598,7 +624,7 @@ mlirtrt::Status runtime::safeDeallocate(AllocTracker &tracker, uintptr_t ptr,
 
   PointerInfo obj = tracker.get(ptr);
   if (obj.owner == PointerOwner::external) {
-    MTRT_DBGF("Untracking externally managed pointer 0x%lx", ptr);
+    MTRT_DBGF("Untracking externally managed 0x%lx", ptr);
     tracker.untrack(obj.ptr);
     return mlirtrt::Status::getOk();
   }
@@ -658,6 +684,7 @@ ResourceTracker::~ResourceTracker() {
 
 void ResourceTracker::track(uintptr_t ptr, Deleter deleter) {
   assert(ptr && deleter && "expected valid ptr and deleter");
+  MTRT_DBGF("tracking resource at 0x%lx", ptr);
   tracker.insert(std::make_pair(ptr, deleter));
 }
 
@@ -749,9 +776,16 @@ StatusOr<std::unique_ptr<MemRefValue>> MemRefValue::create(
   if (!::getFootprintInBytes(shape, strides, bitsPerElement).isOk())
     return getInvalidArgStatus(
         "only memrefs with non-negative strides are allowed");
-  if (!ptr)
+
+  auto isEmptyTensor = [](llvm::ArrayRef<int64_t> shape) -> bool {
+    return std::any_of(shape.begin(), shape.end(),
+                       [](int64_t s) { return s == 0; });
+  };
+
+  if (!ptr && !isEmptyTensor(shape))
     return getInvalidArgStatus(
-        "MemRef objects must be created with a valid pointer");
+        "MemRef objects must be created with a valid pointer for a non-empty "
+        "tensor");
 
   if (isDeviceVisible(addressSpace) && (!device || !*device))
     return getInvalidArgStatus("a specific device must be provided for MemRefs "
@@ -967,7 +1001,7 @@ RuntimeClient::copyToDevice(const MemRefValue &hostBufferImpl,
     // TODO: Currently, this implementation supports only row major packed
     // canonical layout (no padding).
     StatusOr<mlirtrt::PinnedMemoryBlock> pinnedMemory =
-        this->getPinnedMemorAllocator().allocate(totalBufferSize);
+        this->getPinnedMemoryAllocator().allocate(totalBufferSize);
     if (!pinnedMemory.isOk())
       return pinnedMemory.getStatus();
 
@@ -986,7 +1020,7 @@ RuntimeClient::copyToDevice(const MemRefValue &hostBufferImpl,
                         reinterpret_cast<cudaStream_t>(*cudaStream)));
 
     // Free pinned host memory asynchronously.
-    getPinnedMemorAllocator().freeAsync(pinnedMemory->ptr, *cudaStream);
+    getPinnedMemoryAllocator().freeAsync(pinnedMemory->ptr, *cudaStream);
   } else {
     MTRT_DBG("synchronously copying {0} (host) to {1} (device), size={2} bytes",
              hostBufferImpl.getVoidPtr(), (*deviceMemRef)->getVoidPtr(),

--- a/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/LuaRuntime.cpp
+++ b/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/LuaRuntime.cpp
@@ -592,37 +592,45 @@ getScalarValue(const sol::protected_function_result &pfr, int index,
   }
 }
 
-// Parses the results of a function call, handling both scalar and MemRef return
-// types
+/// Parses the results of a function call, handling both scalar and MemRef
+/// return types.
+///
+/// @param pfr The protected function result to parse.
+/// @param sig The function signature view.
+/// @param session Lua runtime session.
+/// @param client Optional runtime client pointer.
+/// @return A vector of unique pointers to RuntimeValue, or an error status.
 static StatusOr<llvm::SmallVector<std::unique_ptr<RuntimeValue>>>
 parseResults(const sol::protected_function_result &pfr,
-             const FunctionSignatureView &sig,
+             const FunctionSignatureView &sig, LuaRuntimeSession &session,
              std::optional<RuntimeClient *> client) {
   llvm::SmallVector<std::unique_ptr<RuntimeValue>> results;
-  for (unsigned i = 0; i < sig.getNumResults(); ++i) {
+  results.reserve(sig.getNumResults());
 
-    if (sig.getResult(i).isa<ScalarTypeView>()) {
-      auto scalar = getScalarValue(pfr, i, sig);
-      if (!scalar.isOk())
-        return scalar.getStatus();
-      results.push_back(std::move(*scalar));
+  for (unsigned i = 0; i < sig.getNumResults(); ++i) {
+    const auto &resultType = sig.getResult(i);
+
+    if (resultType.isa<ScalarTypeView>()) {
+      auto scalarValue = getScalarValue(pfr, i, sig);
+      if (!scalarValue.isOk())
+        return scalarValue.getStatus();
+      results.push_back(std::move(*scalarValue));
       continue;
     }
 
-    MemRefTableReader reader(pfr, i);
-
-    if (!sig.getResult(i).isa<MemRefTypeView>())
+    if (!resultType.isa<MemRefTypeView>())
       return getInvalidArgStatus("Result can only be a memref or scalar");
 
     // Handle MemRef return values
-    const auto &resultView = sig.getResult(i).get<MemRefTypeView>();
-    unsigned rank = resultView.getRank();
+    const auto &memRefView = resultType.get<MemRefTypeView>();
+    MemRefTableReader reader(pfr, i);
 
     // Extract MemRef metadata
     uintptr_t allocPtr = reader.getNextValue<uintptr_t>();
     [[maybe_unused]] uintptr_t alignedPtr = reader.getNextValue<uintptr_t>();
     int64_t offset = reader.getNextValue<int64_t>();
 
+    unsigned rank = memRefView.getRank();
     llvm::SmallVector<int64_t, 4> shape(rank);
     llvm::SmallVector<int64_t, 4> strides(rank);
 
@@ -635,11 +643,36 @@ parseResults(const sol::protected_function_result &pfr,
     if (!client)
       return getInvalidArgStatus("Runtime client cannot be nullptr");
 
-    // Create MemRefValue from extracted data
-    auto memref = (*client)->createExternalMemRef(
-        resultView.getAddressSpace(), resultView.getElementType().getBitWidth(),
-        allocPtr, offset, shape, strides, (*client)->getDevices()[0].get(),
-        resultView.getElementType());
+    // Create an external MemRef and track it in both session and client
+    // allocation trackers
+    MTRT_DBGF("Creating external MemRef for ptr 0x%lx: "
+              "Session alloc tracker: %p, Session pinner memory allocator: %p, "
+              "Client: %p, Client tracker: %p. "
+              "This ptr is registered with the session and will now be tracked "
+              "by the client as well.",
+              allocPtr, static_cast<void *>(&session.getAllocTracker()),
+              static_cast<void *>(&session.getPinnedMemoryAllocator()),
+              static_cast<void *>(*client),
+              static_cast<void *>(&(*client)->getAllocTracker()));
+
+    // We need here actually is to "release" the pointer from the session
+    // ownership and have the client assume
+    PointerInfo info = session.getAllocTracker().get(allocPtr);
+    session.getAllocTracker().untrack(info.ptr);
+    (*client)->getAllocTracker().track(info);
+
+    // Defer deallocation of this pinned memory pointer
+    // This pointer is likely still in use by the client and should not be
+    // immediately freed. By untracking it here, we ensure it won't be
+    // deallocated in the PinnedMemoryAllocator's destructor, allowing
+    // the client to manage its lifecycle.
+    session.getPinnedMemoryAllocator().untrack(info.ptr);
+
+    // Create a memref so that client now tracks it.
+    auto memref = MemRefValue::create(
+        *client, memRefView.getAddressSpace(),
+        memRefView.getElementType().getBitWidth(), allocPtr, offset, shape,
+        strides, (*client)->getDevices()[0].get(), memRefView.getElementType());
 
     if (!memref.isOk())
       return memref.getStatus();
@@ -657,8 +690,11 @@ runtime::executeFunctionWithLuaBackend(
     llvm::ArrayRef<RuntimeValue *> outputArgs, std::optional<CudaStream> stream,
     std::optional<RuntimeClient *> client) {
 
-  FunctionView meta = session.getExecutable().getFunction(name);
-  FunctionSignatureView sig = meta.getSignature();
+  StatusOr<FunctionView> func = session.getExecutable().getFunction(name);
+  if (func.isError())
+    return func.getStatus();
+
+  FunctionSignatureView sig = (*func).getSignature();
 
   // Call the main function, if present.
   sol::state_view lua = session.getLuaState();
@@ -742,5 +778,5 @@ runtime::executeFunctionWithLuaBackend(
                             "\": ", err.what());
   }
 
-  return parseResults(pfr, sig, client);
+  return parseResults(pfr, sig, session, client);
 }

--- a/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/CUDA/CUDAModule.cpp
+++ b/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/CUDA/CUDAModule.cpp
@@ -435,6 +435,15 @@ registerCudaMemoryManagementOps(sol::state_view &lua,
                                                       cudaMemcpyDeviceToHost,
                                                       stream),
                                       state);
+        // Check if the source pointer is marked for release after consumption
+        if (allocTracker->isMarkedForReleaseAfterConsumption(src)) {
+          // This pointer was allocated by TensorRT and used in a device-device
+          // or device-host copy operation. It's not wrapped in a memref, so it
+          // won't be released by external memref destruction. We need to
+          // explicitly free it.
+          SET_LUA_ERROR_IF_ERROR(runtime::safeDeallocate(*allocTracker, src),
+                                 state);
+        }
       };
 
   lua["__cuda_memcpy_host_pinned2device"] =
@@ -486,6 +495,15 @@ registerCudaMemoryManagementOps(sol::state_view &lua,
                                                       cudaMemcpyDeviceToHost,
                                                       stream),
                                       state);
+        // Check if the source pointer is marked for release after consumption
+        if (allocTracker->isMarkedForReleaseAfterConsumption(src)) {
+          // This pointer was allocated by TensorRT and used in a device-device
+          // or device-host copy operation. It's not wrapped in a memref, so it
+          // won't be released by external memref destruction. We need to
+          // explicitly free it.
+          SET_LUA_ERROR_IF_ERROR(runtime::safeDeallocate(*allocTracker, src),
+                                 state);
+        }
       };
   lua["__cuda_memcpy_device2device"] = [allocTracker](
                                            sol::this_state state,
@@ -510,6 +528,15 @@ registerCudaMemoryManagementOps(sol::state_view &lua,
                                                   cudaMemcpyDeviceToDevice,
                                                   stream),
                                   state);
+    // Check if the source pointer is marked for release after consumption
+    if (allocTracker->isMarkedForReleaseAfterConsumption(src)) {
+      // This pointer was allocated by TensorRT and used in a device-device
+      // or device-host copy operation. It's not wrapped in a memref, so it
+      // won't be released by external memref destruction. We need to
+      // explicitly free it.
+      SET_LUA_ERROR_IF_ERROR(runtime::safeDeallocate(*allocTracker, src),
+                             state);
+    }
     return;
   };
 }

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -273,6 +273,7 @@ static std::unique_ptr<PyMemRefValue> createMemRef(
 static std::unique_ptr<PyMemRefValue>
 createMemRefViewFromDLPack(PyRuntimeClient &client, py::capsule capsule,
                            std::optional<bool> assertCanonicalStrides) {
+
   DLManagedTensor *managedTensor = static_cast<DLManagedTensor *>(
       PyCapsule_GetPointer(capsule.ptr(), "dltensor"));
 
@@ -528,6 +529,15 @@ static MTRT_RuntimeValue convertArgType(py::object obj) {
   throw std::runtime_error("argument must be MemRef or scalar");
 }
 
+/// Convert Runtime value to PyMemRefValue or PyScalarValue object.
+static py::object convertGenericArgToPyObject(MTRT_RuntimeValue value) {
+  if (mtrtRuntimeValueIsMemRef(value))
+    return py::cast<PyMemRefValue>(mtrtRuntimeValueDynCastToMemRef(value));
+  if (mtrtRuntimeValueIsScalar(value))
+    return py::cast<PyScalarValue>(mtrtRuntimeValueDynCastToScalar(value));
+  throw std::runtime_error("argument must be MemRef or scalar");
+}
+
 //===----------------------------------------------------------------------===//
 // Declare the bindings.
 //===----------------------------------------------------------------------===//
@@ -552,11 +562,19 @@ PYBIND11_MODULE(_api, m) {
                             py::buffer_protocol())
       .def_property_readonly(MTRT_PYTHON_CAPI_PTR_ATTR,
                              &PyScalarValue::getCapsule)
-      .def_property_readonly("type", [](PyScalarValue &self) {
-        MTRT_ScalarTypeCode code;
-        MTRT_Status s = mtrtScalarValueGetType(self, &code);
+      .def_property_readonly("type",
+                             [](PyScalarValue &self) {
+                               MTRT_ScalarTypeCode code;
+                               MTRT_Status s =
+                                   mtrtScalarValueGetType(self, &code);
+                               THROW_IF_MTRT_ERROR(s);
+                               return code;
+                             })
+      .def_property_readonly("data", [](PyScalarValue &self) {
+        int64_t data;
+        MTRT_Status s = mtrtScalarValueGet(self, &data);
         THROW_IF_MTRT_ERROR(s);
-        return code;
+        return data;
       });
   py::class_<PyMemRefValue>(m, "MemRefValue", py::module_local(),
                             py::buffer_protocol())
@@ -887,22 +905,45 @@ PYBIND11_MODULE(_api, m) {
       .def(
           "execute_function",
           [](PyRuntimeSession &self, std::string name,
-             std::vector<py::object> inArgs, std::vector<py::object> outArgs,
-             std::optional<MTRT_Stream> stream) {
+             std::vector<py::object> inArgs,
+             std::optional<std::vector<py::object>> outArgs,
+             std::optional<MTRT_Stream> stream,
+             PyRuntimeClient *client = nullptr) {
             MTRT_StringView nameRef{name.data(), name.size()};
 
-            auto inArgsGeneric = llvm::map_to_vector(inArgs, convertArgType);
-            auto outArgsGeneric = llvm::map_to_vector(outArgs, convertArgType);
+            int64_t numResults;
+            MTRT_Status s =
+                mtrtRuntimeSessionGetNumResults(self, nameRef, &numResults);
+            THROW_IF_MTRT_ERROR(s);
 
-            MTRT_Status s = mtrtRuntimeSessionExecuteFunction(
+            auto inArgsGeneric = llvm::map_to_vector(inArgs, convertArgType);
+            auto outArgsGeneric =
+                outArgs ? llvm::map_to_vector(*outArgs, convertArgType)
+                        : llvm::SmallVector<MTRT_RuntimeValue>{};
+
+            std::vector<MTRT_RuntimeValue> resultsGeneric(numResults);
+
+            s = mtrtRuntimeSessionExecuteFunction(
                 self, nameRef, inArgsGeneric.data(), inArgsGeneric.size(),
                 outArgsGeneric.data(), outArgsGeneric.size(),
-                stream ? *stream : mtrtStreamGetNull());
+                resultsGeneric.data(), stream ? *stream : mtrtStreamGetNull(),
+                client ? MTRT_RuntimeClient(*client)
+                       : mtrtRuntimeClientGetNull());
             THROW_IF_MTRT_ERROR(s);
-          },
-          py::arg("name"), py::arg("in_args"), py::arg("out_args"),
-          py::arg("stream") = py::none());
 
+            std::vector<py::object> resultPyObject;
+            if (numResults > 0) {
+              for (const auto &arg : resultsGeneric)
+                resultPyObject.push_back(convertGenericArgToPyObject(arg));
+            }
+
+            return resultPyObject;
+          },
+          py::arg("name"), py::arg("in_args"), py::arg("out_args") = py::none(),
+          py::arg("stream") = py::none(), py::arg("client") = nullptr,
+          "Execute a function given input and optional output arguments. "
+          "Return optional results as a Python object if output arguments are "
+          "not present.");
   py::class_<PyGlobalDebugFlag>(m, "GlobalDebug", py::module_local())
       .def_property_static("flag", &PyGlobalDebugFlag::get,
                            &PyGlobalDebugFlag::set, "LLVM-wide debug flag")

--- a/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
@@ -526,30 +526,30 @@ static void packNonSplatInt4Tensor(ElementsAttr values, int64_t count,
   }
 }
 
-static void serializeSplatElements(DenseIntOrFPElementsAttr values,
-                                   std::vector<int8_t> &data) {
+static LogicalResult serializeSplatElements(DenseIntOrFPElementsAttr values,
+                                            std::vector<int8_t> &data) {
   assert(values.isSplat() && "expected SplatElementsAttr");
 
   auto rtt = cast<RankedTensorType>(values.getType());
   if (rtt.getElementType().isInteger(32)) {
     std::fill_n(reinterpret_cast<int32_t *>(data.data()),
                 values.getNumElements(), values.getSplatValue<int32_t>());
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isInteger(64)) {
     std::fill_n(reinterpret_cast<int64_t *>(data.data()),
                 values.getNumElements(), values.getSplatValue<int64_t>());
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isInteger(8)) {
     std::fill_n(reinterpret_cast<int8_t *>(data.data()),
                 values.getNumElements(), values.getSplatValue<int8_t>());
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isF32()) {
     std::fill_n(reinterpret_cast<float *>(data.data()), values.getNumElements(),
                 values.getSplatValue<float>());
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isF16() || rtt.getElementType().isBF16()) {
     APInt tmp = values.getSplatValue<APFloat>().bitcastToAPInt();
@@ -557,7 +557,7 @@ static void serializeSplatElements(DenseIntOrFPElementsAttr values,
     uint16_t fillValue = *reinterpret_cast<const uint16_t *>(tmp.getRawData());
     std::fill_n(reinterpret_cast<uint16_t *>(data.data()),
                 values.getNumElements(), fillValue);
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isFloat8E4M3FN()) {
     APInt tmp = values.getSplatValue<APFloat>().bitcastToAPInt();
@@ -565,7 +565,7 @@ static void serializeSplatElements(DenseIntOrFPElementsAttr values,
     uint8_t fillValue = *reinterpret_cast<const uint8_t *>(tmp.getRawData());
     std::fill_n(reinterpret_cast<uint8_t *>(data.data()),
                 values.getNumElements(), fillValue);
-    return;
+    return llvm::success();
   }
   if (rtt.getElementType().isInteger(4)) {
     APInt tmp = values.getSplatValue<APInt>();
@@ -577,11 +577,12 @@ static void serializeSplatElements(DenseIntOrFPElementsAttr values,
     packed |= ((value & 0x0F) << 4);
     // Fill `data` vector with `packed`
     std::fill_n(reinterpret_cast<uint8_t *>(data.data()), data.size(), packed);
-    return;
+    return llvm::success();
   }
 
-  llvm_unreachable("unsupported data type to convert MLIR splat attribute to "
-                   "TensorRT weights!");
+  return emitError(UnknownLoc::get(values.getContext()))
+         << "unsupported data type to convert MLIR splat attribute to TensorRT "
+            "weights!";
 }
 
 FailureOr<nvinfer1::Weights>
@@ -626,8 +627,10 @@ NvInferNetworkEncoder::getNvInferWeights(ElementsAttr values) {
   weights.values = data.data();
 
   if (values.isSplat() && isa<DenseIntOrFPElementsAttr>(values)) {
-    serializeSplatElements(cast<DenseIntOrFPElementsAttr>(values),
-                           weightsMap[values]);
+    LogicalResult status = serializeSplatElements(
+        cast<DenseIntOrFPElementsAttr>(values), weightsMap[values]);
+    if (failed(status))
+      return failure();
     return weights;
   }
 


### PR DESCRIPTION
Implement python binding changes to allow execute function return multiple returns. Update tests to use non-DPS style calling convention.

Also, enable end to end lowering by enabling conversion of closed alloc group op to tensorrt dialect.

Miscellaneous fixes:
1. Add missing handling of `CallAllocOp` in EliminateShapeOps pass.
2. Skip non ranked tensor type function arguments while collecting host tensor arguments.
3. Temporarily add a pass to remove clone operation in MemRefToExecutor dialect conversion.
4. Relax memref creation for empty shape tensors.
5. Fix memref life returned from Lua function results. This required session allocator to track returned memref.

Also, address
Fix incorrect indexing into output memref results
Return error status instead of silently erroring out during TensorRT weight conversion Address review comments