### PR TITLE
[TensorRT] Sets TRT layer metadata and nvtx profiling verbosity

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
@@ -51,6 +51,9 @@ def TensorRT_Dialect : Dialect {
     static constexpr StringRef kTensorRTPerTensorDequantizationMarker = "tensorrt.pt_dq";
     static constexpr StringRef kTensorRTPerChannelDequantizationMarker = "tensorrt.pc_dq";
     static constexpr StringRef kTensorRTBlockDequantizationMarker = "tensorrt.block_dq";
+
+    /// TensorRT layer metadata markder.
+    static constexpr StringRef kTensorRTLayerMetadataMarker = "metadata";
   }];
 
   let dependentDialects = [

--- a/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
@@ -278,6 +278,10 @@ void NvInferNetworkEncoder::setMetadata(nvinfer1::ILayer *layer,
                                         Operation *sourceOp) {
   std::string name = createName(namesSet, sourceOp);
   layer->setName(name.c_str());
+  if (auto metadataAttr = sourceOp->getAttrOfType<StringAttr>(
+          TensorRTDialect::kTensorRTLayerMetadataMarker)) {
+    layer->setMetadata(metadataAttr.getValue().str().c_str());
+  }
 }
 
 nvinfer1::ITensor *NvInferNetworkEncoder::lookup(Value v) const {

--- a/mlir-tensorrt/tensorrt/lib/Target/TranslateToTensorRT.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TranslateToTensorRT.cpp
@@ -522,11 +522,10 @@ tensorrt::buildFunction(mlir::FunctionOpInterface op,
              << "failed to set timing cache";
   }
 
-  // If created, engines and their layer information are
-  // with detailed description.
-  if (!opts.saveTensorRTEnginesToDirectory.empty() ||
-      !opts.saveTensorRTLayerInfoDirectory.empty())
-    config->setProfilingVerbosity(nvinfer1::ProfilingVerbosity::kDETAILED);
+  // Enable kDETAILED verbosity unconditionally, then use
+  // `IExecutionContext::setNvtxVerbosity` to change the verbosity at runtime
+  // (lower verbosity performs better generally).
+  config->setProfilingVerbosity(nvinfer1::ProfilingVerbosity::kDETAILED);
 
   setBuilderOptimizationLevel(config.get(), opts.tensorrtBuilderOptLevel,
                               builderContext.getTensorRTVersion());


### PR DESCRIPTION
For now we query an environment variable `MTRT_TENSORRT_NVTX` to set the nvtx profiling verbosity. This is not ideal because it cannot support per-engine profiling verbosity. We will change that with a runtime option for TRT module.