### PR TITLE
[TensorRT] Add type inference for QDQ ops

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -2977,6 +2977,7 @@ def TensorRT_DeconvolutionOp : TensorRT_Op<"deconvolution",
 
 def TensorRT_QuantizeOp : TensorRT_Op<"quantize",
     [Pure,
+    TensorRTPartiallyInferTensorResultTypes,
     AllRanksMatch<["input", "result"]>]>{
   let summary = "TensorRT Quantize(IQuantizeLayer) operation";
   let description = [{
@@ -3157,7 +3158,9 @@ def TensorRT_QuantizeOp : TensorRT_Op<"quantize",
 //===----------------------------------------------------------------------===//
 
 def TensorRT_DequantizeOp : TensorRT_Op<"dequantize",
-    [Pure, AllRanksMatch<["input", "result"]>]>{
+    [Pure,
+     TensorRTPartiallyInferTensorResultTypes,
+     AllRanksMatch<["input", "result"]>]>{
   let summary = "TensorRT Dequantize(IDequantizeLayer) operation";
     let description = [{
     The `tensorrt.dequantize` operation dequantize an 8-bit signed integer into

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TypeInferenceInterfaceImpls.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TypeInferenceInterfaceImpls.cpp
@@ -1532,3 +1532,37 @@ LogicalResult tensorrt::NormalizationOp::inferReturnTypeComponents(
       /*elementType=*/inputDataType.getElementType());
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// QuantizeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult tensorrt::QuantizeOp::inferReturnTypeComponents(
+    MLIRContext *ctx, std::optional<Location> loc, ValueShapeRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
+  QuantizeOp::Adaptor adaptor(operands, attributes, properties, regions);
+  auto rtt = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+  if (!rtt)
+    return emitOptionalError(loc, "expected input to be a ranked tensor");
+  inferredReturnShapes.emplace_back(/*vec=*/rtt.getShape(),
+                                    /*elementType=*/nullptr);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DequantizeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult tensorrt::DequantizeOp::inferReturnTypeComponents(
+    MLIRContext *ctx, std::optional<Location> loc, ValueShapeRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents> &inferredReturnShapes) {
+  DequantizeOp::Adaptor adaptor(operands, attributes, properties, regions);
+  auto rtt = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+  if (!rtt)
+    return emitOptionalError(loc, "expected input to be a ranked tensor");
+  inferredReturnShapes.emplace_back(/*vec=*/rtt.getShape(),
+                                    /*elementType=*/nullptr);
+  return success();
+}

--- a/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/invalid.mlir
+++ b/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/invalid.mlir
@@ -1698,6 +1698,14 @@ func.func @trt_quantize(%arg0: tensor<10x10xf32>, %arg1: tensor<2xf32>) -> tenso
 
 // -----
 
+func.func @trt_quantize_shape_mismatch(%arg0: tensor<10x10xf32>, %arg1: tensor<f32>) -> tensor<5x10xi8> {
+  // expected-error @below {{'tensorrt.quantize' op result 0 has type tensor<5x10xi8> but inferred tensor of shape <10x10>}}
+  %result = tensorrt.quantize in(%arg0 : tensor<10x10xf32>) scale(%arg1 : tensor<f32>) -> tensor<5x10xi8>
+  return %result : tensor<5x10xi8>
+}
+
+// -----
+
 func.func @trt_quantize_i4(%arg0: tensor<10x10xf32>, %arg1: tensor<2x10xf32>) -> tensor<10x10xi8> {
   // expected-error @below {{'tensorrt.quantize' op 2D scale is supported only for quantizing INT4 output}}
   %result = tensorrt.quantize in(%arg0 : tensor<10x10xf32>) scale(%arg1 : tensor<2x10xf32>) -> tensor<10x10xi8>
@@ -1730,6 +1738,14 @@ func.func @trt_dequantize(%arg0: tensor<10x10xi8>, %arg1: tensor<2xf32>) -> tens
   // expected-error @below {{'tensorrt.dequantize' op if no axis is provided and input is not INT4, dequantization is per-tensor. In this case, `scale` must be a scalar i.e. 0 dim tensor.}}
   %result = tensorrt.dequantize in(%arg0 : tensor<10x10xi8>) scale(%arg1 : tensor<2xf32>) -> tensor<10x10xf32>
   return %result : tensor<10x10xf32>
+}
+
+// -----
+
+func.func @trt_dequantize_shape_mismatch(%arg0: tensor<10x10xi8>, %arg1: tensor<f32>) -> tensor<5x10xf32> {
+  // expected-error @below {{'tensorrt.dequantize' op result 0 has type tensor<5x10xf32> but inferred tensor of shape <10x10>}}
+  %result = tensorrt.dequantize in(%arg0 : tensor<10x10xi8>) scale(%arg1 : tensor<f32>) -> tensor<5x10xf32>
+  return %result : tensor<5x10xf32>
 }
 
 // -----


### PR DESCRIPTION
Adds type inference for tensorrt QDQ ops to ensure static dims of input/output types are the same.