### PR TITLE
Allows I64 tensors in `tensorrt.shape`

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -2657,7 +2657,7 @@ def TensorRT_ShapeOp : TensorRT_Op<"shape", [Pure,
     ```
   }];
 
-  let arguments = (ins TensorRT_RankedTensorOf<[I1, TensorRT_I8, I32, TensorRT_F8, F16, BF16, F32]>:$input);
+  let arguments = (ins TensorRT_RankedTensorOf<[I1, TensorRT_I8, I32, I64, TensorRT_F8, F16, BF16, F32]>:$input);
   let results = (outs 1DTensorOf<[I32]>:$result);
 
   let assemblyFormat = "attr-dict $input `:` type($input) `->` type($result)";

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
@@ -651,7 +651,7 @@ bool tensorrt::ShapeOp::isValidForTensorRTVersion(int64_t trtMajorVersion) {
     return isType(inputElementType, I1, I8, I32, F16, F32);
   case 9:
   case 10:
-    return isType(inputElementType, I1, I8, I32, F8, F16, BF16, F32);
+    return isType(inputElementType, I1, I8, I32, I64, F8, F16, BF16, F32);
   default:
     return false;
   }

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/shape.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/shape.mlir
@@ -12,6 +12,16 @@ func.func @tensorrt_shape_op(
 }
 
 
+// CHECK-LABEL: @tensorrt_shape_op_int64
+//  CHECK-SAME: tensorrt.engine
+func.func @tensorrt_shape_op_int64(
+    %arg0: tensor<10x?xi64> {tensorrt.shape_profile = #tensorrt.shape_profile<min=[10, 128], opt=[10, 256], max=[10, 512]>},
+  %arg1: tensor<1x1xi64>) -> tensor<2xi32> {
+  %0 = tensorrt.element_wise <kSUM> (%arg0, %arg1 : tensor<10x?xi64>, tensor<1x1xi64>) -> tensor<10x?xi64>
+  %1 = tensorrt.shape %0 : tensor<10x?xi64> -> tensor<2xi32>
+  return %1 : tensor<2xi32>
+}
+
 
 // CHECK-LABEL: @tensorrt_shape_op_0d
 //  CHECK-SAME: tensorrt.engine


### PR DESCRIPTION
Updates `tensorrt.shape` to allow accepting I64 input tensors. The shape operation doesn't really care about the data type of its input (only shape) and so all data types are supported.