### PR TITLE
Ports `cast` and `shape` operations

### DIFF
--- a/tripy/nvtripy/frontend/dimension_size.py
+++ b/tripy/nvtripy/frontend/dimension_size.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,3 +46,22 @@ class DimensionSize(Tensor):
         val = self.tolist()
         assert isinstance(val, int)
         return str(val)
+
+    def eval(self):
+        from nvtripy.trace.ops.shape import GetDimensionSize, Shape
+
+        # TODO (pranavm): Might want to generalize this so that we store values for any common branches in the computation graph.
+        # This could get tricky (e.g. OOMs) so maybe restrict to only Shape operations to start with?
+
+        # If we find a pattern like Shape -> GetDimensionSize, we want to eval the Shape operation
+        # so that we aren't evaluating the entire graph for each dimension.
+        producer = self.trace_tensor.producer
+        if isinstance(producer, GetDimensionSize) and isinstance(producer.inputs[0].producer, Shape):
+            frontend_tensor = producer.inputs[0].frontend_tensor
+            frontend_tensor.eval()
+
+            dim_size = GetDimensionSize([frontend_tensor.trace_tensor], dim=producer.dim)
+            dim_size.outputs[0].is_compile_tracer = self.trace_tensor.is_compile_tracer
+            self.trace_tensor = dim_size.outputs[0]
+
+        return super().eval()

--- a/tripy/nvtripy/frontend/ops/cast.py
+++ b/tripy/nvtripy/frontend/ops/cast.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,6 +71,8 @@ def cast(input: "nvtripy.Tensor", dtype: "nvtripy.dtype") -> "nvtripy.Tensor":
 
     if input.dtype == dtype:
         return input
+
+    # TODO (pranavm): Check if DQ is still needed for quantized types or whether tensorrt.cast can handle it.
 
     # Note: we check for int8 below because MLIR-TRT can handle it in ordinary conversions
     # even though it is a quantized dtype

--- a/tripy/nvtripy/frontend/ops/shape.py
+++ b/tripy/nvtripy/frontend/ops/shape.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 from nvtripy.common.datatype import DATA_TYPES
 from nvtripy.frontend.ops import utils as op_utils
 from nvtripy.frontend.ops._registry import register_tensor_method
-from nvtripy.trace.ops.shape import GetDimensionSize
+from nvtripy.trace.ops.shape import Shape, GetDimensionSize
 from nvtripy.types import ShapeLike
 from nvtripy.utils import wrappers
 
@@ -49,7 +49,8 @@ def shape(self: "nvtripy.Tensor") -> ShapeLike:
     if all(dim >= 0 for dim in self.trace_tensor.shape) and not self.trace_tensor.is_compile_tracer:
         return self.trace_tensor.shape
 
+    shape = op_utils.create_op(Shape, [self])
     return [
-        op_utils.create_op(GetDimensionSize, [self], dim=index, always_cast_to_dimension_size=True)
+        op_utils.create_op(GetDimensionSize, [shape], dim=index, always_cast_to_dimension_size=True)
         for index in range(self.rank)
     ]

--- a/tripy/nvtripy/frontend/ops/utils.py
+++ b/tripy/nvtripy/frontend/ops/utils.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,8 @@ from nvtripy.common.datatype import int32
 from nvtripy.common.exception import raise_error
 
 
-# Creates a Trace operation from the provided frontend tensors and wraps its outputs in frontend Tensors.
+# Creates a Trace operation from the provided frontend tensors and wraps its
+# outputs in frontend Tensors or DimensionSizes.
 def create_op(OpType, inputs, *args, always_cast_to_dimension_size=False, **kwargs):
     from nvtripy.frontend.dimension_size import DimensionSize
     from nvtripy.frontend.tensor import Tensor

--- a/tripy/nvtripy/frontend/tensor.py
+++ b/tripy/nvtripy/frontend/tensor.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,6 +131,15 @@ class Tensor(metaclass=TensorMeta):
 
         look_in = [(tp, "nvtripy")]
         search_for_missing_attr("nvtripy.Tensor", name, look_in)
+
+    @property
+    def trace_tensor(self):
+        return self._trace_tensor
+
+    @trace_tensor.setter
+    def trace_tensor(self, new_trace_tensor):
+        self._trace_tensor = new_trace_tensor
+        self._trace_tensor.frontend_tensor = self
 
     @property
     def name(self):

--- a/tripy/nvtripy/trace/ops/base.py
+++ b/tripy/nvtripy/trace/ops/base.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,8 +95,6 @@ class BaseTraceOp(abc.ABC):
         ), "Default implementation cannot handle cases where there are no inputs, multiple outputs, or multiple inputs with different devices. Please override."
         self.outputs[0].device = self.inputs[0].device
 
-    # TODO (pranavm): Might be better to pass outputs too for symmetry. Otherwise it's not clear
-    # when to access self.inputs/outputs vs. inputs/outputs (ideally should be the latter always).
     @abc.abstractmethod
     def to_mlir(self, inputs: List["ir.Operation"], outputs: List["ir.Operation"]) -> List["ir.Operation"]:
         """

--- a/tripy/nvtripy/trace/ops/cast.py
+++ b/tripy/nvtripy/trace/ops/cast.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 
 from dataclasses import dataclass
 
+from mlir_tensorrt.compiler.dialects import tensorrt
 from nvtripy.trace.ops import utils as op_utils
 from nvtripy.trace.ops.base import BaseTraceOp
 
@@ -30,60 +31,5 @@ class Cast(BaseTraceOp):
     def infer_dtypes(self):
         self.outputs[0].dtype = self.dtype
 
-    def to_flat_ir(self, inputs, outputs):
-        import nvtripy.trace.ops.utils as op_utils
-        from nvtripy.common.datatype import bool as tp_bool
-        from nvtripy.common.datatype import float32, int32, int64
-        from nvtripy.flat_ir.ops import CompareOp, ConstantOp, ConvertOp, DynamicBroadcastOp
-        from nvtripy.flat_ir.tensor import FlatIRTensor
-
-        # If we need to create a constant (namely for comparing with zero), it has to use one of these dtypes.
-        # If the input is not one of these dtypes, the constant needs to be created in one of these and converted.
-        DTYPES_FOR_CONSTANTS = {float32, int32, int64}
-
-        convert_input = inputs[0]
-
-        # For conversion to bool, we must compare with 0 since the underlying semantics for StableHLO
-        # are to do truncation for conversion to integer types (and bools are i1). This would get
-        # unintended results for even numbers, which truncate to 0 in i1.
-        if self.dtype == tp_bool:
-            # Creating a zero tensor uses the same logic as the zeros_like initializer
-
-            # If the input dtype does not allow directly creating a Tripy array, we have to use another like f32
-            # and then cast the zeros tensor.
-            zero_dtype = convert_input.dtype if convert_input.dtype in DTYPES_FOR_CONSTANTS else float32
-            single_zero = FlatIRTensor.build(
-                shape=[],
-                rank=0,
-                dtype=zero_dtype,
-                device=convert_input.device,
-                reason_details=["Zero scalar for casting to bool"],
-            )
-            ConstantOp.build([], [single_zero], data=0)
-            zeros_shape = op_utils.get_shape_of_tensor(convert_input)
-            zeros = FlatIRTensor.build(
-                shape=convert_input.shape,
-                rank=convert_input.rank,
-                dtype=zero_dtype,
-                device=convert_input.device,
-                reason_details=["Tensor of zeroes for comparing to cast to bool"],
-            )
-            DynamicBroadcastOp.build([single_zero, zeros_shape], [zeros], broadcast_dim=[])
-
-            if zero_dtype != convert_input.dtype:
-                zero_output = FlatIRTensor.build(
-                    shape=zeros.shape,
-                    rank=zeros.rank,
-                    dtype=convert_input.dtype,
-                    device=zeros.device,
-                    reason_details=[
-                        f"Cast zero tensor because it cannot be created directly from array with dtype {convert_input.dtype}"
-                    ],
-                )
-                ConvertOp.build([zeros], [zero_output])
-                zeros = zero_output
-
-            CompareOp.build([convert_input, zeros], outputs, compare_direction="NE")
-            return
-
-        ConvertOp.build([convert_input], outputs)
+    def to_mlir(self, inputs, outputs):
+        return [tensorrt.cast(outputs[0], inputs[0])]

--- a/tripy/nvtripy/trace/ops/constant.py
+++ b/tripy/nvtripy/trace/ops/constant.py
@@ -167,7 +167,6 @@ class Constant(BaseTraceOp):
                 stream=None,
             )
 
-        # TODO (pranavm): Need to enable TRT cast:
         # TODO: we can further drop the cast by tolist(memref) -> mlir
         # Workaround (#208): bools are represented as i1 in MLIR-TRT but they cannot be used for DenseElementsAttr
         # so we have to represent them as ints and then cast the result
@@ -183,8 +182,7 @@ class Constant(BaseTraceOp):
                 array=int_memref, type=mlir_utils.get_mlir_dtype(datatype.int32), shape=data_memref.shape
             )
             constant_op = tensorrt.constant(attr)
-            # TODO (pranavm): Replace this with `cast`
-            return [tensorrt.identity(result=outputs[0], input=constant_op)]
+            return [tensorrt.cast(result=outputs[0], input=constant_op)]
 
         attr = ir.DenseElementsAttr.get(
             array=data_memref, type=mlir_utils.get_mlir_dtype(self.outputs[0].dtype), shape=data_memref.shape

--- a/tripy/nvtripy/trace/tensor.py
+++ b/tripy/nvtripy/trace/tensor.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,18 +32,18 @@ class TraceTensor:
     producer: "BaseTraceOp"
     dtype: "nvtripy.common.dtype" = field(default=None, init=False)
     device: "nvtripy.common.device" = field(default=None, init=False)
+    # Indicates the shape of the tensor. Unknown dimensions are indicated by -1.
+    # Generally, the shape will only be known for shape tensors.
     shape: List[int] = field(default=None, init=False)
     stack_info: StackInfo = field(default_factory=lambda: StackInfo([]), init=False)
-    """
-    Indicates the shape of the tensor. Unknown dimensions are indicated by -1.
-    Generally, the shape will only be known for shape tensors.
-    """
 
     # Whether this tensor was constructed in order to trace a computation graph for the compiler.
     is_compile_tracer: bool = False
     # Stack information for the point at which this tensor was evaluated if it was.
     # This is useful in the compiler to disallow evaluation during tracing.
     eval_stack_info: Optional[StackInfo] = field(default=None, init=False)
+
+    frontend_tensor: "nvtripy.Tensor" = field(default=None, init=False)
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
[Ports the cast operation to the TRT dialect](https://github.com/NVIDIA/TensorRT-Incubator/commit/ecad27e9dd196c3a7ad7a7898fc6fc9fd361d9c1)

[Ports shape operation to TRT dialect](https://github.com/NVIDIA/TensorRT-Incubator/commit/6340a21de921bc12f7b31cf857394cbf6746685b)

Also adds an optimization for eager mode where the output of `Shape` will
be stored if we evaluate a `GetDimensionSize` so that subsequent `GetDimensionSize`s
do not need to evaluate the entire graph - otherwise, we recompile the graph
once per dimension of the shape.