### PR TITLE
Allows scalars in unary operations

### DIFF
--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/Verification.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/Verification.cpp
@@ -1352,10 +1352,6 @@ bool hasElementType(TensorType t, Callable... funcs) {
 /// TODO: this should go away when we break out the TensorRT unary operation
 /// into separate ops.
 static LogicalResult verifyAllowedDataTypes(UnaryOp op) {
-  // TensorRT unary op doesn't accept scalar.
-  if (cast<RankedTensorType>(op.getInput().getType()).getRank() == 0)
-    return op->emitOpError("TensorRT Unary ops need at least 1D input");
-
   // Names of the lambdas appear in the error message using the macro below.
   auto I8 = [](Type t) { return isTensorRTInt8Type(t); };
   auto I32 = [](Type t) { return t.isInteger(32); };

--- a/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/invalid.mlir
+++ b/mlir-tensorrt/tensorrt/test/Dialect/TensorRT/invalid.mlir
@@ -1460,14 +1460,6 @@ func.func @trt_unary(%arg0: tensor<10xi32>) -> tensor<10xi32> {
 
 // -----
 
-func.func @trt_unary_sqrt(%arg0: tensor<f32>) -> tensor<f32> {
-  // expected-error @below {{'tensorrt.unary' op TensorRT Unary ops need at least 1D input}}
-  %0 = tensorrt.unary {unaryOperation = #tensorrt.unary_operation<kSQRT>} %arg0 : tensor<f32>
-  return %0 : tensor<f32>
-}
-
-// -----
-
 func.func @trt_unary_sqrt(%arg0: tensor<10xi32>) -> tensor<10xi32> {
   // expected-error @below {{'tensorrt.unary' op expected element type to be one of the following: F16, F32}}
   %0 = tensorrt.unary {unaryOperation = #tensorrt.unary_operation<kSQRT>} %arg0 : tensor<10xi32>

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/unary.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/unary.mlir
@@ -23,3 +23,12 @@ func.func @trt_unary_exp_op_bf16(%arg0: tensor<10x128x64xbf16>) -> tensor<10x128
   } %arg0 : tensor<10x128x64xbf16>
   return %0 : tensor<10x128x64xbf16>
 }
+
+
+// CHECK-LABEL: @trt_unary_scalar
+//  CHECK-SAME: tensorrt.engine
+func.func @trt_unary_scalar() -> tensor<f32> {
+    %inp = tensorrt.constant dense<4.0> : tensor<f32>
+    %0 = tensorrt.unary {unaryOperation = #tensorrt.unary_operation<kSQRT>} %inp : tensor<f32>
+    return %0 : tensor<f32>
+}


### PR DESCRIPTION
Current versions of TensorRT allow unary inputs to be scalar. This change restricts the 1D check to TensorRT 8 so that newer versions are able to accept scalar inputs.