### PR TITLE
Speeds up Tensor.__init__ in certain cases, optimizes Constant.__init__

### DIFF
--- a/tripy/nvtripy/backend/api/executable.py
+++ b/tripy/nvtripy/backend/api/executable.py
@@ -251,7 +251,7 @@ class Executable:
                             )
             raise_error(str(err))
 
-        output_tensors = tuple(Tensor.fast_init(output_memref) for output_memref in output_memrefs)
+        output_tensors = tuple(Tensor(output_memref) for output_memref in output_memrefs)
         if self.__signature__.return_annotation == Tensor:
             output_tensors = output_tensors[0]
         return output_tensors

--- a/tripy/nvtripy/trace/tensor.py
+++ b/tripy/nvtripy/trace/tensor.py
@@ -36,7 +36,7 @@ class TraceTensor:
     # Indicates the shape of the tensor. Unknown dimensions are indicated by DYNAMIC_DIM.
     # Generally, the shape will only be known for shape tensors.
     shape: Tuple[int] = field(default=None, init=False)
-    stack_info: StackInfo = field(default_factory=lambda: StackInfo([]), init=False)
+    stack_info: StackInfo = field(default=None, init=False)
 
     # Whether this tensor was constructed in order to trace a computation graph for the compiler.
     is_compile_tracer: bool = False

--- a/tripy/tests/utils/wrappers/test_interface.py
+++ b/tripy/tests/utils/wrappers/test_interface.py
@@ -68,7 +68,7 @@ class TestDtypes:
             sequence_func([tp.ones((2, 2), dtype=tp.float32), tp.ones((2, 2), dtype=tp.int32)])
 
 
-STACK_DEPTH_OF_CALLER = 5
+STACK_DEPTH_OF_CALLER = 3
 
 
 class TestTensorConversion:


### PR DESCRIPTION
Speeds up `Tensor.__init__` if the input data is a DLPack tensor and no cast/copy is needed. This usage of the constructor is often seen in runtime code that interoperates with frameworks, and so we want to minimze any overheads introduced by Tripy.

This change disables the function registry dispatch logic for `__init__` and enables a fast path that skips fetching stack information. Also drops the explicit `fast_init` constructor since we now automatically determine when the fast path can be used.

Also optimizes `Constant.__init__` with a custom implementation that avoids the overheads of the more general parent constructor.