### PR TITLE
[mlir-tensorrt docker] Add docker build file to make it easier to build the project

### DIFF
--- a/mlir-tensorrt/docker/Dockerfile
+++ b/mlir-tensorrt/docker/Dockerfile
@@ -1,0 +1,62 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+ARG BASE_IMG=ubuntu:24.04
+FROM ${BASE_IMG} AS dev-base
+
+# Specify user IDs
+ARG GROUP
+ARG GID
+ARG USER
+ARG UID
+
+# Run below commands as root
+USER root
+
+# Install packages
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -P /tmp/ && \
+    dpkg -i /tmp/cuda-keyring_1.1-1_all.deb && \
+    rm /tmp/cuda-keyring_1.1-1_all.deb
+
+RUN apt-get update && \
+    apt-get install -y \
+    lld \
+    clang \
+    clang-format \
+    gdb \
+    black \
+    python3-dev \
+    cmake \
+    sudo \
+    vim \
+    ninja-build \
+    patch \
+    pybind11-dev \
+    git \
+    libnccl-dev \
+    libopenmpi-dev \
+    openmpi-bin \
+    python3-pip \
+    python3-pynvml \
+    python3-numpy \
+    python3-psutil \
+    cuda-toolkit-12 && \
+    pip install --break-system-packages nanobind cupy-cuda12x
+
+
+# Set workdir before launching container
+WORKDIR /opt/src/mlir-tensorrt
+
+# Add user permissions
+RUN groupadd -o -g ${GID} ${GROUP} && \
+    useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
+    usermod -aG sudo ${USER} && \
+    chown -R ${USER}:${GROUP} /opt/src/mlir-tensorrt && \
+    echo "${USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Switch to user
+USER ${USER}

--- a/mlir-tensorrt/docker/run_docker.sh
+++ b/mlir-tensorrt/docker/run_docker.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+set -ex
+
+docker build -f ${SCRIPT_DIR}/Dockerfile \
+             -t mlir-tensorrt:dev \
+             --build-arg GROUP=$(id -gn) \
+             --build-arg GID=$(id -g) \
+             --build-arg USER=$(id -un) \
+             --build-arg UID=$(id -u) \
+             .
+
+docker run -it \
+           -v "${SCRIPT_DIR}/../":"/opt/src/mlir-tensorrt" \
+           --gpus all \
+           mlir-tensorrt:dev


### PR DESCRIPTION
This PR adds a `Dockerfile` and a `run_docker.sh` shell script to create an environment for building the mlir-tensorrt project.

Note: the mlir-tensorrt project does not build on ubuntu 25.04 out of the box currently due to new error messages from the newer version of clang.  Similarly, mlir-tensorrt does not build on ubuntu 24.04 as it requires a newer version of cuda-toolkit than was is installed in ubuntu by default.  Additionally, there are are a number of dependencies that are required that I did not see listed in a central location.