### PR TITLE
Simplifies silu, updates executables to reject tensors that are not GPU constants

### DIFF
--- a/tripy/README.md
+++ b/tripy/README.md
@@ -62,7 +62,7 @@ guide for details:
         }
     )
 
-    dummy_input = tp.ones((1, 1, 4, 4))
+    dummy_input = tp.ones((1, 1, 4, 4)).eval()
     ```
 
 - Executing in **eager mode**:

--- a/tripy/docs/post0_developer_guides/00-architecture.md
+++ b/tripy/docs/post0_developer_guides/00-architecture.md
@@ -77,7 +77,7 @@ def scale_up(inp):
 
 compiled_func = tp.compile(scale_up, args=[tp.InputInfo((2, 2), dtype=tp.float32)])
 
-inp = tp.iota((2, 2), dtype=tp.float32)
+inp = tp.iota((2, 2), dtype=tp.float32).eval()
 out = compiled_func(inp)
 ```
 

--- a/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
+++ b/tripy/docs/pre0_user_guides/00-introduction-to-tripy.md
@@ -49,7 +49,7 @@ mlp.load_state_dict({
 })
 
 # Execute:
-inp = tp.iota(shape=(1, 2), dim=1, dtype=tp.float32)
+inp = tp.iota(shape=(1, 2), dim=1, dtype=tp.float32).eval()
 out = mlp(inp)
 ```
 

--- a/tripy/docs/pre0_user_guides/02-compiler.md
+++ b/tripy/docs/pre0_user_guides/02-compiler.md
@@ -48,7 +48,7 @@ Other parameters become **compile-time constants** and will be folded away.
 The compiler returns an {class}`nvtripy.Executable`, which behaves like a callable:
 
 ```py
-inp = tp.ones((1, 2))
+inp = tp.ones((1, 2)).eval()
 out = fast_geglu(inp)
 ```
 
@@ -74,7 +74,7 @@ fast_geglu = tp.compile(layer, args=[inp_info])
 out0 = fast_geglu(inp)
 
 # Now use an input with a different shape: (2, 2):
-inp1 = tp.Tensor([[1., 2.], [2., 3.]], dtype=tp.float32)
+inp1 = tp.Tensor([[1., 2.], [2., 3.]], dtype=tp.float32).eval()
 out1 = fast_geglu(inp1)
 ```
 

--- a/tripy/examples/nanogpt/example.py
+++ b/tripy/examples/nanogpt/example.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,7 +93,7 @@ def main():
     else:
         load_quant_weights_from_hf(model, args.model_type, MODEL_DTYPE, args.quant_mode)
 
-    idx = tp.reshape(tp.Tensor(input_ids), shape=(1, len(input_ids)))
+    idx = tp.unsqueeze(tp.Tensor(input_ids), 0).eval()
 
     # Compile the model before running inference.
     print(f"Compiling the model (this may take a few seconds)...")

--- a/tripy/examples/segment-anything-model-v2/sam2/build_sam.py
+++ b/tripy/examples/segment-anything-model-v2/sam2/build_sam.py
@@ -81,6 +81,7 @@ def get_component_configs(model, cfg):
                     ((4100, 16400, 28736), (1, 2, 8), 64),
                     getattr(tp, model_precision),
                 ),
+                # TODO (#594): Remove this hack once we are able to pass in DimensionSizes directly:
                 tp.InputInfo(((4, 16, 64),), tp.int32),
             ],
             "skip_dtype_convert": ["ln", "norm"],

--- a/tripy/examples/segment-anything-model-v2/sam2/modeling/memory_attention.py
+++ b/tripy/examples/segment-anything-model-v2/sam2/modeling/memory_attention.py
@@ -192,7 +192,7 @@ class MemoryAttention(tp.Module):
         memory_pos: Optional[tp.Tensor] = None,  # pos_enc for cross-attention inputs
         num_obj_ptr_tokens: Optional[tp.Tensor] = None,  # number of object pointer *tokens*
     ):
-
+        # TODO (#594): Remove this hack once we are able to pass in DimensionSizes directly:
         num_obj_ptr_tokens = num_obj_ptr_tokens.shape[0]
         output = curr
         if self.pos_enc_at_input and curr_pos is not None:

--- a/tripy/nvtripy/backend/api/compile.py
+++ b/tripy/nvtripy/backend/api/compile.py
@@ -93,15 +93,15 @@ def compile(
             ],
         )
 
-        small_a = tp.ones((1, 2), dtype=tp.float32)
-        small_b = tp.ones((1, 2), dtype=tp.float32)
+        small_a = tp.ones((1, 2), dtype=tp.float32).eval()
+        small_b = tp.ones((1, 2), dtype=tp.float32).eval()
 
         small_out = compiled_add(small_a, small_b)
 
         # Now we can reuse the compiled function for any shapes within the
         # range:
-        big_a = tp.ones((3, 2), dtype=tp.float32)
-        big_b = tp.ones((3, 2), dtype=tp.float32)
+        big_a = tp.ones((3, 2), dtype=tp.float32).eval()
+        big_b = tp.ones((3, 2), dtype=tp.float32).eval()
 
         big_out = compiled_add(big_a, big_b)
 
@@ -122,7 +122,7 @@ def compile(
         b = tp.ones((1,), dtype=tp.float32)
         compiled_add = tp.compile(add, args=[tp.InputInfo((1,), dtype=tp.float32), b])
 
-        a = tp.ones((1,), dtype=tp.float32)
+        a = tp.ones((1,), dtype=tp.float32).eval()
 
         # Note that we cannot provide `b` as an argument to the compiled function.
         out = compiled_add(a)

--- a/tripy/nvtripy/backend/api/input_info.py
+++ b/tripy/nvtripy/backend/api/input_info.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,6 @@
 from typing import Sequence, Tuple, Union
 
 from nvtripy import export
-from nvtripy.common.exception import raise_error
 from nvtripy.common.shape_bounds import ShapeBounds
 from nvtripy.frontend.dimension_size import DimensionSize
 from nvtripy.types import IntLike

--- a/tripy/nvtripy/backend/api/stream.py
+++ b/tripy/nvtripy/backend/api/stream.py
@@ -57,7 +57,7 @@ class Stream:
             stream = tp.Stream()
             func.stream = stream
 
-            input = tp.ones((2, 2), dtype=tp.float32)
+            input = tp.ones((2, 2), dtype=tp.float32).eval()
             output = func(input)
 
             assert tp.equal(output, tp.relu(input))
@@ -84,7 +84,7 @@ class Stream:
 
             func = tp.compile(tp.relu, args=[tp.InputInfo((2, 2), dtype=tp.float32)])
 
-            input = tp.ones((2, 2), dtype=tp.float32)
+            input = tp.ones((2, 2), dtype=tp.float32).eval()
 
             func.stream = tp.Stream()
 

--- a/tripy/nvtripy/frontend/ops/unary/sigmoid.py
+++ b/tripy/nvtripy/frontend/ops/unary/sigmoid.py
@@ -32,7 +32,7 @@ def sigmoid(input: "nvtripy.Tensor") -> "nvtripy.Tensor":
     r"""
     Applies a logistic sigmoid function to each element of the input tensor:
 
-    :math:`\text{sigmoid}(x)_i = \frac{1}{1 + \exp{-x_i}}`
+    :math:`\text{sigmoid}(x)_i = \Large \frac{1}{1 + e^{-x_i}}`
 
     Args:
         input: The input tensor.

--- a/tripy/nvtripy/frontend/ops/unary/silu.py
+++ b/tripy/nvtripy/frontend/ops/unary/silu.py
@@ -23,7 +23,7 @@ from nvtripy.utils import wrappers
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={
-        "T1": ["float32", "float16", "bfloat16"],
+        "T1": ["float32", "float16", "bfloat16", "int8"],
     },
 )
 def silu(input: "nvtripy.Tensor") -> "nvtripy.Tensor":
@@ -31,9 +31,11 @@ def silu(input: "nvtripy.Tensor") -> "nvtripy.Tensor":
     Applies the Sigmoid Linear Unit (SiLU) function  to each element of the
     input tensor. This function is also known as the swish function.
 
-    :math:`\text{silu}(x) = x \cdot \sigma (x)`
-    where
-    :math:`\sigma (x)_i = \frac{1}{1 + \exp{-x_i}}`
+    :math:`\text{silu}(x) = x \cdot \text{sigmoid} (x)`
+
+    where:
+
+    :math:`\text{sigmoid} (x)_i = \Large \frac{1}{1 + e^{-x_i}}`
 
     Args:
         input: The input tensor.
@@ -44,12 +46,12 @@ def silu(input: "nvtripy.Tensor") -> "nvtripy.Tensor":
     .. code-block:: python
         :linenos:
 
-        input = tp.Tensor([1., 2., 3., 4.], dtype=tp.float32)
+        input = tp.Tensor([1., 2., 3., 4.])
         output = tp.silu(input)
 
         t = torch.tensor([1, 2, 3, 4], dtype=torch.float32) # doc: omit
         assert tp.allclose(output, tp.Tensor(torch.nn.functional.silu(t)))
     """
-    from nvtripy.frontend.ops.unary.exp import exp
+    from nvtripy.frontend.ops.unary.sigmoid import sigmoid
 
-    return input / (1.0 + exp(-1.0 * input))
+    return input * sigmoid(input)

--- a/tripy/nvtripy/frontend/tensor.py
+++ b/tripy/nvtripy/frontend/tensor.py
@@ -202,7 +202,7 @@ class Tensor(metaclass=TensorMeta):
         """
         Immediately evaluates this tensor. By default, tensors are evaluated lazily.
 
-        Note that an evaluated tensor will always reside in device memory.
+        .. note:: The evaluated tensor will always be in **GPU memory**.
 
         Returns:
             The evaluated tensor.

--- a/tripy/tests/backend/api/test_executable.py
+++ b/tripy/tests/backend/api/test_executable.py
@@ -38,13 +38,13 @@ def multiple_return_executable():
 
 class TestExecutable:
     def test_args(self, single_return_executable):
-        args = [tp.ones((2, 2), dtype=tp.float32), tp.ones((2, 2), dtype=tp.float32)]
+        args = [tp.ones((2, 2), dtype=tp.float32).eval(), tp.ones((2, 2), dtype=tp.float32).eval()]
         out = single_return_executable(*args)
 
         assert tp.allclose(out, add(*args))
 
     def test_kwargs(self, single_return_executable):
-        kwargs = {"a": tp.ones((2, 2), dtype=tp.float32), "b": tp.ones((2, 2), dtype=tp.float32)}
+        kwargs = {"a": tp.ones((2, 2), dtype=tp.float32).eval(), "b": tp.ones((2, 2), dtype=tp.float32).eval()}
         out = single_return_executable(**kwargs)
 
         assert tp.allclose(out, add(**kwargs))
@@ -113,7 +113,7 @@ class TestExecutable:
             loaded_executable = tp.Executable.load(exe_file)
             assert loaded_executable.__signature__ == single_return_executable.__signature__
 
-            inp = tp.iota((2, 2), dtype=tp.float32)
+            inp = tp.iota((2, 2), dtype=tp.float32).eval()
             out1 = single_return_executable(inp, inp)
             out2 = loaded_executable(inp, inp)
             assert tp.equal(out1, out2)
@@ -127,5 +127,5 @@ class TestExecutable:
             inp_data0 = np.random.rand(2, 2).astype(np.float32)
             inp_data1 = np.random.rand(2, 2).astype(np.float32)
             output = runner.infer(feed_dict={"arg0": inp_data0, "arg1": inp_data1})["result0"]
-            tripy_output = single_return_executable(tp.Tensor(inp_data0), tp.Tensor(inp_data1))
+            tripy_output = single_return_executable(tp.Tensor(inp_data0).eval(), tp.Tensor(inp_data1).eval())
             assert tp.equal(tripy_output, tp.Tensor(output))

--- a/tripy/tests/backend/api/test_stream.py
+++ b/tripy/tests/backend/api/test_stream.py
@@ -37,7 +37,7 @@ def test_enqueue_work_on_stream():
 
     compiled_linear = tp.compile(linear, args=[tp.InputInfo((2, 25), dtype=tp.float32)])
 
-    a = tp.ones((2, 25), dtype=tp.float32)
+    a = tp.ones((2, 25), dtype=tp.float32).eval()
 
     out = compiled_linear(a)
     tp.default_stream().synchronize()

--- a/tripy/tests/integration/conftest.py
+++ b/tripy/tests/integration/conftest.py
@@ -50,10 +50,10 @@ def eager_or_compiled(request):
 
         compiled_func = tp.compile(func, args=compile_args, kwargs=compile_kwargs)
 
-        tensor_args = tuple(x for x in args if isinstance(x, tp.Tensor) and not isinstance(x, tp.DimensionSize))
+        tensor_args = tuple(x.eval() for x in args if isinstance(x, tp.Tensor) and not isinstance(x, tp.DimensionSize))
 
         tensor_kwargs = {
-            k: v for k, v in kwargs.items() if isinstance(v, tp.Tensor) and not isinstance(v, tp.DimensionSize)
+            k: v.eval() for k, v in kwargs.items() if isinstance(v, tp.Tensor) and not isinstance(v, tp.DimensionSize)
         }
 
         return compiled_func(*tensor_args, **tensor_kwargs)

--- a/tripy/tests/integration/test_plugin.py
+++ b/tripy/tests/integration/test_plugin.py
@@ -42,12 +42,12 @@ class TestPlugin:
 
         compiled_gelu = tp.compile(gelu, args=[tp.InputInfo((2, (1, 2, 3), 4), dtype=tp.float32)])
 
-        inp = tp.iota((2, 1, 4))
+        inp = tp.iota((2, 1, 4)).eval()
         out = compiled_gelu(inp)
         assert out.shape == inp.shape
         assert tp.allclose(out, tp.gelu(inp), atol=0.001)
 
-        new_inp = tp.ones((2, 2, 4), dtype=tp.float32)
+        new_inp = tp.ones((2, 2, 4), dtype=tp.float32).eval()
         out = compiled_gelu(new_inp)
         assert out.shape == new_inp.shape
         assert tp.allclose(out, tp.gelu(new_inp), atol=0.001)


### PR DESCRIPTION
[Updates sigmoid/silu documentation, simplifies silu implementation](https://github.com/NVIDIA/TensorRT-Incubator/commit/337e92996c2516dc8a95498fe58abe7ed9c7b7dd)

[Updates executables to reject tensors that are not GPU constants.](https://github.com/NVIDIA/TensorRT-Incubator/commit/d735115f79461b294123e1fe444104401b38e9e4)