### PR TITLE
Adds `cast` to `tensorrt` dialect

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -354,6 +354,50 @@ def TensorRT_ElementWiseOp : TensorRT_Op<"element_wise", [Pure,
   }];
 }
 
+
+//===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+def TensorRT_CastOp : TensorRT_Op<"cast", [
+      Pure,
+      TensorRTPartiallyInferTensorResultTypes,
+      ElementwiseMappable]>{
+  let summary = "TensorRT cast (ICastLayer) operation";
+  let description = [{
+    The `tensorrt.cast` operation performs a cast from the the input tensor
+    type to the result tensor type, changing only the element type.
+
+    This operation supports casting to and from all data types except f8 and i4.
+  }];
+
+  let arguments = (ins TensorRT_RankedTensorOf<[I1, UI8, TensorRT_I8, I32, I64, F16, BF16, F32]>:$input);
+  let results = (outs TensorRT_RankedTensorOf<[I1, UI8, TensorRT_I8, I32, I64, F16, BF16, F32]>:$result);
+  let assemblyFormat = "attr-dict $input `:` type($input) `to` type($result)";
+
+  let extraClassDeclaration = [{
+    /// Returns true if created op is valid for TensorRT major version.
+    bool isValidForTensorRTVersion(int64_t trtMajorVersion);
+  }] # baseClassDeclaration;
+
+  let trtLayerAdd = [{
+    FailureOr<nvinfer1::DataType> outputTrtType = getNvInferDataType($op.getLoc(),
+                                                        $op.getType().getElementType());
+    if (failed(outputTrtType))
+      return failure();
+
+    nvinfer1::ICastLayer *layer = $net->addCast(*$input,
+        *outputTrtType);
+    if (!$e.isStronglyTyped()) {
+      layer->setOutputType(
+          0, *outputTrtType);
+    }
+    $results.push_back(layer->getOutput(0));
+    $e.setMetadata(layer, $op);
+  }];
+}
+
+
 //===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
@@ -186,6 +186,19 @@ bool tensorrt::ElementWiseOp::isValidForTensorRTVersion(
 }
 
 //===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+bool tensorrt::CastOp::isValidForTensorRTVersion(int64_t trtMajorVersion) {
+  switch (trtMajorVersion) {
+  case 10:
+    return true;
+  default:
+    return false;
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TypeInferenceInterfaceImpls.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TypeInferenceInterfaceImpls.cpp
@@ -124,6 +124,23 @@ LogicalResult tensorrt::ElementWiseOp::inferReturnTypeComponents(
 }
 
 //===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult tensorrt::CastOp::inferReturnTypeComponents(
+    MLIRContext *ctx, std::optional<Location> loc, ValueShapeRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
+  CastOp::Adaptor adaptor(operands, attributes, properties, regions);
+  auto rtt = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+  if (!rtt)
+    return emitOptionalError(loc, "expected input to be a ranked tensor");
+  inferredReturnShapes.emplace_back(/*vec=*/rtt.getShape(),
+                                    /*elementType=*/nullptr);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConcatenateOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/cast.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/cast.mlir
@@ -1,0 +1,29 @@
+// REQUIRES: tensorrt-version-ge-10.0
+// RUN: %pick-one-gpu tensorrt-opt -split-input-file -pass-pipeline="builtin.module(translate-tensorrt-to-engine)" \
+// RUN:  -mlir-elide-elementsattrs-if-larger=32 -tensorrt-builder-opt-level=0 -tensorrt-strongly-typed %s | FileCheck %s
+// RUN: %pick-one-gpu tensorrt-opt -split-input-file -pass-pipeline="builtin.module(translate-tensorrt-to-engine)" \
+// RUN:  -mlir-elide-elementsattrs-if-larger=32 -tensorrt-builder-opt-level=0 %s | FileCheck %s
+
+// CHECK-LABEL: @trt_cast_noop
+//  CHECK-SAME: tensorrt.engine
+func.func @trt_cast_noop(%arg0: tensor<10x128x64xf32>) -> tensor<10x128x64xf32> {
+  %0 = tensorrt.cast %arg0 : tensor<10x128x64xf32> to tensor<10x128x64xf32>
+  return %0 : tensor<10x128x64xf32>
+}
+
+
+// CHECK-LABEL: @trt_cast_f32_i32_f32
+//  CHECK-SAME: tensorrt.engine
+func.func @trt_cast_f32_i32_f32(%arg0: tensor<10x128x64xf32>) -> tensor<10x128x64xf32> {
+  %0 = tensorrt.cast %arg0 : tensor<10x128x64xf32> to tensor<10x128x64xi32>
+  %1 = tensorrt.cast %0 : tensor<10x128x64xi32> to tensor<10x128x64xf32>
+  return %1 : tensor<10x128x64xf32>
+}
+
+
+// CHECK-LABEL: @trt_cast_ui8_f32
+//  CHECK-SAME: tensorrt.engine
+func.func @trt_cast_ui8_f32(%arg0: tensor<10xui8>) -> tensor<10xf32> {
+  %0 = tensorrt.cast %arg0 : tensor<10xui8> to tensor<10xf32>
+  return %0 : tensor<10xf32>
+}


### PR DESCRIPTION
Adds a `cast` operation to the `tensorrt` dialect. Unlike `identity`, `cast` supports many more combinations of input/output types.