### PR TITLE
[TensorRT] Relax same-shape constraint for TRT QDQ ops

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -2977,7 +2977,7 @@ def TensorRT_DeconvolutionOp : TensorRT_Op<"deconvolution",
 
 def TensorRT_QuantizeOp : TensorRT_Op<"quantize",
     [Pure,
-    AllShapesMatch<["input", "result"]>]>{
+    AllRanksMatch<["input", "result"]>]>{
   let summary = "TensorRT Quantize(IQuantizeLayer) operation";
   let description = [{
     The `tensorrt.quantize` operation quantize a floating-point input tensor into
@@ -3157,7 +3157,7 @@ def TensorRT_QuantizeOp : TensorRT_Op<"quantize",
 //===----------------------------------------------------------------------===//
 
 def TensorRT_DequantizeOp : TensorRT_Op<"dequantize",
-    [Pure, AllShapesMatch<["input", "result"]>]>{
+    [Pure, AllRanksMatch<["input", "result"]>]>{
   let summary = "TensorRT Dequantize(IDequantizeLayer) operation";
     let description = [{
     The `tensorrt.dequantize` operation dequantize an 8-bit signed integer into

--- a/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/quantization.mlir
+++ b/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/quantization.mlir
@@ -13,6 +13,17 @@ func.func @trt_quantize(%arg0: tensor<10x10xf32>, %arg1: tensor<f32>) -> tensor<
 
 // -----
 
+func.func @trt_quantize_dynamic(%arg0: tensor<10x10xf32>, %arg1: tensor<f32>) -> tensor<?x?xi8> {
+  %result = tensorrt.quantize in(%arg0 : tensor<10x10xf32>) scale(%arg1 :  tensor<f32>) -> tensor<?x?xi8>
+  return %result : tensor<?x?xi8>
+}
+
+// CHECK-LABEL: @trt_quantize_dynamic
+//       CHECK: tensorrt.quantize
+//  CHECK-SAME: in(%[[arg0:.+]] : tensor<10x10xf32>) scale(%[[arg1:.+]] : tensor<f32>) -> tensor<?x?xi8>
+
+// -----
+
 func.func @trt_quantize_per_axis(%arg0: tensor<10x10xf32>, %arg1: tensor<10xf32>) -> tensor<10x10xi8> {
   %result = tensorrt.quantize {
     axis = 1 : i32
@@ -46,6 +57,17 @@ func.func @trt_dequantize(%arg0: tensor<10x10xi8>, %arg1: tensor<f32>) -> tensor
 // CHECK-LABEL: @trt_dequantize
 //       CHECK: tensorrt.dequantize
 //  CHECK-SAME: in(%[[arg0:.+]] : tensor<10x10xi8>) scale(%[[arg1:.+]] : tensor<f32>) -> tensor<10x10xf32>
+
+// -----
+
+func.func @trt_dequantize_dynamic(%arg0: tensor<10x10xi8>, %arg1: tensor<f32>) -> tensor<?x?xf32> {
+  %result = tensorrt.dequantize in(%arg0 : tensor<10x10xi8>) scale(%arg1 :  tensor<f32>) -> tensor<?x?xf32>
+  return %result : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @trt_dequantize_dynamic
+//       CHECK: tensorrt.dequantize
+//  CHECK-SAME: in(%[[arg0:.+]] : tensor<10x10xi8>) scale(%[[arg1:.+]] : tensor<f32>) -> tensor<?x?xf32>
 
 // -----
 


### PR DESCRIPTION
Changes same-shape constraint for QDQ ops to same-rank, so that we can generate output result type with unknown dims.