### PR TITLE
Implements a workaround for an illegal memory access bug

### DIFF
--- a/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/TensorRT/TensorRTModule.cpp
+++ b/mlir-tensorrt/executor/lib/Runtime/Backend/Lua/Modules/TensorRT/TensorRTModule.cpp
@@ -162,7 +162,8 @@ public:
 
     StatusOr<PointerInfo> alloc = mlirtrt::runtime::allocate(
         *mTracker, PointerType::device, size, alignment,
-        stream ? std::optional<CudaStreamPtr>(stream) : std::nullopt);
+        // TODO (#590): Enable asynchrnous allocations by passing the stream:
+        std::nullopt);
     if (!alloc.isOk())
       return nullptr;
 


### PR DESCRIPTION
Works around an illegal memory access bug that is seen when allocating outputs larger than 32MB. See issue #590 for details.