### PR TITLE
[mlir-tensorrt] Update CI to save cache after build

### DIFF
--- a/.github/workflows/mlir-tensorrt-ci.yml
+++ b/.github/workflows/mlir-tensorrt-ci.yml
@@ -112,10 +112,10 @@ jobs:
           mkdir -p ${{ github.workspace }}/ccache
           mkdir -p ${{ github.workspace }}/.cache.cpm
 
-      # Create cache action
-      - name: Create cache action
-        id: core-build-cache
-        uses: actions/cache@v4
+      # Restore cache, if exists.
+      - name: Restore cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-mlir-tensorrt-cache-${{ hashFiles('mlir-tensorrt/**/*.cpp', 'mlir-tensorrt/**/*.h', 'mlir-tensorrt/build_tools/**/*') }}
           restore-keys: |
@@ -125,8 +125,30 @@ jobs:
             ${{ github.workspace }}/.cache.cpm/*
             !${{ github.workspace }}/.cache.cpm/tensorrt
 
-      # Run LIT tests with TensorRT 10
-      - name: Run MLIR-TensorRT lit tests with TensorRT 10
+      # TensorRT 10 tests
+      - name: TensorRT 10 build
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.DEFAULT_IMAGE }}
+          options: -v ${{ github.workspace }}/mlir-tensorrt:/mlir-tensorrt -v ${{ github.workspace }}/ccache:/ccache -v ${{ github.workspace }}/.cache.cpm:/.cache.cpm --gpus all
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            cd mlir-tensorrt
+            ./build_tools/scripts/cicd_build.sh --build_only
+
+      - name: Save cache
+        id: save-cache
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ runner.os }}-mlir-tensorrt-cache-${{ hashFiles('mlir-tensorrt/**/*.cpp', 'mlir-tensorrt/**/*.h', 'mlir-tensorrt/build_tools/**/*') }}
+          path: |
+            ${{ github.workspace }}/ccache
+            ${{ github.workspace }}/.cache.cpm/*
+            !${{ github.workspace }}/.cache.cpm/tensorrt
+
+      - name: TensorRT 10 test
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEFAULT_IMAGE }}
@@ -138,8 +160,8 @@ jobs:
             cd mlir-tensorrt
             ./build_tools/scripts/cicd_build.sh
 
-      # Run LIT tests with TensorRT 10 & ASAN
-      - name: Run MLIR-TensorRT lit tests with TensorRT 10, ASAN enabled
+      # TensorRT 10 & ASAN
+      - name: TensorRT 10 ASAN test
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.DEFAULT_IMAGE }}

--- a/mlir-tensorrt/build_tools/scripts/cicd_build.sh
+++ b/mlir-tensorrt/build_tools/scripts/cicd_build.sh
@@ -2,6 +2,23 @@
 set -ex
 set -o pipefail
 
+# Parse command line arguments
+BUILD_ONLY=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --build_only)
+      BUILD_ONLY=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--build_only]"
+      echo "  --build_only: Only build, skip tests"
+      exit 1
+      ;;
+  esac
+done
+
 REPO_ROOT=$(pwd)
 BUILD_DIR="${REPO_ROOT}/build"
 export LLVM_LIT_ARGS=${LLVM_LIT_ARGS:-"-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --timeout=1200 --time-tests -Drun_long_tests=${RUN_LONG_TESTS}"}
@@ -17,5 +34,12 @@ rm -rf ${BUILD_DIR}  || true
 
 cmake -B${BUILD_DIR} --preset github-cicd
 
-ninja -C ${BUILD_DIR} -k 0 check-all-mlir-tensorrt
+if [[ "$BUILD_ONLY" == "true" ]]; then
+  echo "🔨 Building only (skipping tests)..."
+  ninja -C ${BUILD_DIR} -k 0 all
+else
+  echo "🔨🧪 Building and testing..."
+  ninja -C ${BUILD_DIR} -k 0 check-all-mlir-tensorrt
+fi
+
 ccache --show-stats || true


### PR DESCRIPTION
This PR updates mlir-tensorrt CI to save cache after each (normal and ASAN) build. Previously, cache was being saved at the end of job but this is problematic when build needs to run again (which takes long time!) just because of single test failure.
Now, `cicd_build.sh` script is separated in build and test phases. Cache is saved immediately after build. This way, even when test fails, next build is faster.