### PR TITLE
[TensorRT] Extract layer metadata from FusedLocation

### DIFF
--- a/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
+++ b/mlir-tensorrt/tensorrt/include/mlir-tensorrt-dialect/TensorRT/IR/TensorRTDialect.td
@@ -51,9 +51,6 @@ def TensorRT_Dialect : Dialect {
     static constexpr StringRef kTensorRTPerTensorDequantizationMarker = "tensorrt.pt_dq";
     static constexpr StringRef kTensorRTPerChannelDequantizationMarker = "tensorrt.pc_dq";
     static constexpr StringRef kTensorRTBlockDequantizationMarker = "tensorrt.block_dq";
-
-    /// TensorRT layer metadata markder.
-    static constexpr StringRef kTensorRTLayerMetadataMarker = "metadata";
   }];
 
   let dependentDialects = [

--- a/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
+++ b/mlir-tensorrt/tensorrt/lib/Target/TensorRTEncodingOpInterface/NetworkEncoder.cpp
@@ -278,10 +278,9 @@ void NvInferNetworkEncoder::setMetadata(nvinfer1::ILayer *layer,
                                         Operation *sourceOp) {
   std::string name = createName(namesSet, sourceOp);
   layer->setName(name.c_str());
-  if (auto metadataAttr = sourceOp->getAttrOfType<StringAttr>(
-          TensorRTDialect::kTensorRTLayerMetadataMarker)) {
-    layer->setMetadata(metadataAttr.getValue().str().c_str());
-  }
+  if (auto fusedLoc = dyn_cast<FusedLoc>(sourceOp->getLoc()))
+    if (auto metadataAttr = dyn_cast<StringAttr>(fusedLoc.getMetadata()))
+      layer->setMetadata(metadataAttr.getValue().str().c_str());
 }
 
 nvinfer1::ITensor *NvInferNetworkEncoder::lookup(Value v) const {


### PR DESCRIPTION
Extracts TRT layer metadata from FusedLocation.metadata. Also removes the "metadata" string from TRT dialect as it is no longer needed.