### PR TITLE
[build_tools] Add cmake preset for clang python wheel release

### DIFF
--- a/mlir-tensorrt/CMakePresets.json
+++ b/mlir-tensorrt/CMakePresets.json
@@ -70,6 +70,23 @@
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++"
       }
+    },
+    {
+      "name": "ninja-clang-wheel-release",
+      "displayName": "Ninja Release clang wheels",
+      "generator": "Ninja",
+      "binaryDir": "build",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "LLVM_ENABLE_ASSERTIONS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_PLATFORM_NO_VERSIONED_SONAME": "ON",
+        "LLVM_MINIMUM_PYTHON_VERSION": "$env{PY_VERSION}",
+        "MLIR_TRT_ENABLE_NCCL": "OFF",
+        "MLIR_TRT_DOWNLOAD_TENSORRT_VERSION": "$env{DOWNLOAD_TENSORRT_VERSION}"
+      }
     }
   ]
 }

--- a/mlir-tensorrt/python/requirements-dev.txt
+++ b/mlir-tensorrt/python/requirements-dev.txt
@@ -2,7 +2,6 @@
 # The GPU version installs `nvidia-` pip packages which confuse JAX.
 -r requirements.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
-numpy<2.0.0
 click
 matplotlib
 pandas


### PR DESCRIPTION
This PR adds cmake preset for clang python wheel release and updates `build_wheels.sh` script to use this preset.