### PR TITLE
Moves `force-entrypoints-return-allocs` into a `PlanAllocOptions`

### DIFF
--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/OptionsProviders.h
@@ -215,6 +215,25 @@ public:
   llvm::Error finalizeImpl();
 };
 
+struct PlanAllocOptions : public OptionsProvider<PlanAllocOptions> {
+public:
+  using OptionsProvider::OptionsProvider;
+
+  /// Forces entrypoint functions to return allocations corresponding to the
+  /// original tensor results. Otherwise, entrypoints will be lowered to use
+  /// destination passing style whenever possible, but some results may still
+  /// lower to returned allocations (because the output shape may not be
+  /// computable from the inputs). In either case, the user should verify the
+  /// final calling convention of the compiled function(s) by inspecting the
+  /// compiled function signature metadata.
+  Option<bool> forceEntrypointsReturnAllocs{
+      &this->ctx, "force-entrypoints-return-allocs", llvm::cl::init(false),
+      llvm::cl::desc(
+          "Require entrypoint functions to return allocations corresponding to"
+          " the original tensor results, otherwise they are transformed"
+          " into destination arguments whenever possible.")};
+};
+
 } // namespace mlirtrt::compiler
 
 #endif // MLIR_TENSORRT_COMPILER_OPTIONS

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StablehloToExecutable/StablehloToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/StablehloToExecutable/StablehloToExecutable.h
@@ -52,7 +52,8 @@ namespace mlirtrt::compiler {
 class StablehloToExecutableTask;
 
 struct StablehloToExecutableOptions
-    : public mlir::OptionsBundle<DebugOptions, ExecutorOptions, DeviceOptions> {
+    : public mlir::OptionsBundle<DebugOptions, ExecutorOptions, DeviceOptions,
+                                 PlanAllocOptions> {
   /// Initializes the options. The extensions in the provided registry
   /// must be extensions for the StableHloToExecutable task.
   StablehloToExecutableOptions(TaskExtensionRegistry extensions);
@@ -70,20 +71,6 @@ struct StablehloToExecutableOptions
 
   Option<std::string> entrypoint{this, "entrypoint", llvm::cl::init("main"),
                                  llvm::cl::desc("entrypoint function name")};
-
-  /// Forces entrypoint functions to return allocations corresponding to the
-  /// original tensor results. Otherwise, entrypoints will be lowered to use
-  /// destination passing style whenever possible, but some results may still
-  /// lower to returned allocations (because the output shape may not be
-  /// computable from the inputs). In either case, the user should verify the
-  /// final calling convention of the compiled function(s) by inspecting the
-  /// compiled function signature metadata.
-  Option<bool> forceEntrypointsReturnAllocs{
-      this, "force-entrypoints-return-allocs", llvm::cl::init(false),
-      llvm::cl::desc(
-          "Require entrypoint functions to return allocations corresponding to"
-          " the original tensor results, otherwise they are transformed"
-          " into destination arguments whenever possible.")};
 
   /// Base class for extensions associated with StableHloToExecutableTask.
   class ExtensionBase : public TaskExtensionBase {

--- a/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/TensorRTToExecutable/TensorRTToExecutable.h
+++ b/mlir-tensorrt/compiler/include/mlir-tensorrt/Compiler/TensorRTToExecutable/TensorRTToExecutable.h
@@ -51,7 +51,7 @@ public:
 
 struct TensorRTToExecutableOptions
     : public mlir::OptionsBundle<DeviceOptions, DebugOptions, ExecutorOptions,
-                                 TensorRTOptions> {
+                                 PlanAllocOptions, TensorRTOptions> {
   // Default initialization does not require any extensions.
   TensorRTToExecutableOptions() = default;
 
@@ -59,20 +59,6 @@ struct TensorRTToExecutableOptions
 
   Option<std::string> entrypoint{this, "entrypoint", llvm::cl::init("main"),
                                  llvm::cl::desc("entrypoint function name")};
-
-  /// Forces entrypoint functions to return allocations corresponding to the
-  /// original tensor results. Otherwise, entrypoints will be lowered to use
-  /// destination passing style whenever possible, but some results may still
-  /// lower to returned allocations (because the output shape may not be
-  /// computable from the inputs). In either case, the user should verify the
-  /// final calling convention of the compiled function(s) by inspecting the
-  /// compiled function signature metadata.
-  Option<bool> forceEntrypointsReturnAllocs{
-      this, "force-entrypoints-return-allocs", llvm::cl::init(false),
-      llvm::cl::desc(
-          "Require entrypoint functions to return allocations corresponding to"
-          " the original tensor results, otherwise they are transformed"
-          " into destination arguments whenever possible.")};
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/StablehloToExecutable.cpp
+++ b/mlir-tensorrt/compiler/lib/Compiler/StablehloToExecutable/StablehloToExecutable.cpp
@@ -132,7 +132,7 @@ void StablehloToExecutableTask::buildPostClusteringPipeline(
   pm.addPass(createMemRefCastEliminationPass());
   plan::PlanAllocTensorsPassOptions allocTensorOpts{};
   allocTensorOpts.forceEntrypointsReturnAllocs =
-      opts.forceEntrypointsReturnAllocs;
+      opts.get<PlanAllocOptions>().forceEntrypointsReturnAllocs;
   pm.addPass(plan::createPlanAllocTensorsPass(allocTensorOpts));
   pm.addPass(plan::createPlanBufferizePass());
   pm.addPass(createMemRefCastEliminationPass());


### PR DESCRIPTION
Also corrects pass ordering in TensorRTToExecutable.