### PR TITLE
Add tensor methods for cast, copy, and shape manipulation ops

### DIFF
--- a/tripy/nvtripy/frontend/ops/cast.py
+++ b/tripy/nvtripy/frontend/ops/cast.py
@@ -20,12 +20,14 @@ from nvtripy import export
 from nvtripy.common.datatype import bool as tp_bool
 from nvtripy.common.datatype import float32, int8
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.frontend.ops.dequantize import dequantize
 from nvtripy.frontend.ops.quantize import quantize
 from nvtripy.trace.ops.cast import Cast
 from nvtripy.utils import wrappers
 
 
+@register_tensor_method("cast")
 @export.public_api(document_under="operations/functions")
 @wrappers.interface(
     dtype_constraints={"input": "T1", "dtype": "T2", wrappers.RETURN_VALUE: "T2"},

--- a/tripy/nvtripy/frontend/ops/copy.py
+++ b/tripy/nvtripy/frontend/ops/copy.py
@@ -21,10 +21,12 @@ from nvtripy.backend.mlir.utils import MLIRRuntimeClient
 from nvtripy.common import device as tp_device
 from nvtripy.common.datatype import DATA_TYPES
 from nvtripy.common.exception import raise_error
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("copy")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": list(DATA_TYPES.keys())},

--- a/tripy/nvtripy/frontend/ops/flatten.py
+++ b/tripy/nvtripy/frontend/ops/flatten.py
@@ -17,10 +17,12 @@ import math
 from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("flatten")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int4", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/ops/permute.py
+++ b/tripy/nvtripy/frontend/ops/permute.py
@@ -20,11 +20,13 @@ from typing import Sequence
 from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.trace.ops.permute import Permute
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("permute")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int4", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/ops/reshape.py
+++ b/tripy/nvtripy/frontend/ops/reshape.py
@@ -20,6 +20,7 @@ import math
 from nvtripy import export
 from nvtripy.common.exception import raise_error
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.trace.ops.reshape import Reshape
 from nvtripy.types import ShapeLike
 from nvtripy.utils import wrappers
@@ -43,6 +44,7 @@ def infer_dimensions(input: "nvtripy.Tensor", shape: ShapeLike) -> ShapeLike:
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("reshape")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int4", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/ops/squeeze.py
+++ b/tripy/nvtripy/frontend/ops/squeeze.py
@@ -16,10 +16,12 @@ from typing import Sequence, Union
 
 from nvtripy import export, utils
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("squeeze")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/ops/transpose.py
+++ b/tripy/nvtripy/frontend/ops/transpose.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 from nvtripy import export
 from nvtripy.common.exception import raise_error
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("transpose")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/ops/unsqueeze.py
+++ b/tripy/nvtripy/frontend/ops/unsqueeze.py
@@ -17,10 +17,12 @@
 
 from nvtripy import export
 from nvtripy.frontend.ops import utils as op_utils
+from nvtripy.frontend.ops._registry import register_tensor_method
 from nvtripy.utils import wrappers
 
 
 @export.public_api(document_under="operations/functions")
+@register_tensor_method("unsqueeze")
 @wrappers.interface(
     dtype_constraints={"input": "T1", wrappers.RETURN_VALUE: "T1"},
     dtype_variables={"T1": ["float32", "float16", "bfloat16", "int8", "int32", "int64", "bool"]},

--- a/tripy/nvtripy/frontend/tensor.py
+++ b/tripy/nvtripy/frontend/tensor.py
@@ -125,6 +125,11 @@ class Tensor(metaclass=TensorMeta):
         return instance
 
     def __getattr__(self, name: str):
+        if name in TENSOR_METHOD_REGISTRY:
+            import types
+
+            return types.MethodType(TENSOR_METHOD_REGISTRY[name], self)
+
         import nvtripy as tp
         from nvtripy.common.exception import search_for_missing_attr
 

--- a/tripy/tests/integration/test_flatten.py
+++ b/tripy/tests/integration/test_flatten.py
@@ -17,17 +17,19 @@ import cupy as cp
 import pytest
 import nvtripy as tp
 
+test_cases = [
+    ((2, 3, 4), 0, -1, (24,)),  # Flatten all dimensions
+    ((2, 3, 4), 1, -1, (2, 12)),  # Flatten dimensions 1 through end
+    ((2, 3, 4), 1, 2, (2, 12)),  # Flatten dimensions 1 through 2
+    ((2, 3, 4), 0, 1, (6, 4)),  # Flatten dimensions 0 through 1
+    ((2, 3, 4, 5), 1, 3, (2, 60)),  # Flatten dimensions 1 through 3
+]
+
 
 class TestFlatten:
     @pytest.mark.parametrize(
         "shape, start_dim, end_dim, expected_shape",
-        [
-            ((2, 3, 4), 0, -1, (24,)),  # Flatten all dimensions
-            ((2, 3, 4), 1, -1, (2, 12)),  # Flatten dimensions 1 through end
-            ((2, 3, 4), 1, 2, (2, 12)),  # Flatten dimensions 1 through 2
-            ((2, 3, 4), 0, 1, (6, 4)),  # Flatten dimensions 0 through 1
-            ((2, 3, 4, 5), 1, 3, (2, 60)),  # Flatten dimensions 1 through 3
-        ],
+        test_cases,
     )
     def test_flatten(self, shape, start_dim, end_dim, expected_shape, eager_or_compiled):
         cp_a = cp.arange(np.prod(shape)).reshape(shape).astype(np.float32)
@@ -55,3 +57,15 @@ class TestFlatten:
         a = tp.ones((2, 3, 4, 5))
         b = eager_or_compiled(tp.flatten, a, start_dim=1, end_dim=-1)
         assert np.array_equal(cp.from_dlpack(b).get(), np.ones((2, 60), dtype=np.float32))
+
+    @pytest.mark.parametrize(
+        "shape, start_dim, end_dim, expected_shape",
+        test_cases,
+    )
+    def test_flatten_tensor_method(self, shape, start_dim, end_dim, expected_shape, eager_or_compiled):
+        """Test that tensor.flatten() method works and produces same result as free function."""
+        cp_a = cp.arange(np.prod(shape)).reshape(shape).astype(np.float32)
+        a = tp.Tensor(cp_a)
+        b = eager_or_compiled(lambda t: t.flatten(start_dim=start_dim, end_dim=end_dim), a)
+        assert b.shape == expected_shape
+        assert np.array_equal(cp.from_dlpack(b).get(), cp_a.reshape(expected_shape).get())

--- a/tripy/tests/integration/test_squeeze.py
+++ b/tripy/tests/integration/test_squeeze.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +15,30 @@
 import nvtripy as tp
 import pytest
 
+test_cases = [
+    ((1, 2, 1), 0, (2, 1)),  # Squeeze first dimension
+    ((1, 2, 1), (0, 2), (2,)),  # Squeeze first and third dimensions
+    ((1, 2, 1), tuple(), (1, 2, 1)),  # No dimensions to squeeze
+    ((1, 2, 1), (-3, -1), (2,)),  # Squeeze using negative dimensions
+]
+
 
 class TestSqueeze:
     @pytest.mark.parametrize(
         "input_shape, dims, expected_shape",
-        [
-            ((1, 2, 1), 0, (2, 1)),  # Squeeze first dimension
-            ((1, 2, 1), (0, 2), (2,)),  # Squeeze first and third dimensions
-            ((1, 2, 1), tuple(), (1, 2, 1)),  # No dimensions to squeeze
-            ((1, 2, 1), (-3, -1), (2,)),  # Squeeze using negative dimensions
-        ],
+        test_cases,
     )
     def test_squeeze(self, input_shape, dims, expected_shape):
         input_tensor = tp.ones(input_shape, dtype=tp.float32)
         output_tensor = tp.squeeze(input_tensor, dims=dims)
+        assert output_tensor.shape == expected_shape
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, expected_shape",
+        test_cases,
+    )
+    def test_squeeze_tensor_method(self, input_shape, dims, expected_shape):
+        """Test that tensor.squeeze() method works and produces same result as free function."""
+        input_tensor = tp.ones(input_shape, dtype=tp.float32)
+        output_tensor = input_tensor.squeeze(dims)
         assert output_tensor.shape == expected_shape

--- a/tripy/tests/integration/test_unsqueeze.py
+++ b/tripy/tests/integration/test_unsqueeze.py
@@ -41,3 +41,14 @@ class TestUnsqueezeOp:
             return tp.unsqueeze(a, 3) == tp.Tensor(3.0)
 
         c = tp.compile(func, args=[tp.InputInfo(((1, 2, 3), 2, 3), dtype=tp.float32)])
+
+    @pytest.mark.parametrize("axis", [-1, 0, 2])
+    def test_unsqueeze_tensor_method(self, axis, eager_or_compiled):
+        """Test that tensor.unsqueeze() method works and produces same result as free function."""
+        inp = np.ones((4, 2, 2, 3), dtype=np.float32)
+
+        out = eager_or_compiled(lambda t: t.unsqueeze(axis), tp.Tensor(inp))
+        ref_out = np.expand_dims(inp, axis=axis)
+        assert tp.allclose(out, tp.Tensor(ref_out))
+
+        assert out.shape == tuple(ref_out.shape)


### PR DESCRIPTION
Currently all operations are implemented as free functions, giving consistency to the API. To improve the user experience, readability, and transfer from other frameworks, we are adding a subset of operations to also be available as tensor methods. Currently, we are including operations that don't modify the underlying data, instead changing attributes like the device, datatype, or view. These are frequently "chained" operations in frameworks like torch, improving the transfer experience and readability.