### PR TITLE
Adds an API to get the stream pointer

### DIFF
--- a/mlir-tensorrt/compiler/test/python/mlir_tensorrt_runtime/test_runtime_api.py
+++ b/mlir-tensorrt/compiler/test/python/mlir_tensorrt_runtime/test_runtime_api.py
@@ -215,6 +215,18 @@ def test_devices():
 # CHECK-LABEL: Test: test_devices
 #  CHECK-NEXT: Device name: cuda:0
 
+
+@make_test
+def test_stream():
+    client = runtime.RuntimeClient()
+    stream = client.create_stream()
+
+    assert isinstance(stream.ptr, int)
+
+
+# CHECK-LABEL: Test: test_stream
+
+
 if __name__ == "__main__":
     for t in TESTS:
         t()

--- a/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
+++ b/mlir-tensorrt/executor/include/mlir-executor-c/Runtime/Runtime.h
@@ -110,6 +110,10 @@ MLIR_CAPI_EXPORTED MTRT_Status mtrtStreamDestroy(MTRT_Stream stream);
 MLIR_CAPI_EXPORTED void
 mtrtStreamPrint(MTRT_Stream stream, MlirStringCallback append, void *userData);
 
+/// Retrieves the pointer to the underlying CUDA stream.
+MLIR_CAPI_EXPORTED MTRT_Status mtrtStreamGetPointer(MTRT_Stream stream,
+                                                    uintptr_t *ptr);
+
 //===----------------------------------------------------------------------===//
 // MTRT_Device
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
+++ b/mlir-tensorrt/executor/lib/CAPI/Runtime/Runtime.cpp
@@ -36,6 +36,7 @@
 
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/ErrorHandling.h"
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #ifdef MLIR_EXECUTOR_ENABLE_CUDA
@@ -313,6 +314,12 @@ mtrtStreamPrint(MTRT_Stream stream, MlirStringCallback append, void *userData) {
   std::stringstream ss;
   ss << std::hex << reinterpret_cast<uintptr_t>(unwrap(stream)->getRawStream());
   printStream << "CUDA Stream @ 0x" << ss.str();
+}
+
+MLIR_CAPI_EXPORTED MTRT_Status mtrtStreamGetPointer(MTRT_Stream stream,
+                                                    uintptr_t *ptr) {
+  *ptr = reinterpret_cast<uintptr_t>(unwrap(stream)->getRawStream());
+  return mtrtStatusGetOk();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
+++ b/mlir-tensorrt/python/bindings/Runtime/RuntimePyBind.cpp
@@ -660,15 +660,22 @@ PYBIND11_MODULE(_api, m) {
              MTRT_Status s = mtrtStreamSynchronize(stream);
              THROW_IF_MTRT_ERROR(s);
            })
-      .def("__str__", [](PyStream &self) {
-        auto callback = [](MlirStringRef data, void *initialString) {
-          *reinterpret_cast<std::string *>(initialString) +=
-              llvm::StringRef(data.data, data.length);
-        };
+      .def("__str__",
+           [](PyStream &self) {
+             auto callback = [](MlirStringRef data, void *initialString) {
+               *reinterpret_cast<std::string *>(initialString) +=
+                   llvm::StringRef(data.data, data.length);
+             };
 
-        std::string result;
-        mtrtStreamPrint(self, callback, &result);
-        return result;
+             std::string result;
+             mtrtStreamPrint(self, callback, &result);
+             return result;
+           })
+      .def_property_readonly("ptr", [](PyStream &self) {
+        uintptr_t ptr;
+        MTRT_Status s = mtrtStreamGetPointer(self, &ptr);
+        THROW_IF_MTRT_ERROR(s);
+        return ptr;
       });
 
   py::class_<PyRuntimeClient>(m, "RuntimeClient", py::module_local())

--- a/mlir-tensorrt/tensorrt/test/lib/Target/TestPlugins.cpp
+++ b/mlir-tensorrt/tensorrt/test/lib/Target/TestPlugins.cpp
@@ -311,7 +311,7 @@ public:
 
   virtual ~SymExpr() {}
 
-  void *getExpr() override {
+  void *getExpr() noexcept override {
     return const_cast<void *>(static_cast<const void *>(expr));
   }
 


### PR DESCRIPTION
Adds an API to the stream wrapper to get a pointer to the underlying CUDA stream. This is useful for interoperating with other CUDA libraries.