### PR TITLE
[TensorRT] Fix dynamic linspace translation, relax dynamic verifier

### DIFF
--- a/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
@@ -371,9 +371,8 @@ nvinfer1::ILayer *NvInferNetworkEncoder::addFillLayer(
     nvinfer1::Dims shapeDims = dynamicShape->getDimensions();
     assert(shapeDims.nbDims == 1 && shapeDims.d[0] > 0 &&
            "invalid shape tensor shape");
-    staticShape.nbDims = shapeDims.d[0];
-    for (int32_t i = 0; i < shapeDims.nbDims; i++)
-      staticShape.d[i] = 1;
+    staticShape.nbDims = 1;
+    staticShape.d[0] = 1;
   }
   nvinfer1::IFillLayer *layer =
       network->addFill(staticShape, fillOperation, elementType);

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/Verification.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/Verification.cpp
@@ -117,7 +117,9 @@ LogicalResult tensorrt::LinspaceOp::verify() {
     if (getStep() == nullptr)
       return emitOpError("dynamic `step` must be specified if the result is "
                          "greater than rank 1");
-    if (getStep().getType().getDimSize(0) != getType().getRank())
+    TensorType stepType = getStep().getType();
+    if (!stepType.isDynamicDim(0) &&
+        stepType.getDimSize(0) != getType().getRank())
       return emitOpError("dynamic `step` type dimension 0 length must be the "
                          "same size as the rank of the result type");
   }


### PR DESCRIPTION
Fixes dynamic linspace translation by passing a 1-D static shape tensor. Relaxes linspace op's verifier when the input step dimension is unknown.