### PR TITLE
Enables more data types in various operations

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
@@ -148,7 +148,7 @@ class TensorRT_Non0RankedTensorOf<list<Type> allowedTypes>
   : TensorRankOf<allowedTypes, [1, 2, 3, 4, 5, 6, 7, 8]>;
 
 def TensorRT_Tensor : TensorRT_RankedTensorOf<
-      [I1, TensorRT_I8, I32, I64, F16, BF16, F32]>;
+      [I1, TensorRT_I4, TensorRT_I8, I32, I64, TensorRT_F8, F16, BF16, F32]>;
 
 def TensorRT_DimensionListAttr : ConfinedAttr<DenseI64ArrayAttr,[
       DenseArrayStrictlySorted<DenseI64ArrayAttr>,

--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTOps.td
@@ -466,7 +466,7 @@ def TensorRT_ConcatenationOp : TensorRT_Op<"concatenation",
   }];
 
   let arguments = (ins
-    Variadic<TensorRT_RankedTensorOf<[I1, TensorRT_I8, I32, I64, TensorRT_F8, F16, BF16, F32]>>:$inputs,
+    Variadic<TensorRT_Tensor>:$inputs,
     I32Attr:$axis
   );
   let results = (outs AnyRankedTensor:$result);
@@ -1578,10 +1578,10 @@ def TensorRT_SelectOp : TensorRT_Op<"select", [
 
   let arguments = (ins
     TensorRT_RankedTensorOf<[I1]>:$condition,
-    TensorRT_RankedTensorOf<[I1, I32, I64, F16, BF16, F32]>:$thenInput,
-    TensorRT_RankedTensorOf<[I1, I32, I64, F16, BF16, F32]>:$elseInput
+    TensorRT_Tensor:$thenInput,
+    TensorRT_Tensor:$elseInput
   );
-  let results = (outs TensorRT_RankedTensorOf<[I1, I32, I64, F16, BF16, F32]>:$result);
+  let results = (outs TensorRT_Tensor:$result);
   let assemblyFormat = "attr-dict `ins` `(` operands `:` type(operands) `)` `->` type($result)";
   let hasVerifier = 1;
   let extraClassDeclaration = [{
@@ -2725,7 +2725,7 @@ def TensorRT_ShapeOp : TensorRT_Op<"shape", [Pure,
     ```
   }];
 
-  let arguments = (ins TensorRT_RankedTensorOf<[I1, TensorRT_I8, I32, I64, TensorRT_F8, F16, BF16, F32]>:$input);
+  let arguments = (ins TensorRT_RankedTensorOf<[I1, TensorRT_I4, TensorRT_I8, I32, I64, TensorRT_F8, F16, BF16, F32]>:$input);
   let results = (outs 1DTensorOf<[I32]>:$result);
 
   let assemblyFormat = "attr-dict $input `:` type($input) `->` type($result)";


### PR DESCRIPTION
Adds input data types for various operations and updates `TensorRT_Tensor` to include I4 and F8 types.