### PR TITLE
Add text option to sphinx-build and update pyproject.toml dependencies

### DIFF
--- a/tripy/pyproject.toml
+++ b/tripy/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "tensorrt>=10.11",
   "mlir-tensorrt-compiler==0.1.42+cuda12.trt109",
   "mlir-tensorrt-runtime==0.1.42+cuda12.trt109",
-  "colored==2.2.3",
+  "colored==2.3.0",
 ]
 
 [project.urls]
@@ -21,20 +21,20 @@ Documentation = "https://nvidia.github.io/TensorRT-Incubator/"
 
 [build-system]
 requires = [
-  "setuptools==75.3.0",
-  "wheel==0.44.0",
+  "setuptools==80.9.0",
+  "wheel==0.45.1",
   # For stubgen:
-  "mypy==1.11.0",
+  "mypy==1.16.1",
 ]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-dev = ["pre-commit==3.6.0"]
+dev = ["pre-commit==4.2.0"]
 build = [
-  "setuptools==75.3.0",
-  "wheel==0.44.0",
+  "setuptools==80.9.0",
+  "wheel==0.45.1",
   # For stubgen:
-  "mypy==1.11.0",
+  "mypy==1.16.1",
 ]
 doc_test_common = [
   "black==24.10.0",
@@ -45,38 +45,38 @@ doc_test_common = [
   "cupy-cuda12x",
 ]
 docs = [
-  "sphinx==7.2.6",
+  "sphinx==7.4.7",
   "furo==2024.8.6",
   "sphinx-copybutton==0.5.2",
-  "sphinx-toolbox==3.5.0",
-  "docutils==0.20.1",
-  "myst-parser==2.0.0",
-  "sphinxcontrib-mermaid==0.9.2",
+  "sphinx-toolbox==4.0.0",
+  "docutils==0.21.2",
+  "myst-parser==3.0.1",
+  "sphinxcontrib-mermaid==1.0.0",
   "nvtripy[doc_test_common]",
   # Needed for guides:
-  "nvidia-modelopt==0.11.1",
-  "transformers==4.44.2",
-  "datasets==2.21.0",
+  "nvidia-modelopt==0.29.0",
+  "transformers==4.46.2",
+  "datasets==3.6.0",
 ]
 test = [
-  "pytest==7.1.3",
-  "pytest-virtualenv==1.8.0",
-  "pytest-profiling==1.7.0",
-  "pytest-cov==4.1.0",
-  "pytest-xdist==3.6.1",
-  "pytest-benchmark==4.0.0",
+  "pytest==8.4.1",
+  "pytest-virtualenv==1.8.1",
+  "pytest-profiling==1.8.1",
+  "pytest-cov==6.2.1",
+  "pytest-xdist==3.8.0",
+  "pytest-benchmark==5.1.0",
   "pytest-lazy-fixture==0.6.3",
-  "pytest-mock==3.14.0",
+  "pytest-mock==3.14.1",
   "path.py==12.5.0",
   # Triton is required for torch.compile
   "triton==3.0.0",
-  "snakeviz==2.2.0",
-  "coverage==7.4.1",
-  "vulture==2.11",
+  "snakeviz==2.2.2",
+  "coverage==7.9.2",
+  "vulture==2.14",
   "nvtripy[doc_test_common]",
   "pytest-notebook==0.10.0",
-  "notebook==7.2.2",
-  "polygraphy==0.49.20",
+  "notebook==7.4.4",
+  "polygraphy==0.49.24",
 ]
 
 [tool.black]


### PR DESCRIPTION
Documentation building with text mode before this resulted in an error due to `CollapseNodes`. This changes should add support for `CollapseNodes` with text build option while not interfering with the html build option. Part of this change also updates some of the dependencies, particularly sphinx-build and sphinx-toolboox which had some bugs when building documentation with different build options.