### PR TITLE
[mlir-tensorrt] Fix CI

### DIFF
--- a/.github/workflows/mlir-tensorrt-ci.yml
+++ b/.github/workflows/mlir-tensorrt-ci.yml
@@ -21,22 +21,6 @@ jobs:
     runs-on: tripy-self-hosted
 
     steps:
-      # Free some disk space, otherwise we get OOM error.
-      - name: Free disk space
-        run: |
-          sudo rm -rf \
-            /usr/share/dotnet "$AGENT_TOOLSDIRECTORY" /usr/local/lib/android /opt/ghc \
-            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-            /usr/lib/jvm
-
-          sudo apt-get purge microsoft-edge-stable || true
-          sudo apt-get purge google-cloud-cli || true
-          sudo apt-get purge dotnet-sdk-* || true
-          sudo apt-get purge google-chrome-stable || true
-
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean -y
-      
       # Value of `github.workspace` is /home/runner/work/{repo_name}/{repo-name}
       # i.e. /home/runner/work/TensorRT-Incubator/TensorRT-Incubator in our case.
       # After this action, repo is cloned inside above path.


### PR DESCRIPTION
Previously we were using free CPU runner hosted by GitHub and to avoid OOM errors we were cleaning up the disk space. Recently, we have shifted to self-hosted runner and we don't need disk clean up stage. This PR cleans CI for it.