### PR TITLE
Enables BF16 in pooling

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -1443,7 +1443,7 @@ def TensorRT_PoolingOp : TensorRT_Op<"pooling",
   }];
 
   let arguments = (ins
-    TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$input,
+    TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32, BF16]>:$input,
     DenseI64ArrayAttr:$windowSize,
     DenseI64ArrayAttr:$stride,
     DenseI64ArrayAttr:$prePadding,
@@ -1452,7 +1452,7 @@ def TensorRT_PoolingOp : TensorRT_Op<"pooling",
     OptionalAttr<F32Attr>:$blendFactor,
     OptionalAttr<BoolAttr>:$averageCountExcludesPadding
   );
-  let results = (outs TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32]>:$result);
+  let results = (outs TensorRT_RankedTensorOf<[TensorRT_I8, F16, F32, BF16]>:$result);
   let assemblyFormat = "attr-dict `ins` `(` $input `:` type($input) `)` `->` type($result)";
   let hasVerifier = 1;
   let extraClassDeclaration = [{

--- a/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
+++ b/mlir-tensorrt/tensorrt/lib/TensorRT/IR/TensorRTVersionCompatibility.cpp
@@ -423,8 +423,9 @@ bool tensorrt::PoolingOp::isValidForTensorRTVersion(int64_t trtMajorVersion) {
   switch (trtMajorVersion) {
   case 8:
   case 9:
-  case 10:
     return isType(inputElementType, I8, F16, F32);
+  case 10:
+    return isType(inputElementType, I8, F16, F32, BF16);
   default:
     return false;
   }

--- a/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/pooling.mlir
+++ b/mlir-tensorrt/tensorrt/test/Target/TensorRT/TRT10/pooling.mlir
@@ -18,3 +18,17 @@ func.func @trt_average_pool_2d_fp8(%arg0: tensor<4x128x200x1xf8E4M3FN>) -> tenso
   } ins(%dq : tensor<4x128x200x1xf16>) -> tensor<4x128x20x1xf16>
   return %0 : tensor<4x128x20x1xf16>
 }
+
+// CHECK-LABEL: @trt_average_pool_2d_bf16
+//  CHECK-SAME: tensorrt.engine
+func.func @trt_average_pool_2d_bf16(%arg0: tensor<4x128x200x1xbf16>) -> tensor<4x128x20x1xbf16> {
+  %0 = tensorrt.pooling {
+    averageCountExcludesPadding = true,
+    poolingType = #tensorrt.pooling_type<kAVERAGE>,
+    postPadding = array<i64: 0, 0>,
+    prePadding = array<i64: 0, 0>,
+    stride = array<i64: 10, 1>,
+    windowSize = array<i64: 10, 1>
+  } ins(%arg0 : tensor<4x128x200x1xbf16>) -> tensor<4x128x20x1xbf16>
+  return %0 : tensor<4x128x20x1xbf16>
+}


### PR DESCRIPTION
The pooling layer in TRT supports all activation types, which includes BF16. For now, this change is restricted to TRT 10+, but likely would apply to TRT 9 as well.