### PR TITLE
Various improvements to SAMv2 demo

### DIFF
--- a/tripy/CONTRIBUTING.md
+++ b/tripy/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Thanks for your interest in contributing to Tripy!
         2. Pull and launch the container. From the [`tripy` root directory](.), run:
 
             ```bash
-            docker run --pull always --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
+            docker run --pull always --gpus all -it --cap-add=SYS_PTRACE -p 8080:8080 -v $(pwd):/tripy/ --rm ghcr.io/nvidia/tensorrt-incubator/tripy
             ```
 
     - If you made changes to the container
@@ -34,7 +34,7 @@ Thanks for your interest in contributing to Tripy!
 
         ```bash
         docker build -t tripy .
-        docker run --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ --rm tripy:latest
+        docker run --gpus all -it --cap-add=SYS_PTRACE -p 8080:8080 -v $(pwd):/tripy/ --rm tripy:latest
         ```
 
 3. **[Optional]** Run a sanity check in the container:
@@ -159,7 +159,7 @@ The Tripy container includes a build of MLIR-TensorRT, but in some cases, you ma
 
 2. Launch the container with mlir-tensorrt repository mapped for accessing wheels files; from the [`tripy` root directory](.), run:
     ```bash
-    docker run --gpus all -it -p 8080:8080 -v $(pwd):/tripy/ -v $(pwd)/../mlir-tensorrt:/mlir-tensorrt  --rm tripy:latest
+    docker run --gpus all -it --cap-add=SYS_PTRACE -p 8080:8080 -v $(pwd):/tripy/ -v $(pwd)/../mlir-tensorrt:/mlir-tensorrt  --rm tripy:latest
     ```
 
 3. Install MLIR-TensorRT wheels

--- a/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_l.yaml
+++ b/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_l.yaml
@@ -62,6 +62,7 @@ model:
   memory_encoder:
       _target_: sam2.modeling.memory_encoder.MemoryEncoder
       out_dim: 64
+      dtype: float16
       position_encoding:
         _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
         num_pos_feats: 64
@@ -73,6 +74,7 @@ model:
         kernel_size: 3
         stride: 2
         padding: 1
+        dtype: float16
       fuser:
         _target_: sam2.modeling.memory_encoder.Fuser
         layer:
@@ -82,6 +84,7 @@ model:
           padding: 3
           layer_scale_init_value: 1e-6
           use_dwconv: True  # depth-wise convs
+          dtype: float16
         num_layers: 2
 
   num_maskmem: 7

--- a/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_s.yaml
+++ b/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_s.yaml
@@ -63,6 +63,7 @@ model:
   memory_encoder:
       _target_: sam2.modeling.memory_encoder.MemoryEncoder
       out_dim: 64
+      dtype: float16
       position_encoding:
         _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
         num_pos_feats: 64
@@ -74,6 +75,7 @@ model:
         kernel_size: 3
         stride: 2
         padding: 1
+        dtype: float16
       fuser:
         _target_: sam2.modeling.memory_encoder.Fuser
         layer:
@@ -83,6 +85,7 @@ model:
           padding: 3
           layer_scale_init_value: 1e-6
           use_dwconv: True  # depth-wise convs
+            dtype: float16
         num_layers: 2
 
   num_maskmem: 7

--- a/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_t.yaml
+++ b/tripy/examples/segment-anything-model-v2/configs/sam2_hiera_t.yaml
@@ -63,6 +63,7 @@ model:
   memory_encoder:
       _target_: sam2.modeling.memory_encoder.MemoryEncoder
       out_dim: 64
+      dtype: float16
       position_encoding:
         _target_: sam2.modeling.position_encoding.PositionEmbeddingSine
         num_pos_feats: 64
@@ -74,6 +75,7 @@ model:
         kernel_size: 3
         stride: 2
         padding: 1
+        dtype: float16
       fuser:
         _target_: sam2.modeling.memory_encoder.Fuser
         layer:
@@ -83,6 +85,7 @@ model:
           padding: 3
           layer_scale_init_value: 1e-6
           use_dwconv: True  # depth-wise convs
+            dtype: float16
         num_layers: 2
 
   num_maskmem: 7

--- a/tripy/examples/segment-anything-model-v2/sam2/modeling/backbones/image_encoder.py
+++ b/tripy/examples/segment-anything-model-v2/sam2/modeling/backbones/image_encoder.py
@@ -56,7 +56,6 @@ class ImageEncoder(tp.Module):
         # Forward through backbone
         if self.compiled_executable:
             features_pos = list(self.compiled_executable(sample))
-            tp.default_stream().synchronize()
         else:
             features_pos = self.forward_impl(sample)
         for i in range(len(features_pos)):

--- a/tripy/examples/segment-anything-model-v2/video_demo.py
+++ b/tripy/examples/segment-anything-model-v2/video_demo.py
@@ -23,17 +23,17 @@
 # limitations under the License.
 
 import argparse
-import torch
-from sam2.build_sam import build_sam2_video_predictor
-import numpy as np
-import matplotlib.pyplot as plt
-from PIL import Image
-from demo_utils import process_and_show_mask as show_mask
-from typing import Optional
-
 import os
 import time
+from typing import Optional
 
+import matplotlib.pyplot as plt
+import numpy as np
+import nvtripy as tp
+import torch
+from demo_utils import process_and_show_mask as show_mask
+from PIL import Image
+from sam2.build_sam import build_sam2_video_predictor
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -187,4 +187,7 @@ def main(video_dir: str, save_path: Optional[str] = None):
 
 
 if __name__ == "__main__":
-    main("./bedroom", save_path="output")
+    # Ensure all work is done on the default Tripy stream
+    stream = torch.cuda.get_stream_from_external(tp.default_stream().ptr, device=torch.device("cuda"))
+    with torch.cuda.stream(stream):
+        main("./bedroom", save_path="output")

--- a/tripy/nvtripy/__init__.py
+++ b/tripy/nvtripy/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 # Import TensorRT to make sure all dependent libraries are loaded first.
 import tensorrt

--- a/tripy/nvtripy/backend/api/stream.py
+++ b/tripy/nvtripy/backend/api/stream.py
@@ -31,11 +31,8 @@ class Stream:
     This class is a wrapper around the underlying stream object, allowing management of CUDA streams.
     """
 
-    def __init__(self, priority: int = 0) -> None:
+    def __init__(self) -> None:
         """
-        Args:
-            priority : Assign priority for the new stream. Lower number signifies higher priority.
-
         .. code-block:: python
             :linenos:
             :caption: Creating New Streams
@@ -62,11 +59,6 @@ class Stream:
 
             assert tp.equal(output, tp.relu(input))
         """
-        if priority != 0:
-            raise_error(
-                "Incorrect stream priority",
-                [f"Stream priority can only be 0 until #172 is fixed, got priority={priority}."],
-            )
         from nvtripy.backend.mlir.utils import MLIRRuntimeClient
 
         self._active_cuda_stream = MLIRRuntimeClient().create_stream()
@@ -110,6 +102,23 @@ class Stream:
 
     def __hash__(self):
         return hash(id(self))
+
+    @property
+    def ptr(self) -> int:
+        """
+        Returns a pointer to the underlying CUDA stream.
+
+        Returns:
+            A pointer to the underlying CUDA stream.
+
+        .. code-block:: python
+            :linenos:
+            :caption: Retrieving The Default Stream
+
+            stream = tp.Stream()
+            stream_ptr = stream.ptr
+        """
+        return self._active_cuda_stream.ptr
 
 
 @export.public_api(document_under="compiling_code/stream.rst")

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -8,8 +8,8 @@ requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 dependencies = [
   "tensorrt>=10.11",
-  "mlir-tensorrt-compiler==0.1.41+cuda12.trt109",
-  "mlir-tensorrt-runtime==0.1.41+cuda12.trt109",
+  "mlir-tensorrt-compiler==0.1.42+cuda12.trt109",
+  "mlir-tensorrt-runtime==0.1.42+cuda12.trt109",
   "colored==2.2.3",
 ]
 

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 dependencies = [
-  "tensorrt>=10.9",
+  "tensorrt>=10.11",
   "mlir-tensorrt-compiler==0.1.41+cuda12.trt109",
   "mlir-tensorrt-runtime==0.1.41+cuda12.trt109",
   "colored==2.2.3",

--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nvtripy"
-version = "0.1.1"
+version = "0.1.2"
 authors = [{ name = "NVIDIA", email = "svc_tensorrt@nvidia.com" }]
 description = "Tripy: A Python Programming Model For TensorRT"
 readme = "README.md"
@@ -8,8 +8,8 @@ requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 dependencies = [
   "tensorrt>=10.9",
-  "mlir-tensorrt-compiler==0.1.40+cuda12.trt109",
-  "mlir-tensorrt-runtime==0.1.40+cuda12.trt109",
+  "mlir-tensorrt-compiler==0.1.41+cuda12.trt109",
+  "mlir-tensorrt-runtime==0.1.41+cuda12.trt109",
   "colored==2.2.3",
 ]
 

--- a/tripy/tests/backend/api/test_stream.py
+++ b/tripy/tests/backend/api/test_stream.py
@@ -27,7 +27,9 @@ def test_new_streams():
     stream1 = tp.Stream()
     stream2 = tp.Stream()
     assert stream1 != stream2
+    assert stream1.ptr != stream2.ptr
     assert stream1 != tp.default_stream()
+    assert stream1.ptr != tp.default_stream().ptr
 
 
 def test_enqueue_work_on_stream():


### PR DESCRIPTION
Adds `--cap-add=SYS_PTRACE` to docker commands so that `gdb` can be used with child processes in the container.

Removes unnecessary stream synchronize in SAMv2 demo.