### PR TITLE
Fixes a segfault when using the DLPack interface with a memref from `…

### DIFF
--- a/mlir-tensorrt/compiler/test/python/mlir_tensorrt_runtime/test_runtime_api.py
+++ b/mlir-tensorrt/compiler/test/python/mlir_tensorrt_runtime/test_runtime_api.py
@@ -78,6 +78,7 @@ def test_memref():
             print(gpu_array.strides)
             print(gpu_array.address_space)
             print(np.asarray(client.copy_to_host(gpu_array)))
+            print(np.from_dlpack(client.copy_to_host(gpu_array)))
         except Exception as e:
             print("Exception caught: ", e)
 
@@ -89,10 +90,14 @@ def test_memref():
 #  CHECK-NEXT: PointerType.device
 #  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
 #  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
+#  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
+#  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
 #  CHECK-NEXT: testing dtype float32
 #  CHECK-NEXT: [2, 8]
 #  CHECK-NEXT: [8, 1]
 #  CHECK-NEXT: PointerType.device
+#  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
+#  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
 #  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
 #  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
 #  CHECK-NEXT: testing dtype float16
@@ -101,10 +106,14 @@ def test_memref():
 #  CHECK-NEXT: PointerType.device
 #  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
 #  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
+#  CHECK-NEXT:  [ 0.  1.  2.  3.  4.  5.  6.  7.]
+#  CHECK-NEXT:  [ 8.  9. 10. 11. 12. 13. 14. 15.]]
 #  CHECK-NEXT: testing dtype int64
 #  CHECK-NEXT: [2, 8]
 #  CHECK-NEXT: [8, 1]
 #  CHECK-NEXT: PointerType.device
+#  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
+#  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 #  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
 #  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 #  CHECK-NEXT: testing dtype int32
@@ -113,16 +122,22 @@ def test_memref():
 #  CHECK-NEXT: PointerType.device
 #  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
 #  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
+#  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
+#  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 #  CHECK-NEXT: testing dtype int16
 #  CHECK-NEXT: [2, 8]
 #  CHECK-NEXT: [8, 1]
 #  CHECK-NEXT: PointerType.device
 #  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
 #  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
+#  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
+#  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 #  CHECK-NEXT: testing dtype int8
 #  CHECK-NEXT: [2, 8]
 #  CHECK-NEXT: [8, 1]
 #  CHECK-NEXT: PointerType.device
+#  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
+#  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 #  CHECK-NEXT:  [ 0  1  2  3  4  5  6  7]
 #  CHECK-NEXT:  [ 8  9 10 11 12 13 14 15]]
 

--- a/mlir-tensorrt/executor/lib/Runtime/API/API.cpp
+++ b/mlir-tensorrt/executor/lib/Runtime/API/API.cpp
@@ -1124,7 +1124,7 @@ RuntimeClient::copyToHost(const MemRefValue &deviceMemRef,
   StatusOr<std::unique_ptr<MemRefValue>> hostMemRef = MemRefValue::create(
       this, allocation->type, deviceMemRef.getElementBitWidth(),
       allocation->ptr, 0, deviceMemRef.getShape(), deviceMemRef.getStrides(),
-      nullptr, deviceMemRef.getScalarType());
+      {}, deviceMemRef.getScalarType());
   if (!hostMemRef.isOk())
     return hostMemRef.getStatus();
 


### PR DESCRIPTION
…copyToHost`

In `copyToHost`, we were previously creating a memref with the device set to `nullptr`. When trying to use the DLPack interface, this would cause a segfault.

What was really intended was to set the device to an empty optional, since a host tensor does not have an associated device. This commit updates the code to correctly create an empty optional.

Also updates the test to trigger this code path by use the DLPack interface of the created memref.