### PR TITLE
[Compiler] Add force-entrypoints-return-allocs option to TRT task

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/TensorRTToExecutable/TensorRTToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/TensorRTToExecutable/TensorRTToExecutable.h
@@ -59,6 +59,20 @@ struct TensorRTToExecutableOptions
 
   Option<std::string> entrypoint{this, "entrypoint", llvm::cl::init("main"),
                                  llvm::cl::desc("entrypoint function name")};
+
+  /// Forces entrypoint functions to return allocations corresponding to the
+  /// original tensor results. Otherwise, entrypoints will be lowered to use
+  /// destination passing style whenever possible, but some results may still
+  /// lower to returned allocations (because the output shape may not be
+  /// computable from the inputs). In either case, the user should verify the
+  /// final calling convention of the compiled function(s) by inspecting the
+  /// compiled function signature metadata.
+  Option<bool> forceEntrypointsReturnAllocs{
+      this, "force-entrypoints-return-allocs", llvm::cl::init(false),
+      llvm::cl::desc(
+          "Require entrypoint functions to return allocations corresponding to"
+          " the original tensor results, otherwise they are transformed"
+          " into destination arguments whenever possible.")};
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/lib/Compiler/TensorRTToExecutable/TensorRTToExecutable.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/TensorRTToExecutable/TensorRTToExecutable.cpp
@@ -88,6 +88,9 @@ void TensorRTToExecutableTask::buildPostClusteringPipeline(
       nullptr, options.get<TensorRTOptions>().options));
 
   pm.addPass(createMemRefCastEliminationPass());
+  plan::PlanAllocTensorsPassOptions allocTensorOpts{};
+  allocTensorOpts.forceEntrypointsReturnAllocs =
+      options.forceEntrypointsReturnAllocs;
   pm.addPass(plan::createPlanAllocTensorsPass());
   pm.addPass(plan::createPlanBufferizePass());
   pm.addPass(createMemRefCastEliminationPass());


### PR DESCRIPTION
Add force-entrypoints-return-allocs option to TRT task, also update the integration test to use non-DPS style calling convention.